### PR TITLE
[rene][rrc] preserve colored parallel diagnostics

### DIFF
--- a/crates/rene/src/compile.rs
+++ b/crates/rene/src/compile.rs
@@ -14,7 +14,9 @@
 //! graph's content digests, the toolchain, and the CLI overrides. A build
 //! whose fingerprint matches and whose artifact still exists reruns nothing.
 
+use std::io::Write as _;
 use std::path::{Path, PathBuf};
+use std::process::{ExitStatus, Stdio};
 
 use serde::{Deserialize, Serialize};
 
@@ -52,6 +54,9 @@ pub struct Options {
     pub upstream: std::collections::BTreeMap<String, String>,
     /// `rene build -j`: the bound on concurrent compile processes.
     pub jobs: Option<std::num::NonZeroUsize>,
+    /// Whether compiler diagnostics should retain ANSI styling while they
+    /// are buffered away from the terminal.
+    pub color: bool,
 }
 
 /// A built (or reused) product.
@@ -143,14 +148,32 @@ pub async fn build(
         let command = planned
             .remove(*name)
             .ok_or_else(|| format!("target `{name}` missing from the plan"))?;
-        invocations.push(Invocation::from_planned(command, &rt.rustc));
+        invocations.push(Invocation::from_planned(command, &rt.rustc, opts.color));
     }
