### PR TITLE
Expose polymorphic core panic intrinsic

### DIFF
--- a/crates/reussir-codegen/src/lower/expr.rs
+++ b/crates/reussir-codegen/src/lower/expr.rs
@@ -787,6 +787,18 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
             // dialect ops and attributes; the backend pipeline's dialect
             // conversions take the emitted op from there.
             Intrinsic { op, args } => match op {
+                IntrinsicOp::Panic => {
+                    debug_assert!(args.is_empty(), "panic has no value operands");
+                    block.append_operation(
+                        dialect::panic(
+                            self.context,
+                            StringAttribute::new(self.context, "explicit panic"),
+                            loc,
+                        )
+                        .into(),
+                    );
+                    self.poison_value(block, e.ty)
+                }
                 IntrinsicOp::Math { func, flag } => {
                     let mut operands = Vec::with_capacity(args.len());
                     for a in args.iter() {
@@ -1377,7 +1389,9 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
             // A non-exhaustive gap or a redundant arm: both were already diagnosed
             // by the frontend, so this position is dead — a poison of the result
             // type terminates it without observing an undefined value.
-            DecisionTree::Uncovered | DecisionTree::Unreachable => self.dead_arm(block, result_ty),
+            DecisionTree::Uncovered | DecisionTree::Unreachable => {
+                self.poison_value(block, result_ty)
+            }
         }
     }
 
@@ -1965,9 +1979,10 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
         Ok(())
     }
 
-    /// Terminate a provably-dead decision position with a poison value of the
-    /// result type (or nothing for a unit match).
-    fn dead_arm<'b>(
+    /// Produce a poison value of `result_ty`, or no SSA value for unit. This
+    /// keeps typed control flow structurally valid after an aborting operation
+    /// or at a decision-tree position proven unreachable by the frontend.
+    fn poison_value<'b>(
         &self,
         block: &'b Block<'c>,
         result_ty: Ty<'tcx>,

--- a/crates/reussir-core/src/full/ownership.rs
+++ b/crates/reussir-core/src/full/ownership.rs
@@ -616,7 +616,8 @@ impl<'tcx> Analyzer<'_, 'tcx> {
                 crate::intrinsic::IntrinsicOp::Cell { func } => {
                     self.place_cell_intrinsic(e, func, args, live_after)
                 }
