### PR TITLE
[std] fix codegen antipatterns in the pure collections

### DIFF
--- a/library/std/src/collections/pure/fingertree.rr
+++ b/library/std/src/collections/pure/fingertree.rr
@@ -28,13 +28,16 @@ pub enum FingerTree<T> {
 }
 
 /// The empty or first-element view of a finger tree.
-pub enum ViewLeft<T> {
+/// This stays inline because callers destructure it immediately; a shared
+/// box would cost an allocation on every step of the O(n) traversals.
+pub enum [value] ViewLeft<T> {
     Empty,
     Cons(T, FingerTree<T>)
 }
 
 /// The empty or last-element view of a finger tree.
-pub enum ViewRight<T> {
+/// This stays inline for the same reason as `ViewLeft`.
+pub enum [value] ViewRight<T> {
     Empty,
     Snoc(FingerTree<T>, T)
 }
@@ -46,7 +49,9 @@ pub enum [value] Split<T> {
 }
 
 /// The result of removing a value at an index.
-pub enum Remove<T> {
+/// This stays inline because it is a transient result destructured
+/// immediately, like `ViewLeft`.
+pub enum [value] Remove<T> {
     Removed(T, FingerTree<T>),
     OutOfBounds(FingerTree<T>)
 }
@@ -1006,6 +1011,17 @@ fn reverse_digit<T>(digit : Digit<T>) -> Digit<T> {
     }
 }
 
+// Building by `snoc` keeps the recursion in tail position, so the loop
+// conversion applies and construction runs in constant stack; the naive
+// `from_list(rest).cons(value)` shape pins a frame per element because the
+// recursive result flows through another call.
+fn from_list_impl<T>(values : List<T>, acc : FingerTree<T>) -> FingerTree<T> {
+    match values {
+        List::Nil => acc,
+        List::Cons(value, rest) => from_list_impl(rest, acc.snoc(value))
+    }
+}
+
 fn reverse_tree<T>(tree : FingerTree<T>) -> FingerTree<T> {
     match tree {
         FingerTree::Empty => FingerTree::Empty,
@@ -1031,10 +1047,7 @@ impl<T> FingerTree<T> {
 
     /// Creates a finger tree from values in list order. O(n).
     pub fn from_list(values : List<T>) -> Self {
-        match values {
-            List::Nil => FingerTree::new(),
-            List::Cons(value, rest) => FingerTree::from_list(rest).cons(value)
-        }
+        from_list_impl(values, FingerTree::new())
     }
 
     /// Returns the number of stored values from the cached measure. O(1).

--- a/library/std/src/collections/pure/list.rr
+++ b/library/std/src/collections/pure/list.rr
@@ -145,7 +145,3 @@ impl<T : Eq> List<T> {
         }
     }
 }
-
-pub fn min_list_u32(x : List<u32>) -> u32 {
-   x.min().unwrap_or_panic()
-}


### PR DESCRIPTION
Scanning the freshly landed std library (#532) for shapes the backend cannot optimize turned up three issues, all in the pure collections.

## Changes

- **`FingerTree::from_list` — unbounded stack.** It recursed as `from_list(rest).cons(value)`: the recursive result flows through another call, so neither TRMC nor tail-call elimination applies and construction pinned a stack frame per element. Rebuilt on a `snoc` accumulator in tail position; the loop conversion now applies and construction runs in constant stack.
- **`ViewLeft`/`ViewRight`/`Remove` were shared (rc-boxed) enums** although they are transient carriers destructured immediately by every caller, so each element step of the O(n) traversals (`to_list`, `fold_left`, `filter`, …) paid a heap allocation that survives even at `-O aggressive`. Marked them `[value]`, matching the file's own inline carriers (`ElementViewLeft`, `TreeSplit`, `Split`) and `rtqueue`'s public `Pop`.
- **Dropped `min_list_u32`** from `list.rr`: unused scratch left over from development (`List::min` is covered by the downstream list test).

## Measurements (old vs fixed std, same driver, `rene --profile release`)

Wall time, `FingerTree<i32>`, N=100k, best of 5:

| workload | old | new | speedup |
|---|---|---|---|
| `fold_left` ×100 | 747 ms | 690 ms | 1.08× |
| `to_list` ×50 | 386 ms | 353 ms | 1.09× |
| `filter` ×50 | 559 ms | 529 ms | 1.05× |
| `from_list` ×20 | 156 ms | 134 ms | 1.16× |
| `contains` ×100 | 651 ms | 575 ms | 1.13× |
| `remove_at`+`insert_at` ×20k | 112 ms | 113 ms | 0.99× |

- **callgrind** (`fold_left`, 200k traversal steps): total Ir 157.6M → 148.7M (−5.7%); `__reussir_allocate_small` calls 759,743 → 559,743 and `__reussir_deallocate` 400,010 → 200,010 — both exactly −200,000, i.e. one `ViewLeft` box per element per traversal step eliminated.
- **cachegrind**: data reads −7.0%, writes −4.5%; cache-miss counts flat at this working-set size (the win is allocator round-trips, not misses).
- **llvm-objdump**: the old monomorphized `from_list` contains a genuine self-`call` — and aborts with a stack overflow building a 1M-element tree under the default 8 MiB rlimit — while the new `from_list_impl` has zero self-calls (pure branch loop) and completes.
- **llvm-mca** (hot `fold_left` loop bodies, calls elided): IPC 5.66 → 5.91, both near the 6-wide dispatch limit — the `[value]` inlining introduces no port bottleneck; the wins come from the eliminated allocator traffic mca cannot model.

`remove_at` is honestly neutral: its cost is split/concat tree surgery and the `Remove` carrier is built once per operation — that change is allocation hygiene/consistency.

## Testing

- Full lit integration suite: 485 tests pass (including the four std package tests; fingertree covers 17 input scenarios).
- C++ unit tests: 30/30.
- Built with the conda-forge LLVM/MLIR 22.1.8 toolchain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JrRGzJEYiq9fnXA6r76VaS

---
_Generated by [Claude Code](https://claude.ai/code/session_01JrRGzJEYiq9fnXA6r76VaS)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/533"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788622209&installation_model_id=426051&pr_number=533&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F533&signature=9bde81197aedce4a0ce86517f25576ea1cf9ae8db743faf1c5cdf5da3fb987ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->