-    futures_util::future::try_join_all(
+    // Every child owns a private stderr pipe. Wait for all jobs, then replay
+    // each complete diagnostic block in declaration order: target compiles
+    // remain concurrent, but their ANSI escape sequences can never interleave.
+    let completed = futures_util::future::join_all(
         invocations
             .into_iter()
-            .map(|invocation| async move { pool.run(move || invocation.run()).await? }),
+            .map(|invocation| pool.run(move || invocation.run())),
     )
-    .await?;
+    .await;
+    let mut failure = None;
+    for result in completed {
+        let result = match result {
+            Ok(result) => result,
+            Err(error) => Err(error),
+        };
+        if let Err(error) = result.and_then(CompletedInvocation::report)
+            && failure.is_none()
+        {
+            failure = Some(error);
+        }
+    }
+    if let Some(error) = failure {
+        return Err(error);
+    }
     let mut products = Vec::with_capacity(plan.len());
     for (name, _, path, key, current) in plan {
         if !current {
@@ -231,12 +254,19 @@ pub(crate) struct Invocation {
     envs: Vec<(&'static str, OsString)>,
     /// What the failure message names.
     out: PathBuf,
+    /// The parent terminal's resolved color policy. The child writes to a
+    /// pipe, so `auto` inside rrc would otherwise discard styling.
+    color: bool,
 }
 
 impl Invocation {
     /// An `rrc` invocation from a planned command: the real program
     /// resolved, the baking toolchain pinned through `REUSSIR_RUSTC`.
-    pub(crate) fn from_planned(command: plan::PlannedCommand, rustc: &Path) -> Invocation {
+    pub(crate) fn from_planned(
+        command: plan::PlannedCommand,
+        rustc: &Path,
+        color: bool,
+    ) -> Invocation {
         Invocation {
             program: deps::resolve_rrc(),
             args: command.args.into_iter().map(OsString::from).collect(),
@@ -244,28 +274,63 @@ impl Invocation {
             // and the polyffi texture compiles must agree with.
             envs: vec![("REUSSIR_RUSTC", rustc.into())],
             out: command.out,
+            color,
         }
     }
 
-    /// Spawn and await the process (on whichever runtime polls this).
-    /// rrc's diagnostics stream straight through to the user.
-    pub(crate) async fn run(self) -> Result<(), String> {
+    /// Spawn and await the process (on whichever runtime polls this), keeping
+    /// its diagnostics private until the scheduler can replay them as one
+    /// indivisible block.
+    pub(crate) async fn run(self) -> Result<CompletedInvocation, String> {
         let mut cmd = compio::process::Command::new(&self.program);
         cmd.args(&self.args);
-        // A verbose `rene` runs a verbose `rrc`: the child's DEBUG phase
-        // events land on the same stderr, so a wedged compile names the
-        // phase it wedged in rather than just the package.
+        // A verbose `rene` runs a verbose `rrc`; its DEBUG phase events join
+        // the same private diagnostic block and are replayed intact.
         if tracing::enabled!(tracing::Level::DEBUG) {
             cmd.arg("-v");
         }
         for (key, value) in &self.envs {
             cmd.env(key, value);
         }
-        let status = cmd
-            .status()
+        // rrc sees a pipe here, so carry the already-resolved parent policy
+        // explicitly. This preserves terminal color without leaking escapes
+        // into redirected logs.
+        cmd.arg("--color")
+            .arg(if self.color { "always" } else { "never" });
+        let output = cmd
+            .stderr(Stdio::piped())
+            .expect("pipe rrc stderr")
+            .output()
             .await
             .map_err(|e| format!("cannot run `{}`: {e}", self.program.display()))?;
-        if !status.success() {
+        Ok(CompletedInvocation {
+            status: output.status,
+            diagnostics: output.stderr,
+            out: self.out,
+        })
+    }
+}
+
+/// One finished compiler process. Diagnostics stay as raw bytes so ANSI
+/// sequences and any non-UTF-8 tool output survive the buffering unchanged.
+pub(crate) struct CompletedInvocation {
+    status: ExitStatus,
+    diagnostics: Vec<u8>,
+    out: PathBuf,
+}
+
+impl CompletedInvocation {
+    /// Replay the complete diagnostic block under stderr's process-wide lock,
+    /// then turn a failing exit status into rene's target-level error.
+    pub(crate) fn report(self) -> Result<(), String> {
+        if !self.diagnostics.is_empty() {
+            let mut stderr = std::io::stderr().lock();
+            stderr
+                .write_all(&self.diagnostics)
+                .and_then(|()| stderr.flush())
+                .map_err(|e| format!("cannot write rrc diagnostics: {e}"))?;
+        }
+        if !self.status.success() {
             return Err(format!(
                 "compiling `{}` failed (see rrc's diagnostics above)",
                 self.out.display()

--- a/crates/rene/src/deps.rs
+++ b/crates/rene/src/deps.rs
@@ -212,7 +212,7 @@ impl Prepared {
 /// Bring the recorded source graph up to date, re-scanning through `rrc` when
 /// it cannot be trusted. A run where every recorded file still matches does
 /// nothing at all — no subprocess, no write.
-pub async fn prepare(dir: &BuildDir, loaded: &Loaded) -> Result<Prepared, String> {
+pub async fn prepare(dir: &BuildDir, loaded: &Loaded, color: bool) -> Result<Prepared, String> {
     let hash = config_hash(&loaded.dump);
     let reason = staleness(dir, &hash)?;
     if reason.is_up_to_date() {
@@ -225,7 +225,7 @@ pub async fn prepare(dir: &BuildDir, loaded: &Loaded) -> Result<Prepared, String
 
     tracing::debug!(%reason, "scanning the package source graph");
     let root = source_root(loaded);
-    let mut files = scan(&root, &loaded.manifest.package.name).await?;
+    let mut files = scan(&root, &loaded.manifest.package.name, color).await?;
     // Order by path, the order the table reads back in, so what this returns
     // does not depend on whether it came from the scan or the record.
     files.sort_by(|a, b| a.path.cmp(&b.path));
@@ -238,7 +238,7 @@ pub async fn prepare(dir: &BuildDir, loaded: &Loaded) -> Result<Prepared, String
 
 /// Ask `rrc --scan-deps` for the package's source graph and stat every file
 /// it names.
-pub async fn scan(root: &Path, package: &str) -> Result<Vec<SourceFile>, String> {
+pub async fn scan(root: &Path, package: &str, color: bool) -> Result<Vec<SourceFile>, String> {
     let rrc = resolve_rrc();
     if !root.is_dir() {
         return Err(format!(
@@ -254,23 +254,29 @@ pub async fn scan(root: &Path, package: &str) -> Result<Vec<SourceFile>, String>
         .arg(root)
         .arg("--package-name")
         .arg(package)
-        .arg("--scan-deps");
+        .arg("--scan-deps")
+        // Both streams are captured below. Preserve the parent CLI's resolved
+        // color policy while rrc renders into its private stderr pipe.
+        .arg("--color")
+        .arg(if color { "always" } else { "never" });
     // The bundled core carries the reserved name; scanning it needs the
     // same lift its compile commands get.
     if package == "core" {
         cmd.arg("--core");
     }
     let out = cmd
-        // compio inherits stdio unless told otherwise; the graph arrives on
-        // stdout while rrc's diagnostics stream through on stderr.
+        // Keep the JSON and diagnostics on separate private pipes. A failed
+        // scan returns the latter as one block to its scheduler.
         .stdout(Stdio::piped())
         .expect("pipe stdout")
+        .stderr(Stdio::piped())
+        .expect("pipe stderr")
         .output()
         .await
         .map_err(|e| format!("cannot run `{}`: {e}", rrc.display()))?;
     if !out.status.success() {
-        // rrc has already rendered its diagnostics to stderr; pass them on
-        // rather than paraphrasing.
+        // rrc has already rendered its diagnostics; pass them on rather than
+        // paraphrasing.
         let stderr = String::from_utf8_lossy(&out.stderr);
         let stderr = stderr.trim();
         return Err(if stderr.is_empty() {

--- a/crates/rene/src/exec.rs
+++ b/crates/rene/src/exec.rs
@@ -42,6 +42,8 @@ pub struct Options<'a> {
     /// `rene build -j`: the process admission bound (held by the [`Pool`]).
     pub jobs: Option<NonZeroUsize>,
     pub build_dir: &'a Path,
+    /// Whether buffered rrc diagnostics retain ANSI styling.
+    pub color: bool,
 }
 
 /// Build every dependency of the graph through the pool, each dispatched
@@ -159,8 +161,9 @@ async fn build_node(
     // next run's freshness walk has something to compare against.
     let src_root = graph.nodes[name].dir.join("src");
     let package = name.to_owned();
+    let color = opts.color;
     let mut sources = pool
-        .run(move || async move { deps::scan(&src_root, &package).await })
+        .run(move || async move { deps::scan(&src_root, &package, color).await })
         .await??;
     sources.sort_by(|a, b| a.path.cmp(&b.path));
 
@@ -173,8 +176,11 @@ async fn build_node(
     };
     for command in plan::node_commands(graph, name, &plan_opts, Some(rt)) {
         bar.set_message(format!("{name}: {}", command.emit));
-        let invocation = compile::Invocation::from_planned(command, &rt.rustc);
-        pool.run(move || invocation.run()).await??;
+        let invocation = compile::Invocation::from_planned(command, &rt.rustc, opts.color);
+        let completed = pool.run(move || invocation.run()).await??;
+        // Clear/redraw every active bar around the indivisible diagnostic
+        // block. `suspend` also serializes these callbacks on the scheduler.
+        progress.suspend(|| completed.report())?;
     }
     fresh::record_dep(graph, name, &ctx, rt, &sources)?;
     bar.finish_and_clear();

--- a/crates/rene/src/fresh.rs
+++ b/crates/rene/src/fresh.rs
@@ -284,6 +284,8 @@ fn root_state(
             linker: ctx.linker.map(Path::to_path_buf),
             upstream,
             jobs: None,
+            // Output policy is deliberately absent from the fingerprint.
+            color: false,
         },
     );
     let out_dir = ctx.build_dir.join(ctx.profile_name);

--- a/crates/rene/src/main.rs
+++ b/crates/rene/src/main.rs
@@ -20,6 +20,7 @@
 //! machine-readable listing. Exit 0 on success, 1 on a failed command, 2 on
 //! a usage error.
 
+use std::io::IsTerminal;
 use std::path::PathBuf;
 use std::process::ExitCode;
 
@@ -38,8 +39,30 @@ struct Cli {
     #[arg(short = 'v', long)]
     verbose: bool,
 
+    /// Output colors: `auto` (when stderr is a terminal), `always`, or
+    /// `never`. The resolved policy is forwarded to rrc diagnostics.
+    #[arg(long, value_enum, default_value_t = ColorChoice::Auto, global = true)]
+    color: ColorChoice,
+
     #[command(subcommand)]
     command: Command,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, palc::ValueEnum)]
+enum ColorChoice {
+    Auto,
+    Always,
+    Never,
+}
+
+impl ColorChoice {
+    fn resolve(self, terminal: bool) -> bool {
+        match self {
+            ColorChoice::Auto => terminal,
+            ColorChoice::Always => true,
+            ColorChoice::Never => false,
+        }
+    }
 }
 
 /// Arguments shared by every command that touches the build directory.
@@ -224,7 +247,8 @@ fn main() -> ExitCode {
             }
         },
     };
-    init_tracing(cli.verbose);
+    let color = cli.color.resolve(std::io::stderr().is_terminal());
+    init_tracing(cli.verbose, color);
     // One completion-based runtime (io_uring/IOCP) drives the whole command:
     // child processes and file reads await on it, and independent work —
     // digests, target compiles — runs concurrently on the single thread.
@@ -237,9 +261,9 @@ fn main() -> ExitCode {
     };
     let result = runtime.block_on(async {
         match cli.command {
-            Command::Build(args) => build(&args).await,
+            Command::Build(args) => build(&args, color).await,
             Command::Clean(args) => clean(&args.location),
-            Command::Inspect(args) => inspect(&args).await,
+            Command::Inspect(args) => inspect(&args, color).await,
             Command::New(args) => new::run(&new::Options {
                 path: args.path,
                 name: args.name,
@@ -264,7 +288,7 @@ fn main() -> ExitCode {
 /// Install a `tracing` subscriber writing to **stderr** (stdout carries the
 /// machine-readable output). `RUST_LOG` wins if set; otherwise `-v` selects
 /// DEBUG and the default shows build progress (INFO).
-fn init_tracing(verbose: bool) {
+fn init_tracing(verbose: bool, color: bool) {
     use tracing_subscriber::EnvFilter;
     let filter = EnvFilter::try_from_default_env()
         // pubgrub narrates every solver step at INFO; that is solver
@@ -278,9 +302,9 @@ fn init_tracing(verbose: bool) {
         });
     let _ = tracing_subscriber::fmt()
         .with_env_filter(filter)
-        // Plain text off-terminal: CI logs and FileCheck'd stderr must not
-        // carry ANSI escapes.
-        .with_ansi(std::io::IsTerminal::is_terminal(&std::io::stderr()))
+        // Plain text off-terminal by default; `--color` can explicitly
+        // override that for tools which capture and re-display the stream.
+        .with_ansi(color)
         .with_writer(std::io::stderr)
         .try_init();
 }
@@ -315,7 +339,7 @@ fn locate_manifest(flag: &Option<PathBuf>) -> Result<PathBuf, String> {
     }
 }
 
-async fn build(args: &BuildArgs) -> Result<(), String> {
+async fn build(args: &BuildArgs, color: bool) -> Result<(), String> {
     let location = &args.location;
     let manifest_path = locate_manifest(&location.manifest_path)?;
     let loaded = manifest::load(&manifest_path).map_err(|e| e.to_string())?;
@@ -352,7 +376,7 @@ async fn build(args: &BuildArgs) -> Result<(), String> {
     // The source graph first: it is cheap, it fails fast on a broken package,
     // and a build that finds nothing moved skips straight to the freshness
     // checks below.
-    let sources = deps::prepare(&dir, &loaded).await?;
+    let sources = deps::prepare(&dir, &loaded, color).await?;
     // The bake links the runtime dylib with the same linker pinning the
     // driver-level links get: the CLI override first, then the profile's.
     // The progress surface exists from here on: the bake's spinner first,
@@ -397,6 +421,7 @@ async fn build(args: &BuildArgs) -> Result<(), String> {
             linker: args.linker.as_deref(),
             jobs: args.jobs,
             build_dir: &root,
+            color,
         },
         &pool,
         &progress,
@@ -432,6 +457,7 @@ async fn build(args: &BuildArgs) -> Result<(), String> {
                 &target,
             ),
             jobs: args.jobs,
+            color,
         },
         &graph,
         &pool,
@@ -450,7 +476,7 @@ async fn build(args: &BuildArgs) -> Result<(), String> {
 /// default a stale record is refreshed first (the same scan `build` runs, but
 /// without the runtime bake), so the report describes the package as it is
 /// now; `--frozen` reports what is on record and never writes.
-async fn inspect(args: &InspectArgs) -> Result<(), String> {
+async fn inspect(args: &InspectArgs, color: bool) -> Result<(), String> {
     let location = &args.location;
     let frozen = args.frozen;
     let manifest_path = locate_manifest(&location.manifest_path)?;
@@ -476,7 +502,7 @@ async fn inspect(args: &InspectArgs) -> Result<(), String> {
         if dir.is_cleaning().map_err(|e| e.to_string())? {
             return Err(pending_clean(&root));
         }
-        let prepared = deps::prepare(&dir, &loaded).await?;
+        let prepared = deps::prepare(&dir, &loaded, color).await?;
         // After a refresh the record is by construction current; report that
         // rather than the reason it was rebuilt (which the log already
         // carries).

--- a/crates/rene/tests/cli.rs
+++ b/crates/rene/tests/cli.rs
@@ -222,28 +222,55 @@ impl Fakes {
         // fabricates the `-o` artifact.
         let rrc = script(
             "fake-rrc",
-            "root=\"\"; out=\"\"; prev=\"\"; scan=no\n\
-             for arg in \"$@\"; do\n\
-               [ \"$prev\" = \"--package-root\" ] && root=\"$arg\"\n\
-               [ \"$prev\" = \"-o\" ] && out=\"$arg\"\n\
-               [ \"$arg\" = \"--scan-deps\" ] && scan=yes\n\
-               prev=\"$arg\"\n\
-             done\n\
-             if [ \"$scan\" = no ]; then\n\
-               echo \"$* rustc=$REUSSIR_RUSTC\" >> \"$(dirname \"$0\")/rrc-compiles\"\n\
-               echo compiled > \"$out\"\n\
-               exit 0\n\
-             fi\n\
-             echo run >> \"$(dirname \"$0\")/rrc-runs\"\n\
-             printf '{\"package\":\"pkg\",\"files\":[{\"path\":\"%s\",\"module\":[\"pkg\"]}' \"$root/lib.rr\"\n\
-             for f in \"$root\"/*.rr; do\n\
-               case \"$f\" in */lib.rr) continue;; esac\n\
-               [ -f \"$f\" ] || continue\n\
-               base=$(basename \"$f\" .rr)\n\
-               printf ',{\"path\":\"%s\",\"module\":[\"pkg\",\"%s\"]}' \"$f\" \"$base\"\n\
-             done\n\
-             printf ']}\\n'\n"
-                .to_owned(),
+            r#"root=""; out=""; package=""; color=auto; prev=""; scan=no
+for arg in "$@"; do
+  [ "$prev" = "--package-root" ] && root="$arg"
+  [ "$prev" = "--package-name" ] && package="$arg"
+  [ "$prev" = "-o" ] && out="$arg"
+  [ "$prev" = "--color" ] && color="$arg"
+  [ "$arg" = "--scan-deps" ] && scan=yes
+  prev="$arg"
+done
+if [ "$scan" = no ]; then
+  echo "$* rustc=$REUSSIR_RUSTC" >> "$(dirname "$0")/rrc-compiles"
+  if [ "$FAKE_RRC_FRAGMENTED_DIAGNOSTIC" = yes ] && [ "$package" != core ]; then
+    if [ "$color" = always ]; then
+      sync="$(dirname "$0")/diagnostic-sync"
+      id=$(basename "$out")
+      mkdir -p "$sync"
+      touch "$sync/ready.$id"
+      while :; do
+        set -- "$sync"/ready.*
+        [ -e "$1" ] && [ "$#" -ge 2 ] && break
+        sleep 0.01
+      done
+      printf '\033[' >&2
+      touch "$sync/escape.$id"
+      while :; do
+        set -- "$sync"/escape.*
+        [ -e "$1" ] && [ "$#" -ge 2 ] && break
+        sleep 0.01
+      done
+      printf '31mDIAGNOSTIC\033[0m\n' >&2
+    else
+      printf 'DIAGNOSTIC\n' >&2
+    fi
+    exit 1
+  fi
+  echo compiled > "$out"
+  exit 0
+fi
+echo run >> "$(dirname "$0")/rrc-runs"
+printf '{"package":"pkg","files":[{"path":"%s","module":["pkg"]}' "$root/lib.rr"
+for f in "$root"/*.rr; do
+  case "$f" in */lib.rr) continue;; esac
+  [ -f "$f" ] || continue
+  base=$(basename "$f" .rr)
+  printf ',{"path":"%s","module":["pkg","%s"]}' "$f" "$base"
+done
+printf ']}\n'
+"#
+            .to_owned(),
         );
 
         Fakes {
@@ -1013,6 +1040,69 @@ fn build_honors_a_single_job_cap() {
         assert!(Path::new(line).is_file(), "no artifact at {line}");
     }
     assert_eq!(fakes.package_compiles().len(), 3);
+}
+
+/// Parallel rrc jobs write into private pipes. Even deliberately fragmented
+/// ANSI sequences are replayed as whole diagnostic blocks, with rene's color
+/// policy forwarded through the pipe.
+#[cfg(unix)]
+#[test]
+fn build_keeps_parallel_colored_diagnostics_intact() {
+    let tmp_dir = tempfile::tempdir().unwrap();
+    let tmp = tmp_dir.path().canonicalize().unwrap();
+    let root = tmp.join("reussir-build");
+    package(&tmp, "demo");
+    let manifest = tmp.join("rene.ncl");
+    std::fs::write(
+        &manifest,
+        "{ package = { name = \"demo\", version = \"0.1.0\" },\n\
+         \x20 targets.shared = { kind = 'dynlib },\n\
+         \x20 targets.archive = { kind = 'staticlib } }\n",
+    )
+    .unwrap();
+    let fakes = Fakes::new(&tmp);
+
+    let out = run(rene(&["--color", "always", "build", "--jobs", "2"])
+        .arg("--manifest-path")
+        .arg(&manifest)
+        .arg("--build-dir")
+        .arg(&root)
+        .env("REUSSIR_RRC", &fakes.rrc)
+        .env("REUSSIR_CARGO", &fakes.cargo)
+        .env("REUSSIR_RUSTC", &fakes.rustc)
+        .env("FAKE_RRC_FRAGMENTED_DIAGNOSTIC", "yes"));
+    assert_eq!(out.status.code(), Some(1), "stderr: {}", stderr(&out));
+
+    let colored_stderr = stderr(&out);
+    let block = "\x1b[31mDIAGNOSTIC\x1b[0m\n";
+    assert_eq!(
+        colored_stderr.match_indices(block).count(),
+        2,
+        "parallel diagnostics were corrupted:\n{colored_stderr:?}"
+    );
+    assert!(
+        !colored_stderr.contains("\x1b[\x1b["),
+        "ANSI prefixes interleaved:\n{colored_stderr:?}"
+    );
+
+    // The default resolves against rene's stderr, not the child's pipe. The
+    // test harness captures stderr, so the same failed build must be plain.
+    let plain = run(rene(&["build", "--jobs", "2"])
+        .arg("--manifest-path")
+        .arg(&manifest)
+        .arg("--build-dir")
+        .arg(&root)
+        .env("REUSSIR_RRC", &fakes.rrc)
+        .env("REUSSIR_CARGO", &fakes.cargo)
+        .env("REUSSIR_RUSTC", &fakes.rustc)
+        .env("FAKE_RRC_FRAGMENTED_DIAGNOSTIC", "yes"));
+    assert_eq!(plain.status.code(), Some(1), "stderr: {}", stderr(&plain));
+    assert!(
+        !plain.stderr.contains(&b'\x1b'),
+        "auto color polluted redirected stderr: {:?}",
+        plain.stderr
+    );
+    assert_eq!(stderr(&plain).match_indices("DIAGNOSTIC\n").count(), 2);
 }
 
 /// The pool needs at least one process: `-j 0` is a usage error (exit 2),

--- a/crates/reussir-compiler/src/driver.rs
+++ b/crates/reussir-compiler/src/driver.rs
@@ -14,7 +14,6 @@
 //! fed back in isolation. Exit 0 on success, 1 on a compile error, 2 on a usage
 //! or I/O error.
 
-use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
@@ -77,7 +76,7 @@ pub fn main() -> ExitCode {
             }
         },
     };
-    init_tracing(cli.verbose);
+    init_tracing(cli.verbose, cli.use_color());
     match run(&cli) {
         Ok(true) => ExitCode::SUCCESS,
         Ok(false) => ExitCode::FAILURE,
@@ -241,11 +240,12 @@ fn run(cli: &Cli) -> Result<bool, String> {
             }
         }
         let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
-        let mut pkg = match load_package_or_render(&root, &pkg_name, &interner, cli.core) {
-            Ok(pkg) => pkg,
-            Err(msg) if msg.is_empty() => return Ok(false),
-            Err(msg) => return Err(msg),
-        };
+        let mut pkg =
+            match load_package_or_render(&root, &pkg_name, &interner, cli.core, cli.use_color()) {
+                Ok(pkg) => pkg,
+                Err(msg) if msg.is_empty() => return Ok(false),
+                Err(msg) => return Err(msg),
+            };
         let name = pkg.cache.name(FileId::ROOT).to_owned();
         let context = reussir_backend::context();
         if cli.disable_backend_multithreading {
@@ -353,6 +353,7 @@ fn load_package_or_render(
     name: &str,
     interner: &std::sync::Arc<reussir_syntax::MultiThreadedTokenInterner>,
     allow_core: bool,
+    color: bool,
 ) -> Result<package::PackageSource, String> {
     let loaded = match root {
         PackageRoot::Dir(dir) => package::load_package_with(dir, name, interner, allow_core),
@@ -368,7 +369,6 @@ fn load_package_or_render(
             file,
             errors,
         }) => {
-            let color = std::io::stderr().is_terminal();
             let _ =
                 diagnostics::render_errors(&cache, file, &errors, color, std::io::stderr().lock());
             Err(String::new())
@@ -389,7 +389,7 @@ fn scan_deps(cli: &Cli, package: Option<&(PackageRoot, String)>) -> Result<bool,
         );
     };
     let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
-    let pkg = match load_package_or_render(root, pkg_name, &interner, cli.core) {
+    let pkg = match load_package_or_render(root, pkg_name, &interner, cli.core, cli.use_color()) {
         Ok(pkg) => pkg,
         Err(msg) if msg.is_empty() => return Ok(false),
         Err(msg) => return Err(msg),

--- a/crates/reussir-compiler/src/driver/cli.rs
+++ b/crates/reussir-compiler/src/driver/cli.rs
@@ -11,6 +11,27 @@ use reussir_codegen::source::SourceCache;
 use super::stage::{Lto, RuntimeLinkage, SanitizerCli, Stage, VariantEncoding};
 use crate::RelocMode;
 
+/// When diagnostics and tracing should carry ANSI styling.
+#[derive(Clone, Copy, PartialEq, Eq, palc::ValueEnum)]
+pub(crate) enum ColorChoice {
+    /// Color only when stderr is a terminal.
+    Auto,
+    /// Always emit ANSI color codes, including through a pipe.
+    Always,
+    /// Never emit ANSI color codes.
+    Never,
+}
+
+impl ColorChoice {
+    fn enabled(self, terminal: bool) -> bool {
+        match self {
+            ColorChoice::Auto => terminal,
+            ColorChoice::Always => true,
+            ColorChoice::Never => false,
+        }
+    }
+}
+
 /// Reussir compiler driver.
 #[derive(Parser)]
 #[command(name = "rrc", version)]
@@ -240,10 +261,24 @@ pub(crate) struct Cli {
     #[arg(long = "no-source-locations")]
     pub(crate) no_source_locations: bool,
 
+    /// Diagnostic colors: `auto` (when stderr is a terminal), `always`, or
+    /// `never`.
+    #[arg(long, value_enum, default_value_t = ColorChoice::Auto)]
+    color: ColorChoice,
+
     /// Log the lowering/backend `tracing` events (to stderr) at DEBUG level.
     /// `RUST_LOG`, if set, takes precedence over this.
     #[arg(short = 'v', long = "verbose")]
     pub(crate) verbose: bool,
+}
+
+impl Cli {
+    /// Resolve the CLI color policy against this process's stderr.
+    pub(crate) fn use_color(&self) -> bool {
+        use std::io::IsTerminal;
+
+        self.color.enabled(std::io::stderr().is_terminal())
+    }
 }
 
 /// The stage the input enters at: `--from` if given, else the extension. `-`
@@ -356,12 +391,13 @@ pub(crate) fn write_text(path: &Path, text: &str) -> Result<(), String> {
 /// Install a `tracing` subscriber writing to **stderr** (so it never corrupts a
 /// `-o -` stdout dump). `RUST_LOG` wins if set; otherwise `-v` selects DEBUG and
 /// the default is quiet (WARN).
-pub(crate) fn init_tracing(verbose: bool) {
+pub(crate) fn init_tracing(verbose: bool, color: bool) {
     use tracing_subscriber::EnvFilter;
     let filter = EnvFilter::try_from_default_env()
         .unwrap_or_else(|_| EnvFilter::new(if verbose { "debug" } else { "warn" }));
     let _ = tracing_subscriber::fmt()
         .with_env_filter(filter)
+        .with_ansi(color)
         .with_writer(std::io::stderr)
         .try_init();
 }

--- a/crates/reussir-compiler/src/driver/frontend.rs
+++ b/crates/reussir-compiler/src/driver/frontend.rs
@@ -3,7 +3,6 @@
 //! whichever stage `--emit` requests: a text dump (HIR, the `.rri`
 //! interface, MIR) or the lowered module(s) handed to the back leg.
 
-use std::io::IsTerminal;
 use std::path::Path;
 
 use reussir_codegen::lower::{
@@ -16,7 +15,7 @@ use reussir_core::full::mono::{MonoInput, MonoTraits, monomorphize};
 use reussir_core::semi::hir;
 use reussir_core::semi::resolve::DefTable;
 use reussir_core::semi::ty::TyCtxt;
-use reussir_core::semi::{elaborate, render_reports};
+use reussir_core::semi::{Report, elaborate, render_reports_to};
 use reussir_core::surface;
 use reussir_syntax::diagnostics;
 use reussir_syntax::kind::{Resolver, TokenKey};
@@ -26,6 +25,11 @@ use crate::package;
 use super::Produced;
 use super::cli::Cli;
 use super::stage::Stage;
+
+/// Render middle-end reports with the driver's explicit color policy.
+fn render_reports(cli: &Cli, cache: &SourceCache, reports: &[Report]) -> bool {
+    render_reports_to(cache, reports, cli.use_color(), std::io::stderr().lock())
+}
 
 /// The arena-scoped front leg for package mode: elaborate every discovered
 /// file as one translation unit, then continue exactly as the single-file
@@ -96,7 +100,7 @@ pub(crate) fn frontend_package<'c, 'tcx>(
         })
         .collect();
     let elab = elaborate_package_with_externs(tcx, &files, interner, &extern_pkgs);
-    if render_reports(&pkg.cache, &elab.reports) {
+    if render_reports(cli, &pkg.cache, &elab.reports) {
         return Err(String::new());
     }
     if target == Stage::Hir {
@@ -195,7 +199,7 @@ pub(crate) fn frontend_package<'c, 'tcx>(
         return Ok(Produced::Text(text));
     }
     let (full, reports) = monomorphize(&elab.mono_input());
-    if render_reports(&pkg.cache, &reports) {
+    if render_reports(cli, &pkg.cache, &reports) {
         return Err(String::new());
     }
     finish_mir(
@@ -231,19 +235,18 @@ pub(crate) fn frontend<'c, 'tcx>(
             let interner = std::sync::Arc::new(reussir_syntax::new_threaded_interner());
             let parse = reussir_syntax::parse_with_interner(source, interner.clone());
             if !parse.ok() {
-                let color = std::io::stderr().is_terminal();
                 let _ = diagnostics::render_errors(
                     sources,
                     FileId::ROOT,
                     &parse.errors,
-                    color,
+                    cli.use_color(),
                     std::io::stderr().lock(),
                 );
                 return Err(String::new());
             }
             let prog = surface::program(&parse.root);
             let elab = elaborate(tcx, &prog, &interner);
-            if render_reports(sources, &elab.reports) {
+            if render_reports(cli, sources, &elab.reports) {
                 return Err(String::new());
             }
             if target == Stage::Hir {
@@ -265,7 +268,7 @@ pub(crate) fn frontend<'c, 'tcx>(
                 return Ok(Produced::Text(text));
             }
             let (full, reports) = monomorphize(&elab.mono_input());
-            if render_reports(sources, &reports) {
+            if render_reports(cli, sources, &reports) {
                 return Err(String::new());
             }
             finish_mir(
@@ -350,12 +353,12 @@ pub(crate) fn frontend<'c, 'tcx>(
             let (full, reports) = monomorphize(&input);
             match &dump_sources {
                 Some(cache) => {
-                    if render_reports(cache, &reports) {
+                    if render_reports(cli, cache, &reports) {
                         return Err(String::new());
                     }
                 }
                 None => {
-                    if render_reports(sources, &reports) {
+                    if render_reports(cli, sources, &reports) {
                         return Err(String::new());
                     }
                 }
@@ -419,6 +422,7 @@ pub(crate) fn lower_or_render<T>(
     result: std::result::Result<T, LoweringError>,
     sources: Option<&SourceCache>,
     name: &str,
+    color: bool,
 ) -> Result<T, String> {
     match result {
         Ok(value) => Ok(value),
@@ -432,7 +436,6 @@ pub(crate) fn lower_or_render<T>(
                     severity: diagnostics::Severity::Error,
                     message: error.message(),
                 };
-                let color = std::io::stderr().is_terminal();
                 let _ = diagnostics::render(
                     sources,
                     std::slice::from_ref(&diagnostic),
@@ -505,6 +508,7 @@ pub(crate) fn finish_mir<'c, 'tcx>(
                 ),
                 sources,
                 name,
+                cli.use_color(),
             )?;
             units.push(module);
         }
@@ -514,6 +518,7 @@ pub(crate) fn finish_mir<'c, 'tcx>(
         lower_program(context, tcx, program, sources, names, linkage, &sanitizers),
         sources,
         name,
+        cli.use_color(),
     )?;
     Ok(Produced::Module(module, Some(exports)))
 }

--- a/crates/reussir-compiler/tests/driver.rs
+++ b/crates/reussir-compiler/tests/driver.rs
@@ -75,6 +75,46 @@ fn read(path: &Path) -> String {
     std::fs::read_to_string(path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
 }
 
+/// `--color` is an explicit contract, not just TTY autodetection. This is
+/// what lets a parent such as rene buffer complete diagnostics and replay
+/// them later without losing their styling.
+#[test]
+fn color_policy_controls_redirected_diagnostics() {
+    let dir = scratch("color");
+    let src = dir.path().join("broken.rr");
+    std::fs::write(&src, "pub fn broken( -> i64 { 0 }\n").expect("write invalid source");
+
+    let run = |choice: &str| {
+        rrc(&[
+            &src,
+            Path::new("--emit"),
+            Path::new("hir"),
+            Path::new("-o"),
+            Path::new("-"),
+            Path::new("--color"),
+            Path::new(choice),
+        ])
+    };
+
+    let always = run("always");
+    assert_eq!(always.status.code(), Some(1));
+    assert!(
+        always.stderr.windows(2).any(|bytes| bytes == b"\x1b["),
+        "--color always emitted no ANSI styling:\n{}",
+        String::from_utf8_lossy(&always.stderr)
+    );
+
+    for choice in ["auto", "never"] {
+        let output = run(choice);
+        assert_eq!(output.status.code(), Some(1));
+        assert!(
+            !output.stderr.contains(&b'\x1b'),
+            "--color {choice} polluted redirected stderr: {:?}",
+            output.stderr
+        );
+    }
+}
+
 /// Write `PROGRAM` to a `.rr` file in a fresh scratch dir. The returned
 /// [`TempDir`] must be kept alive for the test's duration (it cleans up on drop).
 fn source(tag: &str) -> (TempDir, PathBuf) {

--- a/tests/integration/rene/build.rr
+++ b/tests/integration/rene/build.rr
@@ -72,3 +72,10 @@
 
 // NOPROFILE: no profile named `bogus`
 // NOTARGET: no binary target named `bogus`
+
+// A real parallel failure is buffered per rrc process: both diagnostics keep
+// their ANSI prefixes even though rrc sees a pipe, and each reaches stderr as
+// a complete block. Reuse this test's runtime bake; only the package changes.
+// RUN: %not %rene --color always build --manifest-path %S/diagnostics/rene.ncl --build-dir %t.bdir -j 2 2> %t.color.log
+// RUN: printf '// COLOR-COUNT-2: \033[31mError:' > %t.color.check
+// RUN: %FileCheck --check-prefix=COLOR %t.color.check < %t.color.log

--- a/tests/integration/rene/diagnostics/lit.local.cfg
+++ b/tests/integration/rene/diagnostics/lit.local.cfg
@@ -1,0 +1,2 @@
+# The package compiled by ../build.rr; its source is not a test itself.
+config.suffixes = []

--- a/tests/integration/rene/diagnostics/rene.ncl
+++ b/tests/integration/rene/diagnostics/rene.ncl
@@ -1,0 +1,10 @@
+{
+  package = {
+    name = "diagnostics",
+    version = "0.1.0",
+  },
+  targets = {
+    shared = { kind = 'dynlib },
+    archive = { kind = 'staticlib },
+  },
+}

--- a/tests/integration/rene/diagnostics/src/lib.rr
+++ b/tests/integration/rene/diagnostics/src/lib.rr
@@ -1,0 +1,5 @@
+pub struct [value] LibVersion(i64, i64, i64)
+
+pub fn library_version() -> LibVersion {
+    Version { 0, 1, 0 }
+}


### PR DESCRIPTION
## Summary

- buffer each rrc stderr stream per process and replay complete diagnostic blocks in declaration order
- add auto, always, and never color policies to rene and rrc, forwarding the resolved parent policy through compiler pipes
- capture source-scan diagnostics and keep progress-bar redraws isolated from compiler output
- add deterministic fragmented-ANSI coverage plus a real two-target lit regression

## Testing

- cargo test -p rene
- cmake --build build --target rrc-test -j 2
- build/bin/reussir-ut (30 passed)
- cmake --build build --target check -j 2 (473 passed, 6 unsupported)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/529"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788583248&installation_model_id=426051&pr_number=529&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F529&signature=ada210cd0828e06844a301957bbe7d68638ced37ac382f8885b47ac72a1321c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->