-                crate::intrinsic::IntrinsicOp::Math { .. } => self.place_args(args, live_after),
+                crate::intrinsic::IntrinsicOp::Math { .. }
+                | crate::intrinsic::IntrinsicOp::Panic => self.place_args(args, live_after),
             },
             ExprKind::NullableCall(opt) => {
                 if let Some(x) = opt {

--- a/crates/reussir-core/src/intrinsic.rs
+++ b/crates/reussir-core/src/intrinsic.rs
@@ -298,6 +298,9 @@ impl ArrayFn {
 /// rebuilds the typed op from that triple.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum IntrinsicOp {
+    /// `core::intrinsic::panic::panic()`: aborts execution and inhabits the
+    /// contextually expected result type.
+    Panic,
     /// `core::intrinsic::math::<func>`, with an `arith.fastmath` flag.
     Math { func: MathFn, flag: u32 },
     /// `core::intrinsic::cell::<func>`; cell operations have no immediates
@@ -309,6 +312,7 @@ impl IntrinsicOp {
     /// The family segment under `core::intrinsic::` (`math`, …).
     pub fn family(self) -> &'static str {
         match self {
+            IntrinsicOp::Panic => "panic",
             IntrinsicOp::Math { .. } => "math",
             IntrinsicOp::Cell { .. } => "cell",
         }
@@ -317,6 +321,7 @@ impl IntrinsicOp {
     /// The op's name within its family (also the dialect mnemonic).
     pub fn name(self) -> &'static str {
         match self {
+            IntrinsicOp::Panic => "panic",
             IntrinsicOp::Math { func, .. } => func.as_str(),
             IntrinsicOp::Cell { func, .. } => func.as_str(),
         }
@@ -325,6 +330,7 @@ impl IntrinsicOp {
     /// The family's packed immediate, as printed in the textual IR.
     pub fn imm(self) -> u32 {
         match self {
+            IntrinsicOp::Panic => 0,
             IntrinsicOp::Math { flag, .. } => flag,
             IntrinsicOp::Cell { .. } => 0,
         }
@@ -334,6 +340,7 @@ impl IntrinsicOp {
     /// `None` if the family or name is unknown.
     pub fn parse(family: &str, name: &str, imm: u32) -> Option<IntrinsicOp> {
         match family {
+            "panic" if name == "panic" && imm == 0 => Some(IntrinsicOp::Panic),
             "math" => Some(IntrinsicOp::Math {
                 func: MathFn::parse(name)?,
                 flag: imm,
@@ -353,6 +360,7 @@ mod tests {
     #[test]
     fn intrinsic_op_round_trips_through_textual_triple() {
         for op in [
+            IntrinsicOp::Panic,
             IntrinsicOp::Math {
                 func: MathFn::Sqrt,
                 flag: 0,
@@ -375,6 +383,8 @@ mod tests {
             );
         }
         assert_eq!(IntrinsicOp::parse("math", "nope", 0), None);
+        assert_eq!(IntrinsicOp::parse("panic", "panic", 1), None);
+        assert_eq!(IntrinsicOp::parse("panic", "abort", 0), None);
         assert_eq!(IntrinsicOp::parse("cell", "get", 1), None);
         assert!(
             IntrinsicOp::parse("cell", "in_use", 0).is_some(),

--- a/crates/reussir-core/src/semi.rs
+++ b/crates/reussir-core/src/semi.rs
@@ -700,6 +700,60 @@ mod tests {
         assert!(m.contains("expects 2 argument(s)"), "{m}");
     }
 
+    #[test]
+    fn panic_intrinsic_uses_the_contextual_result_type() {
+        check(
+            r#"
+                fn integer() -> i64 { core::intrinsic::panic::panic() }
+                fn boolean() -> bool { core::intrinsic::panic::panic() }
+                fn explicit() -> i32 { core::intrinsic::panic::panic<i32>() }
+                fn generic<T>() -> T { core::intrinsic::panic::panic() }
+                fn unit() { core::intrinsic::panic::panic() }
+            "#,
+            |elab, tcx| {
+                use crate::intrinsic::IntrinsicOp;
+                use crate::semi::hir::ExprKind;
+
+                for name in ["integer", "boolean", "explicit", "generic", "unit"] {
+                    let function = function(elab, name);
+                    let body = function.body.as_ref().expect("panic function has a body");
+                    let ExprKind::Intrinsic { op, args } = &body.kind else {
+                        panic!("{name} body is the panic intrinsic: {body:#?}");
+                    };
+                    assert_eq!(*op, IntrinsicOp::Panic);
+                    assert!(args.is_empty());
+                    assert_eq!(body.ty, function.return_ty);
+                }
+                assert_eq!(
+                    function(elab, "integer").return_ty,
+                    tcx.mk_int(IntTy::Signed(64))
+                );
+                assert_eq!(function(elab, "boolean").return_ty, tcx.mk_bool());
+                assert_eq!(function(elab, "unit").return_ty, tcx.mk_unit());
+            },
+        );
+    }
+
+    #[test]
+    fn panic_intrinsic_rejects_arguments_and_unknown_operations() {
+        let messages = |source| {
+            reports_of(source)
+                .into_iter()
+                .map(|r| r.message)
+                .collect::<Vec<_>>()
+                .join("\n")
+        };
+        let m = messages("fn f() -> i64 { core::intrinsic::panic::panic(1) }");
+        assert!(m.contains("`panic` expects 0 arguments, got 1"), "{m}");
+        let m = messages("fn f() -> i64 { core::intrinsic::panic::panic<i64, bool>() }");
+        assert!(m.contains("takes at most one type argument"), "{m}");
+        let m = messages("fn f() -> i64 { core::intrinsic::panic::abort() }");
+        assert!(
+            m.contains("unknown panic intrinsic `core::intrinsic::panic::abort`"),
+            "{m}"
+        );
+    }
+
     /// Impl members ride the ordinary defs/generics/functions tables, so the
     /// Checkpoint's truncate-and-retain rollback is sufficient: a rejected
     /// batch retracts them and the method name is reusable.
@@ -2085,11 +2139,11 @@ mod tests {
     }
 
     /// The bundled `library/core` sources stay honest: they elaborate
-    /// cleanly and bind a prototype for *every* math intrinsic the
-    /// compiler surfaces — a new `MathFn` without a core declaration (or
-    /// vice versa) fails here, in `cargo test`, before any rene build.
+    /// cleanly and bind prototypes for the surfaced intrinsics. A new
+    /// intrinsic without a core declaration (or vice versa) fails here, in
+    /// `cargo test`, before any rene build.
     #[test]
-    fn bundled_core_covers_every_math_intrinsic() {
+    fn bundled_core_covers_surfaced_intrinsics() {
         use crate::intrinsic::MathFn;
         use crate::semi::lang::{IntrinsicItem, LangItem};
         check_package(
@@ -2122,6 +2176,10 @@ mod tests {
                     &["intrinsic", "nullable"],
                     include_str!("../../../library/core/src/intrinsic/nullable.rr"),
                 ),
+                (
+                    &["intrinsic", "panic"],
+                    include_str!("../../../library/core/src/intrinsic/panic.rr"),
+                ),
             ],
             |elab, _| {
                 assert!(!elab.has_errors(), "{:#?}", elab.reports);
@@ -2133,6 +2191,15 @@ mod tests {
                         f.as_str()
                     );
                 }
+                let panic_item = LangItem::Intrinsic(IntrinsicItem::Panic);
+                assert!(
+                    elab.lang.get(panic_item).is_some(),
+                    "core declares no prototype for `panic`"
+                );
+                assert!(
+                    elab.lang_item_site(panic_item).is_some(),
+                    "core's `panic` prototype has no declaration site"
+                );
                 // `core::cmp` binds the whole comparison tower, with sites.
                 for item in LangItem::CMP_TRAITS.into_iter().chain([LangItem::Ordering]) {
                     let (_, span) = elab

--- a/crates/reussir-core/src/semi/check.rs
+++ b/crates/reussir-core/src/semi/check.rs
@@ -2177,6 +2177,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             return Some(self.poison(span));
         };
         match *family {
+            "panic" => Some(self.infer_panic_intrinsic(fc, span)),
             "math" => Some(self.infer_math_intrinsic(fc, span)),
             "array" => Some(self.infer_array_intrinsic(fc, span)),
             "cell" => Some(self.infer_cell_intrinsic(fc, span)),
@@ -2188,6 +2189,50 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 Some(self.poison(span))
             }
         }
+    }
+
+    /// (PANIC) `core::intrinsic::panic::panic::<T?>()`: emit an aborting
+    /// operation and inhabit the explicitly supplied or contextually expected
+    /// result type. A fresh inference variable is deliberate here: unlike the
+    /// error-recovery-only bottom type, it is solved by the surrounding
+    /// expression and therefore reaches code generation as a concrete type.
+    fn infer_panic_intrinsic(&mut self, fc: &surface::FuncCall, span: Option<Span>) -> Expr<'tcx> {
+        use crate::intrinsic::IntrinsicOp;
+
+        let name = self.sym(fc.name.basename);
+        if name != "panic" {
+            self.error(
+                span,
+                format!("unknown panic intrinsic `core::intrinsic::panic::{name}`"),
+            );
+            return self.poison(span);
+        }
+        if !fc.args.is_empty() {
+            self.error(
+                span,
+                format!("`panic` expects 0 arguments, got {}", fc.args.len()),
+            );
+            return self.poison(span);
+        }
+        let result = match fc.ty_args.as_slice() {
+            [] | [None] => self.infer.new_hole_ty(),
+            [Some(t)] => self.eval_type(t),
+            _ => {
+                self.error(
+                    span,
+                    "`panic` takes at most one type argument (the result type)",
+                );
+                return self.poison(span);
+            }
+        };
+        self.mk_expr(
+            ExprKind::Intrinsic {
+                op: IntrinsicOp::Panic,
+                args: Vec::new(),
+            },
+            result,
+            span,
+        )
     }
 
     /// (MATH) `core::intrinsic::math::<fn>::<T?>(args…, flag)`: the value

--- a/crates/reussir-core/src/semi/lang.rs
+++ b/crates/reussir-core/src/semi/lang.rs
@@ -29,6 +29,7 @@ use crate::semi::ty::DefId;
 /// while checking and lowering stay wired in the compiler.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum IntrinsicItem {
+    Panic,
     Math(crate::intrinsic::MathFn),
     Array(crate::intrinsic::ArrayFn),
     Cell(crate::intrinsic::CellFn),
@@ -37,6 +38,7 @@ pub enum IntrinsicItem {
 impl IntrinsicItem {
     pub fn family(self) -> &'static str {
         match self {
+            IntrinsicItem::Panic => "panic",
             IntrinsicItem::Math(_) => "math",
             IntrinsicItem::Array(_) => "array",
             IntrinsicItem::Cell(_) => "cell",
@@ -45,6 +47,7 @@ impl IntrinsicItem {
 
     pub fn op_name(self) -> &'static str {
         match self {
+            IntrinsicItem::Panic => "panic",
             IntrinsicItem::Math(f) => f.as_str(),
             IntrinsicItem::Array(f) => f.as_str(),
             IntrinsicItem::Cell(f) => f.as_str(),
@@ -53,6 +56,7 @@ impl IntrinsicItem {
 
     fn from_parts(family: &str, name: &str) -> Option<IntrinsicItem> {
         match family {
+            "panic" if name == "panic" => Some(IntrinsicItem::Panic),
             "math" => crate::intrinsic::MathFn::parse(name).map(IntrinsicItem::Math),
             "array" => crate::intrinsic::ArrayFn::parse(name).map(IntrinsicItem::Array),
             "cell" => crate::intrinsic::CellFn::parse(name).map(IntrinsicItem::Cell),

--- a/library/core/src/intrinsic/mod.rr
+++ b/library/core/src/intrinsic/mod.rr
@@ -10,3 +10,4 @@ pub mod arc;
 pub mod cell;
 pub mod math;
 pub mod nullable;
+pub mod panic;

--- a/library/core/src/intrinsic/panic.rr
+++ b/library/core/src/intrinsic/panic.rr
@@ -1,0 +1,6 @@
+//! Operations that terminate execution.
+
+/// Abort execution. Because this function never returns, its result may be
+/// used wherever any type `T` is expected.
+#[lang("core::intrinsic::panic::panic")]
+pub fn panic<T>() -> T;

--- a/tests/integration/frontend/panic.rr
+++ b/tests/integration/frontend/panic.rr
@@ -1,0 +1,86 @@
+// The zero-argument panic intrinsic never returns, so contextual inference may
+// assign it any result type. Its typed HIR form survives serialization, and
+// code generation emits the existing aborting dialect operation followed by a
+// poison value solely to keep the surrounding SSA structurally well-formed.
+
+// RUN: %rrc %s --emit hir --no-source-locations -o - | %FileCheck %s --check-prefix=HIR
+// RUN: %rrc %s --emit hir --no-source-locations -o %t.hir
+// RUN: %rrc %t.hir --from hir --emit mir --no-source-locations -o - | %FileCheck %s --check-prefix=MIR
+// RUN: %rrc %s --emit mlir --no-source-locations -o - | %FileCheck %s --check-prefix=MLIR
+// RUN: %rrc %s --emit mlir-llvm --no-source-locations -O none -o - | %FileCheck %s --check-prefix=LLVM
+// RUN: %rrc %s -o %t.o
+
+import core::intrinsic::panic;
+
+// HIR-LABEL: pub fn #integer() -> i64 {
+// HIR-NEXT: intrinsic#panic#panic#0() : i64
+// HIR-NEXT: }
+// HIR-LABEL: pub fn #boolean() -> bool {
+// HIR-NEXT: intrinsic#panic#panic#0() : bool
+// HIR-NEXT: }
+// HIR-LABEL: pub fn #aggregate() -> #Pair {
+// HIR-NEXT: intrinsic#panic#panic#0() : #Pair
+// HIR-NEXT: }
+// HIR-LABEL: pub fn #generic<$0 (T)>() -> $0 {
+// HIR-NEXT: intrinsic#panic#panic#0() : $0
+// HIR-NEXT: }
+// HIR-LABEL: pub fn #unit() -> () {
+// HIR-NEXT: intrinsic#panic#panic#0() : ()
+// HIR-NEXT: }
+
+// The MIR run consumes the serialized HIR, exercising textual round-tripping.
+// MIR-LABEL: pub fn @_RC4unit() -> () {
+// MIR-NEXT: intrinsic#panic#panic#0() : ()
+// MIR-NEXT: }
+// MIR-LABEL: pub fn @_RC7boolean() -> bool {
+// MIR-NEXT: intrinsic#panic#panic#0() : bool
+// MIR-NEXT: }
+// MIR-LABEL: pub fn @_RC7integer() -> i64 {
+// MIR-NEXT: intrinsic#panic#panic#0() : i64
+// MIR-NEXT: }
+// MIR-LABEL: pub fn @_RC9aggregate() -> Pair {
+// MIR-NEXT: intrinsic#panic#panic#0() : Pair
+// MIR-NEXT: }
+
+// MLIR-LABEL: func.func @_RC4unit()
+// MLIR-NEXT: reussir.panic "explicit panic"
+// MLIR-NEXT: return
+// MLIR-LABEL: func.func @_RC7boolean() -> i1
+// MLIR-NEXT: reussir.panic "explicit panic"
+// MLIR-NEXT: %{{.+}} = ub.poison : i1
+// MLIR-LABEL: func.func @_RC7integer() -> i64
+// MLIR-NEXT: reussir.panic "explicit panic"
+// MLIR-NEXT: %{{.+}} = ub.poison : i64
+// MLIR-LABEL: func.func @_RC9aggregate()
+// MLIR-NEXT: reussir.panic "explicit panic"
+// MLIR-NEXT: %{{.+}} = ub.poison : !reussir.record<compound "_RC4Pair" [value] {i64, i1}>
+
+// LLVM: llvm.func @__reussir_panic(!llvm.ptr, i64)
+// LLVM-LABEL: llvm.func @_RC7integer() -> i64
+// LLVM: llvm.mlir.poison : i64
+// LLVM: llvm.call @__reussir_panic
+
+pub struct [value] Pair {
+    number: i64,
+    flag: bool
+}
+
+pub fn integer() -> i64 {
+    panic::panic()
+}
+
+pub fn boolean() -> bool {
+    core::intrinsic::panic::panic()
+}
+
+pub fn aggregate() -> Pair {
+    panic::panic<Pair>()
+}
+
+pub fn generic<T>() -> T {
+    panic::panic()
+}
+
+pub fn unit() {
+    panic::panic()
+}

--- a/tests/integration/rene/core_math.rr
+++ b/tests/integration/rene/core_math.rr
@@ -16,6 +16,7 @@
 // RRI: interface 1 package "core"
 // RRI-DAG: #[lang("core::intrinsic::math::sqrt")] pub fn #core::intrinsic::math::sqrt<{{.*}}: core::num::FloatingPoint>({{.*}}) -> {{.*}} in {{[0-9]+}} [{{[0-9]+}}..{{[0-9]+}}];
 // RRI-DAG: #[lang("core::intrinsic::math::powf")]
+// RRI-DAG: #[lang("core::intrinsic::panic::panic")] pub fn #core::intrinsic::panic::panic<{{.*}}>() -> {{.*}} in {{[0-9]+}} [{{[0-9]+}}..{{[0-9]+}}];
 
 // RUN: %t.bdir/dev/mathdemo%exe_ext | %FileCheck %s --check-prefix=OUT
 

--- a/tests/integration/rene/core_math/src/lib.rr
+++ b/tests/integration/rene/core_math/src/lib.rr
@@ -5,6 +5,12 @@ fn is_f64(x: f64, want: f64) -> u64 {
     if x == want { 1 } else { 0 }
 }
 
+// Keep a polymorphic panic call in this real core-backed package without
+// invoking it from the executable's entry point.
+fn impossible() -> i64 {
+    core::intrinsic::panic::panic()
+}
+
 #[main]
 pub fn entry() {
     console::print_u64(is_f64(core::intrinsic::math::sqrt(9.0, 0), 3.0));


### PR DESCRIPTION
## Summary

- expose core::intrinsic::panic::panic<T>() -> T from the bundled core package
- infer an omitted result type from context and preserve a dedicated panic intrinsic through HIR and MIR
- lower panic through the existing reussir.panic operation with a typed poison value for valid SSA
- cover diagnostics, textual round-tripping, core.rri exposure, MLIR/LLVM lowering, and object emission

## Tests

- cargo fmt --all -- --check
- cmake --build build --target reussir-core-test reussir-codegen-test -j2
- cmake --build build --target rrc-test reussir-ut -j2
- build/bin/reussir-ut (30 passed)
- cmake --build build --target check -j2 (475 passed, 6 unsupported)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/531"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788585864&installation_model_id=426051&pr_number=531&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F531&signature=9a1da2995fd592de6baeda3cbe57f5d672393459508b02c8f71152de19e9b61c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->