### PR TITLE
[rc] prototype projection-only compound moves

### DIFF
--- a/crates/reussir-backend-sys/src/lib.rs
+++ b/crates/reussir-backend-sys/src/lib.rs
@@ -139,6 +139,7 @@ unsafe extern "C" {
     pub fn reussirCreateSpecialPointerTagPass(arch_independent: bool) -> MlirPass;
     pub fn reussirCreateClosureBetaReductionPass() -> MlirPass;
     pub fn reussirCreateRcDispatchFusionPass() -> MlirPass;
+    pub fn reussirCreatePartialMovePass() -> MlirPass;
     pub fn reussirCreateRcCreateFusionPass() -> MlirPass;
     pub fn reussirCreateTRMCRecursionAnalysisPass() -> MlirPass;
     pub fn reussirCreateCompilePolymorphicFFIPass(optimized: bool) -> MlirPass;

--- a/crates/reussir-backend/src/pipeline.rs
+++ b/crates/reussir-backend/src/pipeline.rs
@@ -368,8 +368,8 @@ pub fn run_lowering_pipeline(
         // the cancellation pass (which cancels `inc; destructuring dec` into
         // borrow semantics) and the decrement expansion (which expands the
         // tagged decs shallowly).
-        func:   sys::reussirCreatePartialMovePass();
         func:   sys::reussirCreateRcDispatchFusionPass();
+        func:   sys::reussirCreatePartialMovePass();
         func:   sys::reussirCreateIncDecCancellationPass();
         module: sys::reussirCreateRcDecrementExpansionPass();
         func:   sys::reussirCreateInferVariantTagPass();

--- a/crates/reussir-backend/src/pipeline.rs
+++ b/crates/reussir-backend/src/pipeline.rs
@@ -367,7 +367,9 @@ pub fn run_lowering_pipeline(
         // Fuse pattern-match consumption into destructuring decrements before
         // the cancellation pass (which cancels `inc; destructuring dec` into
         // borrow semantics) and the decrement expansion (which expands the
-        // tagged decs shallowly).
+        // tagged decs shallowly). PartialMove must follow dispatch fusion:
+        // variant fusion exposes adjacent compound-consumption sites that the
+        // old combined pass handled in that order.
         func:   sys::reussirCreateRcDispatchFusionPass();
         func:   sys::reussirCreatePartialMovePass();
         func:   sys::reussirCreateIncDecCancellationPass();

--- a/crates/reussir-backend/src/pipeline.rs
+++ b/crates/reussir-backend/src/pipeline.rs
@@ -368,6 +368,7 @@ pub fn run_lowering_pipeline(
         // the cancellation pass (which cancels `inc; destructuring dec` into
         // borrow semantics) and the decrement expansion (which expands the
         // tagged decs shallowly).
+        func:   sys::reussirCreatePartialMovePass();
         func:   sys::reussirCreateRcDispatchFusionPass();
         func:   sys::reussirCreateIncDecCancellationPass();
         module: sys::reussirCreateRcDecrementExpansionPass();

--- a/include/Reussir-c/Passes.h
+++ b/include/Reussir-c/Passes.h
@@ -61,6 +61,7 @@ MlirPass reussirCreateSpecialPointerTagPass(bool archIndependent);
 /// `begin` without an `end` names it). Intended for verbose/diagnostic runs.
 void reussirPassManagerAttachPhaseLogger(MlirPassManager pm);
 MlirPass reussirCreateRcDispatchFusionPass(void);
+MlirPass reussirCreatePartialMovePass(void);
 MlirPass reussirCreateRcCreateFusionPass(void);
 MlirPass reussirCreateTRMCRecursionAnalysisPass(void);
 MlirPass reussirCreateCompilePolymorphicFFIPass(bool optimized);

--- a/include/Reussir/Transformation/Passes.td
+++ b/include/Reussir/Transformation/Passes.td
@@ -113,6 +113,14 @@ def ReussirRcDispatchFusionPass
     on the shared path the bound members are retained. A preceding increment
     cancels against the destructuring decrement in
     `reussir-inc-dec-cancellation` by rematerializing the bound retains.
+
+    The pass also recognizes a projection-only compound owner whose last
+    projection appears after an earlier extracted member is consumed. When all
+    nontrivial top-level members transfer, it gathers the canonical extraction
+    chains at the first consuming use and advances a tagless destructuring
+    decrement to that ownership cut. It rejects control flow and any crossed
+    count observation that may alias the root. Complete transfer is required
+    because an unbound member's early drop may invoke observable cleanup glue.
   }];
   let dependentDialects = ["::reussir::ReussirDialect"];
 }

--- a/include/Reussir/Transformation/Passes.td
+++ b/include/Reussir/Transformation/Passes.td
@@ -98,6 +98,29 @@ def ReussirRcCreateFusionPass
 }
 
 //===----------------------------------------------------------------------===//
+// PartialMove
+//===----------------------------------------------------------------------===//
+def ReussirPartialMovePass
+    : Pass<"reussir-partial-move", "::mlir::func::FuncOp"> {
+  let summary = "recognize and materialize partial moves";
+  let description = [{
+    `reussir-partial-move` recognizes a projection-only compound owner whose
+    last projection appears after an earlier extracted member is consumed.
+    When all nontrivial top-level members transfer, it gathers the canonical
+    extraction chains at the first consuming use and advances the root
+    decrement to that ownership cut. It rejects control flow and any crossed
+    count observation that may alias the root. Complete transfer is required
+    because an unbound member's early drop may invoke observable cleanup glue.
+
+    The already-adjacent retain/decrement pattern is the degenerate case. Both
+    forms materialize as a tagless destructuring decrement whose
+    `boundMembers` transfer on the unique path and rematerialize their retains
+    on the shared path.
+  }];
+  let dependentDialects = ["::reussir::ReussirDialect"];
+}
+
+//===----------------------------------------------------------------------===//
 // RcDispatchFusion
 //===----------------------------------------------------------------------===//
 def ReussirRcDispatchFusionPass
@@ -114,13 +137,6 @@ def ReussirRcDispatchFusionPass
     cancels against the destructuring decrement in
     `reussir-inc-dec-cancellation` by rematerializing the bound retains.
 
-    The pass also recognizes a projection-only compound owner whose last
-    projection appears after an earlier extracted member is consumed. When all
-    nontrivial top-level members transfer, it gathers the canonical extraction
-    chains at the first consuming use and advances a tagless destructuring
-    decrement to that ownership cut. It rejects control flow and any crossed
-    count observation that may alias the root. Complete transfer is required
-    because an unbound member's early drop may invoke observable cleanup glue.
   }];
   let dependentDialects = ["::reussir::ReussirDialect"];
 }

--- a/lib/CAPI/Passes.cpp
+++ b/lib/CAPI/Passes.cpp
@@ -112,6 +112,9 @@ MlirPass reussirCreateRcCreateSinkPass(void) {
 MlirPass reussirCreateRcDispatchFusionPass(void) {
   return wrapOwned(reussir::createReussirRcDispatchFusionPass());
 }
+MlirPass reussirCreatePartialMovePass(void) {
+  return wrapOwned(reussir::createReussirPartialMovePass());
+}
 MlirPass reussirCreateRcCreateFusionPass(void) {
   return wrapOwned(reussir::createReussirRcCreateFusionPass());
 }
@@ -200,9 +203,8 @@ bool reussirCompilePolymorphicFFI(MlirModule module, bool optimized,
   dirs.reserve(nLibDirs);
   for (intptr_t i = 0; i < nLibDirs; ++i)
     dirs.push_back(unwrap(libDirs[i]));
-  return succeeded(reussir::compilePolymorphicFFI(unwrap(module), optimized,
-                                                  unwrap(rustPath), dirs,
-                                                  unwrap(targetTriple)));
+  return succeeded(reussir::compilePolymorphicFFI(
+      unwrap(module), optimized, unwrap(rustPath), dirs, unwrap(targetTriple)));
 }
 
 LLVMModuleRef reussirGatherCompiledModules(MlirModule module,

--- a/lib/Transformation/RcDispatchFusion/RcDispatchFusion.cpp
+++ b/lib/Transformation/RcDispatchFusion/RcDispatchFusion.cpp
@@ -66,7 +66,7 @@
 #include "Reussir/Transformation/Passes.h"
 
 #include <llvm/ADT/DenseSet.h>
-#include <llvm/ADT/SmallDenseMap.h>
+#include <llvm/ADT/DenseMap.h>
 #include <llvm/ADT/SmallPtrSet.h>
 #include <llvm/Support/ErrorHandling.h>
 #include <mlir/Analysis/AliasAnalysis.h>

--- a/lib/Transformation/RcDispatchFusion/RcDispatchFusion.cpp
+++ b/lib/Transformation/RcDispatchFusion/RcDispatchFusion.cpp
@@ -66,7 +66,9 @@
 #include "Reussir/Transformation/Passes.h"
 
 #include <llvm/ADT/DenseSet.h>
+#include <llvm/ADT/SmallDenseMap.h>
 #include <llvm/ADT/SmallPtrSet.h>
+#include <llvm/Support/ErrorHandling.h>
 #include <mlir/Analysis/AliasAnalysis.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/IR/Builders.h>
@@ -77,6 +79,7 @@
 namespace reussir {
 
 #define GEN_PASS_DEF_REUSSIRRCDISPATCHFUSIONPASS
+#define GEN_PASS_DEF_REUSSIRPARTIALMOVEPASS
 #include "Reussir/Transformation/Passes.h.inc"
 
 namespace {
@@ -230,7 +233,8 @@ matchCompoundExtraction(ReussirRefProjectOp project,
       !load->isBeforeInBlock(terminalDec))
     return std::nullopt;
 
-  CompoundExtraction extraction{project.getIndex().getSExtValue(), load};
+  CompoundExtraction extraction{
+      project.getIndex().getSExtValue(), load, nullptr, {}};
   extraction.chain.push_back(project);
   extraction.chain.push_back(load);
 
@@ -416,7 +420,7 @@ bool scheduleCompleteCompoundMove(ReussirRcDecOp dec,
     return false;
 
   mlir::Operation *cut = nullptr;
-  for (const CompoundExtraction &extraction : extractions) {
+  for (CompoundExtraction &extraction : extractions) {
     for (mlir::Operation *user : extraction.load.getValue().getUsers()) {
       if (chainOps.contains(user))
         continue;
@@ -494,12 +498,18 @@ bool scheduleCompleteCompoundMove(ReussirRcDecOp dec,
     if (user == dec)
       continue;
     auto borrow = llvm::cast<ReussirRcBorrowOp>(user);
-    assert(borrow->isBeforeInBlock(dec));
+    if (!borrow->isBeforeInBlock(dec))
+      llvm::report_fatal_error("partial move left a borrow after its root dec");
     for (mlir::Operation *borrowUser : borrow.getBorrowed().getUsers()) {
       auto project = llvm::cast<ReussirRefProjectOp>(borrowUser);
-      assert(project->isBeforeInBlock(dec));
+      if (!project->isBeforeInBlock(dec))
+        llvm::report_fatal_error(
+            "partial move left a projection after its root dec");
       for (mlir::Operation *projectUser : project.getProjected().getUsers())
-        assert(projectUser->isBeforeInBlock(dec));
+        if (!projectUser->isBeforeInBlock(dec))
+          llvm::report_fatal_error(
+              "partial move left a projected reference live after its root "
+              "dec");
     }
   }
   return true;
@@ -522,8 +532,15 @@ void fuseCompoundConsumption(ReussirRcDecOp dec) {
       !recordType.hasNoRegionalFields())
     return;
 
-  llvm::SmallVector<mlir::Operation *> retains;
+  llvm::SmallDenseMap<int64_t, llvm::SmallVector<mlir::Operation *, 2>, 4>
+      retainsByMember;
   llvm::SmallVector<int64_t> bound;
+  auto rememberRetain = [&](int64_t index, mlir::Operation *retain) {
+    auto &memberRetains = retainsByMember[index];
+    if (memberRetains.empty())
+      bound.push_back(index);
+    memberRetains.push_back(retain);
+  };
   for (mlir::Operation *cursor = dec->getPrevNode(); cursor;
        cursor = cursor->getPrevNode()) {
     if (auto inc = llvm::dyn_cast<ReussirRcIncOp>(cursor)) {
@@ -531,17 +548,13 @@ void fuseCompoundConsumption(ReussirRcDecOp dec) {
       // cancellation; do not shadow it.
       if (inc.getRcPtr() == dec.getRcPtr())
         return;
-      if (auto idx = loadedMemberIndex(inc.getRcPtr(), dec.getRcPtr())) {
-        retains.push_back(cursor);
-        bound.push_back(*idx);
-      }
+      if (auto idx = loadedMemberIndex(inc.getRcPtr(), dec.getRcPtr()))
+        rememberRetain(*idx, cursor);
       continue;
     }
     if (auto acquire = llvm::dyn_cast<ReussirRefAcquireOp>(cursor)) {
-      if (auto idx = acquiredMemberIndex(acquire, dec.getRcPtr())) {
-        retains.push_back(cursor);
-        bound.push_back(*idx);
-      }
+      if (auto idx = acquiredMemberIndex(acquire, dec.getRcPtr()))
+        rememberRetain(*idx, cursor);
       continue;
     }
     // Reads of any box and spills of loaded values commute with the
@@ -559,8 +572,11 @@ void fuseCompoundConsumption(ReussirRcDecOp dec) {
 
   mlir::OpBuilder builder(dec);
   dec.setBoundMembersAttr(builder.getDenseI64ArrayAttr(bound));
-  for (mlir::Operation *retain : retains)
-    retain->erase();
+  // The box owns one reference per field, so at most one retain per member
+  // can be replaced by that transferred owner. Duplicate projections are
+  // additional real copies and keep their remaining retains.
+  for (int64_t index : bound)
+    retainsByMember[index].front()->erase();
 }
 
 struct RcDispatchFusionPass
@@ -568,8 +584,6 @@ struct RcDispatchFusionPass
   using Base::Base;
 
   void runOnOperation() override {
-    mlir::AliasAnalysis aliasAnalysis(getOperation());
-    registerAliasAnalysisImplementations(aliasAnalysis);
     getOperation()->walk([&](ReussirRecordDispatchOp dispatch) {
       auto borrow = llvm::dyn_cast_if_present<ReussirRcBorrowOp>(
           dispatch.getVariant().getDefiningOp());
@@ -597,6 +611,16 @@ struct RcDispatchFusionPass
         fuseArm(region, tagSet[0], scrutinee);
       }
     });
+  }
+};
+
+struct PartialMovePass
+    : public impl::ReussirPartialMovePassBase<PartialMovePass> {
+  using Base::Base;
+
+  void runOnOperation() override {
+    mlir::AliasAnalysis aliasAnalysis(getOperation());
+    registerAliasAnalysisImplementations(aliasAnalysis);
     llvm::SmallVector<ReussirRcDecOp> decrements;
     getOperation()->walk(
         [&](ReussirRcDecOp dec) { decrements.push_back(dec); });

--- a/lib/Transformation/RcDispatchFusion/RcDispatchFusion.cpp
+++ b/lib/Transformation/RcDispatchFusion/RcDispatchFusion.cpp
@@ -59,13 +59,19 @@
 ///
 //===----------------------------------------------------------------------===//
 
+#include "Reussir/Analysis/AliasAnalysis.h"
 #include "Reussir/IR/ReussirDialect.h"
 #include "Reussir/IR/ReussirOps.h"
 #include "Reussir/IR/ReussirTypes.h"
 #include "Reussir/Transformation/Passes.h"
 
+#include <llvm/ADT/DenseSet.h>
+#include <llvm/ADT/SmallPtrSet.h>
+#include <mlir/Analysis/AliasAnalysis.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/IR/Builders.h>
+#include <mlir/Interfaces/CallInterfaces.h>
+#include <mlir/Interfaces/ControlFlowInterfaces.h>
 #include <mlir/Pass/Pass.h>
 
 namespace reussir {
@@ -184,6 +190,321 @@ std::optional<int64_t> acquiredMemberIndex(ReussirRefAcquireOp acquire,
   return project.getIndex().getSExtValue();
 }
 
+struct CompoundExtraction {
+  int64_t index;
+  ReussirRefLoadOp load;
+  mlir::Operation *retain = nullptr;
+  llvm::SmallVector<mlir::Operation *> chain;
+};
+
+// Recognize one direct, owned projection from a compound box. The frontend's
+// canonical borrow-extract shape retains an rc member immediately after its
+// load, and retains a value member either through the projected slot or a
+// spilled copy of the load. Keeping this matcher deliberately narrow makes
+// every reference derived from the box movable as one closed chain.
+std::optional<CompoundExtraction>
+matchCompoundExtraction(ReussirRefProjectOp project,
+                        ReussirRcDecOp terminalDec) {
+  if (project->getBlock() != terminalDec->getBlock() ||
+      !project->isBeforeInBlock(terminalDec))
+    return std::nullopt;
+
+  ReussirRefLoadOp load;
+  ReussirRefAcquireOp directAcquire;
+  for (mlir::Operation *user : project.getProjected().getUsers()) {
+    if (auto candidate = llvm::dyn_cast<ReussirRefLoadOp>(user)) {
+      if (load)
+        return std::nullopt;
+      load = candidate;
+      continue;
+    }
+    if (auto candidate = llvm::dyn_cast<ReussirRefAcquireOp>(user)) {
+      if (directAcquire)
+        return std::nullopt;
+      directAcquire = candidate;
+      continue;
+    }
+    return std::nullopt;
+  }
+  if (!load || load->getBlock() != terminalDec->getBlock() ||
+      !load->isBeforeInBlock(terminalDec))
+    return std::nullopt;
+
+  CompoundExtraction extraction{project.getIndex().getSExtValue(), load};
+  extraction.chain.push_back(project);
+  extraction.chain.push_back(load);
+
+  mlir::Type memberType = load.getValue().getType();
+  if (isTriviallyCopyable(memberType)) {
+    if (directAcquire)
+      return std::nullopt;
+    return extraction;
+  }
+
+  if (llvm::isa<RcType>(memberType)) {
+    if (directAcquire)
+      return std::nullopt;
+    auto inc = llvm::dyn_cast_if_present<ReussirRcIncOp>(load->getNextNode());
+    if (!inc || inc.getRcPtr() != load.getValue() ||
+        !inc->isBeforeInBlock(terminalDec))
+      return std::nullopt;
+    extraction.retain = inc;
+    extraction.chain.push_back(inc);
+    return extraction;
+  }
+
+  if (directAcquire) {
+    if (directAcquire->getBlock() != terminalDec->getBlock() ||
+        !directAcquire->isBeforeInBlock(terminalDec))
+      return std::nullopt;
+    extraction.retain = directAcquire;
+    extraction.chain.push_back(directAcquire);
+    return extraction;
+  }
+
+  auto spilled =
+      llvm::dyn_cast_if_present<ReussirRefSpilledOp>(load->getNextNode());
+  if (!spilled || spilled.getValue() != load.getValue() ||
+      !spilled.getSpilled().hasOneUse())
+    return std::nullopt;
+  auto acquire =
+      llvm::dyn_cast_if_present<ReussirRefAcquireOp>(spilled->getNextNode());
+  if (!acquire || acquire.getRef() != spilled.getSpilled() ||
+      !acquire->isBeforeInBlock(terminalDec))
+    return std::nullopt;
+  extraction.retain = acquire;
+  extraction.chain.push_back(spilled);
+  extraction.chain.push_back(acquire);
+  return extraction;
+}
+
+// Whether a value's type can transitively own the candidate root type. Calls
+// consuming such a value may hide a uniqueness observation or a release of an
+// alias. Recursive record graphs are cut by `seen`.
+bool typeMayContain(mlir::Type type, RcType root,
+                    llvm::DenseSet<mlir::Type> &seen) {
+  if (type == root)
+    return true;
+  if (!seen.insert(type).second)
+    return false;
+  if (auto rc = llvm::dyn_cast<RcType>(type))
+    return typeMayContain(rc.getElementType(), root, seen);
+  if (auto ref = llvm::dyn_cast<RefType>(type))
+    return typeMayContain(ref.getElementType(), root, seen);
+  if (auto nullable = llvm::dyn_cast<NullableType>(type))
+    return typeMayContain(nullable.getPtrTy(), root, seen);
+  if (auto record = llvm::dyn_cast<RecordType>(type)) {
+    if (!record.getComplete())
+      return true;
+    return llvm::any_of(record.getMembers(), [&](mlir::Type member) {
+      return typeMayContain(member, root, seen);
+    });
+  }
+  if (auto array = llvm::dyn_cast<ArrayType>(type))
+    return typeMayContain(array.getElementType(), root, seen);
+  if (auto cell = llvm::dyn_cast<CellType>(type))
+    return typeMayContain(cell.getElementType(), root, seen);
+  // Unknown nontrivial containers (notably closures) may hide the root in
+  // their payload. Primitive and raw values cannot.
+  return !isTriviallyCopyable(type);
+}
+
+bool typeMayContain(mlir::Type type, RcType root) {
+  llvm::DenseSet<mlir::Type> seen;
+  return typeMayContain(type, root, seen);
+}
+
+bool mayAliasRoot(mlir::Value value, mlir::TypedValue<RcType> root,
+                  mlir::AliasAnalysis &aliasAnalysis) {
+  // Distinct typed rc values cannot denote the same box. The in-tree alias
+  // implementation intentionally falls back to MayAlias across RcType
+  // parameters, so establish this cheap type fact before querying it.
+  if (value.getType() != root.getType())
+    return false;
+  return aliasAnalysis.alias(value, root) != mlir::AliasResult::NoAlias;
+}
+
+// Advancing a release changes the count observed in the crossed interval.
+// Reject every operation that could make that change semantically visible.
+// Canonical extraction-chain operations are ignored by the caller.
+bool isUnsafeAcrossAdvancedRelease(mlir::Operation *op,
+                                   mlir::TypedValue<RcType> root,
+                                   mlir::AliasAnalysis &aliasAnalysis) {
+  if (llvm::isa<mlir::RegionBranchOpInterface>(op))
+    return true;
+  if (auto call = llvm::dyn_cast<mlir::CallOpInterface>(op)) {
+    return llvm::any_of(call->getOperands(), [&](mlir::Value operand) {
+      return typeMayContain(operand.getType(), root.getType());
+    });
+  }
+  if (auto view = llvm::dyn_cast<ReussirArrayWithUniqueViewOp>(op))
+    return mayAliasRoot(view.getArray(), root, aliasAnalysis);
+  if (auto uniqify = llvm::dyn_cast<ReussirClosureUniqifyOp>(op))
+    return mayAliasRoot(uniqify.getClosure(), root, aliasAnalysis);
+  if (auto apply = llvm::dyn_cast<ReussirClosureApplyOp>(op))
+    return mayAliasRoot(apply.getClosure(), root, aliasAnalysis);
+  if (auto eval = llvm::dyn_cast<ReussirClosureEvalOp>(op))
+    return mayAliasRoot(eval.getClosure(), root, aliasAnalysis);
+  if (auto unique = llvm::dyn_cast<ReussirRcIsUniqueOp>(op))
+    return mayAliasRoot(unique.getRcPtr(), root, aliasAnalysis);
+  if (auto inc = llvm::dyn_cast<ReussirRcIncOp>(op))
+    return mayAliasRoot(inc.getRcPtr(), root, aliasAnalysis);
+  if (auto dec = llvm::dyn_cast<ReussirRcDecOp>(op))
+    return mayAliasRoot(dec.getRcPtr(), root, aliasAnalysis);
+  if (auto fetch = llvm::dyn_cast<ReussirRcFetchOp>(op))
+    return mayAliasRoot(fetch.getRcPtr(), root, aliasAnalysis);
+  if (auto fetchSub = llvm::dyn_cast<ReussirRcFetchSubOp>(op))
+    return mayAliasRoot(fetchSub.getRcPtr(), root, aliasAnalysis);
+  if (auto set = llvm::dyn_cast<ReussirRcSetOp>(op))
+    return mayAliasRoot(set.getRcPtr(), root, aliasAnalysis);
+  if (auto drop = llvm::dyn_cast<ReussirRefDropOp>(op))
+    return typeMayContain(drop.getRef().getType().getElementType(),
+                          root.getType());
+  if (auto set = llvm::dyn_cast<ReussirCellSetOp>(op))
+    return typeMayContain(set.getCell().getType().getElementType(),
+                          root.getType());
+  if (llvm::isa<ReussirCellRmwOp, ReussirCellRdlockOp, ReussirRegionCleanupOp>(
+          op))
+    return true;
+  return false;
+}
+
+// Schedule a projection-only compound owner at its true ownership cut. Every
+// nontrivial member must transfer: otherwise advancing the dec across a call
+// could run an observable member drop (including an FFI cleanup hook) early.
+// The runtime count==1 split remains the dynamic guard that makes freeing the
+// box itself safe when an unseen holder exists.
+bool scheduleCompleteCompoundMove(ReussirRcDecOp dec,
+                                  mlir::AliasAnalysis &aliasAnalysis) {
+  if (dec.isDestructuring())
+    return false;
+  if (dec.getNullableToken() && !dec.getNullableToken().use_empty())
+    return false;
+  mlir::TypedValue<RcType> root = dec.getRcPtr();
+  RcType type = root.getType();
+  if (type.getCapability() != Capability::shared ||
+      type.getAtomicKind() != AtomicKind::normal || type.isRegional())
+    return false;
+  auto record = llvm::dyn_cast<RecordType>(type.getElementType());
+  if (!record || !record.isCompound() || !record.getComplete() ||
+      !record.hasNoRegionalFields())
+    return false;
+
+  llvm::SmallVector<CompoundExtraction> extractions;
+  llvm::SmallPtrSet<mlir::Operation *, 16> chainOps;
+  for (mlir::Operation *user : root.getUsers()) {
+    if (user == dec)
+      continue;
+    auto borrow = llvm::dyn_cast<ReussirRcBorrowOp>(user);
+    if (!borrow || borrow->getBlock() != dec->getBlock() ||
+        !borrow->isBeforeInBlock(dec))
+      return false;
+    chainOps.insert(borrow);
+    for (mlir::Operation *borrowUser : borrow.getBorrowed().getUsers()) {
+      auto project = llvm::dyn_cast<ReussirRefProjectOp>(borrowUser);
+      if (!project)
+        return false;
+      auto extraction = matchCompoundExtraction(project, dec);
+      if (!extraction)
+        return false;
+      for (mlir::Operation *chainOp : extraction->chain)
+        chainOps.insert(chainOp);
+      extractions.push_back(std::move(*extraction));
+    }
+  }
+  if (extractions.empty())
+    return false;
+
+  mlir::Operation *cut = nullptr;
+  for (const CompoundExtraction &extraction : extractions) {
+    for (mlir::Operation *user : extraction.load.getValue().getUsers()) {
+      if (chainOps.contains(user))
+        continue;
+      if (user->getBlock() != dec->getBlock())
+        return false;
+      if (!cut || user->isBeforeInBlock(cut))
+        cut = user;
+    }
+  }
+  if (!cut || dec->isBeforeInBlock(cut))
+    return false;
+
+  llvm::SmallVector<llvm::SmallVector<mlir::Operation *>> retainsByMember(
+      record.getMembers().size());
+  for (const CompoundExtraction &extraction : extractions) {
+    if (extraction.index < 0 ||
+        static_cast<size_t>(extraction.index) >= retainsByMember.size())
+      return false;
+    if (extraction.retain)
+      retainsByMember[extraction.index].push_back(extraction.retain);
+  }
+
+  llvm::SmallVector<int64_t> boundMembers;
+  llvm::SmallVector<mlir::Operation *> retainsToErase;
+  for (auto [index, member, isField] :
+       llvm::enumerate(record.getMembers(), record.getMemberIsField())) {
+    mlir::Type projected = getProjectedType(
+        member, isField, Capability::unspecified, type.getAtomicKind());
+    if (isTriviallyCopyable(projected))
+      continue;
+    if (retainsByMember[index].empty())
+      return false;
+    boundMembers.push_back(index);
+    // A unique box contributes exactly one owned reference per field. With
+    // duplicate projections only one retain is the transferred owner; the
+    // remaining retains are real copies and must survive.
+    retainsToErase.push_back(retainsByMember[index].front());
+  }
+  if (boundMembers.empty())
+    return false;
+
+  // The advanced release is inserted immediately before `cut`, so inspect
+  // every operation whose view of the root count could change. Extraction
+  // chains are being rescheduled as part of the same ownership rewrite.
+  for (mlir::Operation *cursor = cut; cursor && cursor != dec;
+       cursor = cursor->getNextNode()) {
+    if (chainOps.contains(cursor))
+      continue;
+    if (isUnsafeAcrossAdvancedRelease(cursor, root, aliasAnalysis))
+      return false;
+  }
+
+  // Preserve the extraction chains' original relative order while moving
+  // them together. Member counts remain exact: before the cut the root still
+  // owns each field; after it the unique path transfers that owner and the
+  // shared path rematerializes the erased retain.
+  llvm::SmallVector<mlir::Operation *> orderedChain;
+  for (mlir::Operation &op : *dec->getBlock())
+    if (chainOps.contains(&op))
+      orderedChain.push_back(&op);
+  for (mlir::Operation *op : orderedChain)
+    op->moveBefore(cut);
+  dec->moveBefore(cut);
+
+  mlir::OpBuilder builder(dec);
+  dec.setBoundMembersAttr(builder.getDenseI64ArrayAttr(boundMembers));
+  for (mlir::Operation *retain : retainsToErase)
+    retain->erase();
+
+  // Local, always-on postcondition for the PoC: no reference into the freed
+  // box survives the new ownership cut, and every nontrivial member has one
+  // transfer entry. Whole-function balance is additionally exercised by lit
+  // and sanitizer coverage.
+  for (mlir::Operation *user : root.getUsers()) {
+    if (user == dec)
+      continue;
+    auto borrow = llvm::cast<ReussirRcBorrowOp>(user);
+    assert(borrow->isBeforeInBlock(dec));
+    for (mlir::Operation *borrowUser : borrow.getBorrowed().getUsers()) {
+      auto project = llvm::cast<ReussirRefProjectOp>(borrowUser);
+      assert(project->isBeforeInBlock(dec));
+      for (mlir::Operation *projectUser : project.getProjected().getUsers())
+        assert(projectUser->isBeforeInBlock(dec));
+    }
+  }
+  return true;
+}
+
 // Fuse a rebuild-style consumption of a compound box: scan backward from a
 // plain `rc.dec` collecting member retains, stopping at the first op the
 // retains cannot soundly move past (into the decrement's shared branch).
@@ -247,6 +568,8 @@ struct RcDispatchFusionPass
   using Base::Base;
 
   void runOnOperation() override {
+    mlir::AliasAnalysis aliasAnalysis(getOperation());
+    registerAliasAnalysisImplementations(aliasAnalysis);
     getOperation()->walk([&](ReussirRecordDispatchOp dispatch) {
       auto borrow = llvm::dyn_cast_if_present<ReussirRcBorrowOp>(
           dispatch.getVariant().getDefiningOp());
@@ -274,8 +597,13 @@ struct RcDispatchFusionPass
         fuseArm(region, tagSet[0], scrutinee);
       }
     });
+    llvm::SmallVector<ReussirRcDecOp> decrements;
     getOperation()->walk(
-        [&](ReussirRcDecOp dec) { fuseCompoundConsumption(dec); });
+        [&](ReussirRcDecOp dec) { decrements.push_back(dec); });
+    for (ReussirRcDecOp dec : decrements) {
+      scheduleCompleteCompoundMove(dec, aliasAnalysis);
+      fuseCompoundConsumption(dec);
+    }
   }
 };
 

--- a/tests/integration/conversion/compound_consumption_fusion.mlir
+++ b/tests/integration/conversion/compound_consumption_fusion.mlir
@@ -1,4 +1,4 @@
-// RUN: %reussir-opt %s --reussir-rc-dispatch-fusion | %FileCheck %s
+// RUN: %reussir-opt %s --reussir-partial-move | %FileCheck %s
 
 // A rebuild-style consumption of a compound box: fields are loaded and
 // retained, then the box is released. The fusion folds the retains into a

--- a/tests/integration/conversion/partial_move_fusion.mlir
+++ b/tests/integration/conversion/partial_move_fusion.mlir
@@ -1,0 +1,110 @@
+// RUN: %reussir-opt %s --reussir-rc-dispatch-fusion | %FileCheck %s
+
+// Projection-only compound owners can move at their first consuming use even
+// when a late scalar projection originally kept the carrier alive across a
+// call. Every nontrivial member transfers, so the advanced dec only frees the
+// box on its unique path and rematerializes the transferred retain when shared.
+
+!leaf = !reussir.record<compound "Leaf" [value] {i64}>
+!tree = !reussir.record<variant "Tree" {!leaf}>
+!rc_tree = !reussir.rc<!tree>
+!carrier = !reussir.record<compound "Carrier" {!tree, i1, i1}>
+!rc_carrier = !reussir.rc<!carrier>
+
+func.func private @consume_tree(!rc_tree, i1) -> !rc_tree
+func.func private @consume_one(!rc_tree)
+
+// CHECK-LABEL: func.func @lazy_projection(
+// CHECK: %[[ROOT_REF:.+]] = reussir.rc.borrow
+// CHECK: %[[TREE_SLOT:.+]] = reussir.ref.project (%[[ROOT_REF]]
+// CHECK: %[[TREE:.+]] = reussir.ref.load (%[[TREE_SLOT]]
+// CHECK-NOT: reussir.rc.inc
+// CHECK: reussir.ref.project
+// CHECK: reussir.ref.load
+// CHECK: reussir.ref.project
+// CHECK: %[[LATE:.+]] = reussir.ref.load
+// CHECK: reussir.rc.dec
+// CHECK-SAME: boundMembers = array<i64: 0>
+// CHECK-NEXT: %{{.+}} = call @consume_tree(%[[TREE]],
+// CHECK: return %[[LATE]]
+func.func @lazy_projection(%carrier: !rc_carrier) -> i1 {
+  %ref = reussir.rc.borrow (%carrier : !rc_carrier) : !reussir.ref<!carrier>
+  %tree_slot = reussir.ref.project (%ref : !reussir.ref<!carrier>) [0] : !reussir.ref<!rc_tree>
+  %tree = reussir.ref.load (%tree_slot : !reussir.ref<!rc_tree>) : !rc_tree
+  reussir.rc.inc (%tree : !rc_tree)
+  %early_slot = reussir.ref.project (%ref : !reussir.ref<!carrier>) [1] : !reussir.ref<i1>
+  %early = reussir.ref.load (%early_slot : !reussir.ref<i1>) : i1
+  %updated = func.call @consume_tree(%tree, %early) : (!rc_tree, i1) -> !rc_tree
+  %late_slot = reussir.ref.project (%ref : !reussir.ref<!carrier>) [2] : !reussir.ref<i1>
+  %late = reussir.ref.load (%late_slot : !reussir.ref<i1>) : i1
+  reussir.rc.dec (%carrier : !rc_carrier)
+  reussir.rc.dec (%updated : !rc_tree)
+  return %late : i1
+}
+
+// Repeated extraction of one field transfers the box's one owner and keeps
+// the extra copy's retain. Duplicate boundMembers would be unsound because the
+// unique box contains only one reference to transfer.
+// CHECK-LABEL: func.func @duplicate_projection(
+// CHECK-COUNT-1: reussir.rc.inc
+// CHECK: reussir.rc.dec
+// CHECK-SAME: boundMembers = array<i64: 0>
+// CHECK-NEXT: call @consume_one
+func.func @duplicate_projection(%carrier: !rc_carrier) -> !rc_tree {
+  %ref0 = reussir.rc.borrow (%carrier : !rc_carrier) : !reussir.ref<!carrier>
+  %slot0 = reussir.ref.project (%ref0 : !reussir.ref<!carrier>) [0] : !reussir.ref<!rc_tree>
+  %tree0 = reussir.ref.load (%slot0 : !reussir.ref<!rc_tree>) : !rc_tree
+  reussir.rc.inc (%tree0 : !rc_tree)
+  func.call @consume_one(%tree0) : (!rc_tree) -> ()
+  %ref1 = reussir.rc.borrow (%carrier : !rc_carrier) : !reussir.ref<!carrier>
+  %slot1 = reussir.ref.project (%ref1 : !reussir.ref<!carrier>) [0] : !reussir.ref<!rc_tree>
+  %tree1 = reussir.ref.load (%slot1 : !reussir.ref<!rc_tree>) : !rc_tree
+  reussir.rc.inc (%tree1 : !rc_tree)
+  %late_slot = reussir.ref.project (%ref1 : !reussir.ref<!carrier>) [2] : !reussir.ref<i1>
+  %late = reussir.ref.load (%late_slot : !reussir.ref<i1>) : i1
+  reussir.rc.dec (%carrier : !rc_carrier)
+  return %tree1 : !rc_tree
+}
+
+!two_trees = !reussir.record<compound "TwoTrees" {!tree, !tree, i1}>
+!rc_two_trees = !reussir.rc<!two_trees>
+
+// A nontrivial unbound member could run arbitrary drop glue before the call,
+// so incomplete transfers stay untouched.
+// CHECK-LABEL: func.func @incomplete_transfer(
+// CHECK: reussir.rc.inc
+// CHECK: call @consume_one
+// CHECK: reussir.rc.dec
+// CHECK-NOT: boundMembers
+func.func @incomplete_transfer(%carrier: !rc_two_trees) -> i1 {
+  %ref = reussir.rc.borrow (%carrier : !rc_two_trees) : !reussir.ref<!two_trees>
+  %tree_slot = reussir.ref.project (%ref : !reussir.ref<!two_trees>) [0] : !reussir.ref<!rc_tree>
+  %tree = reussir.ref.load (%tree_slot : !reussir.ref<!rc_tree>) : !rc_tree
+  reussir.rc.inc (%tree : !rc_tree)
+  func.call @consume_one(%tree) : (!rc_tree) -> ()
+  %late_slot = reussir.ref.project (%ref : !reussir.ref<!two_trees>) [2] : !reussir.ref<i1>
+  %late = reussir.ref.load (%late_slot : !reussir.ref<i1>) : i1
+  reussir.rc.dec (%carrier : !rc_two_trees)
+  return %late : i1
+}
+
+// A count observer on a same-typed MayAlias value blocks the advanced release.
+// CHECK-LABEL: func.func @count_observer(
+// CHECK: reussir.rc.inc
+// CHECK: reussir.rc.is_unique
+// CHECK: call @consume_one
+// CHECK: reussir.rc.dec
+// CHECK-NOT: boundMembers
+func.func @count_observer(%carrier: !rc_carrier, %alias: !rc_carrier) -> i1 {
+  %ref = reussir.rc.borrow (%carrier : !rc_carrier) : !reussir.ref<!carrier>
+  %tree_slot = reussir.ref.project (%ref : !reussir.ref<!carrier>) [0] : !reussir.ref<!rc_tree>
+  %tree = reussir.ref.load (%tree_slot : !reussir.ref<!rc_tree>) : !rc_tree
+  reussir.rc.inc (%tree : !rc_tree)
+  %unique = reussir.rc.is_unique (%alias : !rc_carrier) : i1
+  func.call @consume_one(%tree) : (!rc_tree) -> ()
+  %late_slot = reussir.ref.project (%ref : !reussir.ref<!carrier>) [2] : !reussir.ref<i1>
+  %late = reussir.ref.load (%late_slot : !reussir.ref<i1>) : i1
+  reussir.rc.dec (%carrier : !rc_carrier)
+  reussir.rc.dec (%alias : !rc_carrier)
+  return %late : i1
+}

--- a/tests/integration/conversion/partial_move_fusion.mlir
+++ b/tests/integration/conversion/partial_move_fusion.mlir
@@ -1,4 +1,4 @@
-// RUN: %reussir-opt %s --reussir-partial-move --reussir-rc-dispatch-fusion | %FileCheck %s
+// RUN: %reussir-opt %s --reussir-rc-dispatch-fusion --reussir-partial-move | %FileCheck %s
 
 // Projection-only compound owners can move at their first consuming use even
 // when a late scalar projection originally kept the carrier alive across a

--- a/tests/integration/conversion/partial_move_fusion.mlir
+++ b/tests/integration/conversion/partial_move_fusion.mlir
@@ -1,4 +1,4 @@
-// RUN: %reussir-opt %s --reussir-rc-dispatch-fusion | %FileCheck %s
+// RUN: %reussir-opt %s --reussir-partial-move --reussir-rc-dispatch-fusion | %FileCheck %s
 
 // Projection-only compound owners can move at their first consuming use even
 // when a late scalar projection originally kept the carrier alive across a

--- a/tests/integration/conversion/partial_move_fusion.mlir
+++ b/tests/integration/conversion/partial_move_fusion.mlir
@@ -16,8 +16,8 @@ func.func private @consume_one(!rc_tree)
 
 // CHECK-LABEL: func.func @lazy_projection(
 // CHECK: %[[ROOT_REF:.+]] = reussir.rc.borrow
-// CHECK: %[[TREE_SLOT:.+]] = reussir.ref.project (%[[ROOT_REF]]
-// CHECK: %[[TREE:.+]] = reussir.ref.load (%[[TREE_SLOT]]
+// CHECK: %[[TREE_SLOT:.+]] = reussir.ref.project(%[[ROOT_REF]]
+// CHECK: %[[TREE:.+]] = reussir.ref.load(%[[TREE_SLOT]]
 // CHECK-NOT: reussir.rc.inc
 // CHECK: reussir.ref.project
 // CHECK: reussir.ref.load
@@ -88,14 +88,38 @@ func.func @incomplete_transfer(%carrier: !rc_two_trees) -> i1 {
   return %late : i1
 }
 
-// A count observer on a same-typed MayAlias value blocks the advanced release.
+// A count observer on a same-typed MayAlias value inside the crossed interval
+// blocks the advanced release.
 // CHECK-LABEL: func.func @count_observer(
 // CHECK: reussir.rc.inc
-// CHECK: reussir.rc.is_unique
 // CHECK: call @consume_one
+// CHECK: reussir.rc.is_unique
 // CHECK: reussir.rc.dec
 // CHECK-NOT: boundMembers
 func.func @count_observer(%carrier: !rc_carrier, %alias: !rc_carrier) -> i1 {
+  %ref = reussir.rc.borrow (%carrier : !rc_carrier) : !reussir.ref<!carrier>
+  %tree_slot = reussir.ref.project (%ref : !reussir.ref<!carrier>) [0] : !reussir.ref<!rc_tree>
+  %tree = reussir.ref.load (%tree_slot : !reussir.ref<!rc_tree>) : !rc_tree
+  reussir.rc.inc (%tree : !rc_tree)
+  func.call @consume_one(%tree) : (!rc_tree) -> ()
+  %unique = reussir.rc.is_unique (%alias : !rc_carrier) : i1
+  %late_slot = reussir.ref.project (%ref : !reussir.ref<!carrier>) [2] : !reussir.ref<i1>
+  %late = reussir.ref.load (%late_slot : !reussir.ref<i1>) : i1
+  reussir.rc.dec (%carrier : !rc_carrier)
+  reussir.rc.dec (%alias : !rc_carrier)
+  return %late : i1
+}
+
+// An observer before the cut is not crossed: the release may still advance to
+// the cut after it without changing the observer's count.
+// CHECK-LABEL: func.func @count_observer_before_cut(
+// CHECK: reussir.rc.is_unique
+// CHECK-NOT: reussir.rc.inc
+// CHECK: reussir.rc.dec
+// CHECK-SAME: boundMembers = array<i64: 0>
+// CHECK-NEXT: call @consume_one
+func.func @count_observer_before_cut(%carrier: !rc_carrier,
+                                     %alias: !rc_carrier) -> i1 {
   %ref = reussir.rc.borrow (%carrier : !rc_carrier) : !reussir.ref<!carrier>
   %tree_slot = reussir.ref.project (%ref : !reussir.ref<!carrier>) [0] : !reussir.ref<!rc_tree>
   %tree = reussir.ref.load (%tree_slot : !reussir.ref<!rc_tree>) : !rc_tree

--- a/tests/integration/frontend/partial_move.rr
+++ b/tests/integration/frontend/partial_move.rr
@@ -1,0 +1,53 @@
+// RUN: %rrc %s --emit mlir -O none --no-source-locations -o %t.mlir
+// RUN: %reussir-opt %t.mlir --reussir-partial-move | %FileCheck %s
+
+// This is the source-level shape that motivated partial-move materialization:
+// a nontrivial member is consumed by a call while scalar projections keep the
+// carrier live until afterward. The pass must move all projections to the cut,
+// transfer the carrier's ownership of `tree`, and erase its retain.
+
+struct Leaf {
+    value: i64
+}
+
+struct Carrier {
+    tree: Leaf,
+    early: i64,
+    late: i64
+}
+
+fn consume(tree: Leaf, delta: i64) -> Leaf {
+    Leaf { value: tree.value + delta }
+}
+
+fn natural(carrier: Carrier) -> i64 {
+    let updated = consume(carrier.tree, carrier.early);
+    updated.value + carrier.late
+}
+
+// CHECK-LABEL: func.func private @_RC7natural(
+// CHECK: %[[ROOT_REF:.+]] = reussir.rc.borrow
+// CHECK: %[[TREE_SLOT:.+]] = reussir.ref.project(%[[ROOT_REF]]
+// CHECK: %[[TREE:.+]] = reussir.ref.load(%[[TREE_SLOT]]
+// CHECK-NOT: reussir.rc.inc
+// CHECK: reussir.ref.project
+// CHECK: reussir.ref.load
+// CHECK: reussir.ref.project
+// CHECK: %[[LATE:.+]] = reussir.ref.load
+// CHECK: reussir.rc.dec
+// CHECK-SAME: boundMembers = array<i64: {{[0-9]+}}>
+// CHECK-NEXT: %{{.+}} = call @_RC7consume(%[[TREE]],
+
+// Projecting `tree` twice creates two owned copies. Only the carrier's one
+// reference transfers; the retain for the second copy must survive.
+fn duplicate(carrier: Carrier) -> Leaf {
+    let first = consume(carrier.tree, carrier.early);
+    consume(carrier.tree, first.value + carrier.late)
+}
+
+// CHECK-LABEL: func.func private @_RC9duplicate(
+// CHECK: reussir.rc.inc
+// CHECK-NOT: reussir.rc.inc
+// CHECK: reussir.rc.dec
+// CHECK-SAME: boundMembers = array<i64: {{[0-9]+}}>
+// CHECK: call @_RC7consume

--- a/tool/reussir-opt/main.cpp
+++ b/tool/reussir-opt/main.cpp
@@ -68,6 +68,9 @@ int main(int argc, char **argv) {
     return reussir::createReussirRcDispatchFusionPass();
   });
   mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {
+    return reussir::createReussirPartialMovePass();
+  });
+  mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {
     return reussir::createReussirRegionPatternsPass();
   });
   mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {


### PR DESCRIPTION
## Summary

Prototype a dedicated `reussir-partial-move` pass for shared compound RC carriers. `RcDispatchFusion` remains the local tagged-variant rewrite; the new pass owns use-cone discovery, legality checks, code motion, and the tagless compound transfer (including the already-adjacent degenerate case).

When a carrier's only uses are direct canonical field extractions plus one terminal decrement, the pass gathers those extraction chains at the first consuming use, advances the root decrement, and records a tagless destructuring transfer through the existing `boundMembers` mechanism.

The default order is deliberately:

`rc-dispatch-fusion -> partial-move -> inc-dec-cancellation`

This preserves the old combined pass's dependency: tagged variant fusion may expose adjacent compound-consumption sites that PartialMove must see.

## Soundness boundary

- single MLIR block only; region/control-flow crossings are rejected
- shared, nonatomic, nonregional, complete compound boxes without `[field]` members
- every nontrivial top-level member must transfer before an effectful interval is crossed
- no root/ref escape and no used decrement token
- count observers and calls that may receive the root transitively block the rewrite
- duplicate projection of one member erases exactly one retain; further retains remain as real copies

The runtime `count == 1` split remains the dynamic guard: the unique path transfers the box's owned fields, while the shared path rematerializes the erased retain before lowering the count.

## Applicability limit and benchmark

The deterministic A/B used compiler base `484048bf` (TokenReuse determinism merged in #547) versus this PR at `e1e1a2d`, with identical flags and PR #537 commit `fd47ec54`'s natural lazy WAVL workload: 100k-key set insertion plus build-and-drain.

| | base | this PR |
|---|---:|---:|
| emitted IR | 371,247 bytes | 371,247 bytes |
| set insert (100k) | 33.5 +/- 5.2 ms | 35.0 +/- 7.5 ms |
| build + drain | 57.2 +/- 8.2 ms | 53.4 +/- 7.1 ms |

The emitted IR is byte-identical and output checksums match. The timing differences are therefore noise: this PR has zero codegen regression on the workload, but it also does **not** demonstrate the intended win.

### Manual-scheduling opportunity bound

To separate what the current pass captures from the underlying opportunity, the deterministic base and PR compilers used identical `-Oaggressive --reuse-across-call` flags and link lines. Each timing arm used 40 runs.

| # | source spelling | compiler | min | median |
|---|---|---|---:|---:|
| 1 | natural | base `484048bf` (pass absent) | 32.9 ms | 33.5 ms |
| 2 | natural | PR `e1e1a2d` (pass enabled) | 32.9 ms | 33.5 ms |
| 3 | hand-scheduled | base `484048bf` (pass absent) | **29.4 ms** | **30.3 ms** |

Rows 1 and 2 emit byte-identical IR: the current pass does not fire on this natural spelling. Row 3 is about 11% faster and represents the unclaimed opportunity. In other words, (1) -> (2) measures what #538 captures today (nothing on this shape), while (2) -> (3) measures the gap the early scheduling phase is intended to close.

The fingertree rewrite is one genuine consumption hoist in `snoc`'s `Deep/Four` arm: construct `Digit::Two{d, x}` before the recursive call, completing the scrutinee's destructuring before recursion. The final IR diff is 52 lines, while allocation/deallocation/reallocation call counts are unchanged; the measured cost is placement of RC work relative to the call, not extra allocation volume.

A no-op `let p = prefix` experiment emitted byte-identical IR, confirming that rebinding a match variable does not schedule ownership work. Some match-style cases (notably `view_left`'s `Deep/One` arm) have post-call consumptions in multiple result branches and no equivalent full hand-scheduling source spelling; a compiler transform is required there.

The independent WAVL natural-versus-project-first comparison reproduces the carrier-style opportunity:

| workload | natural min/median | project-first min/median | improvement |
|---|---:|---:|---:|
| set insert 100k | 31.1 / 32.2 ms | 29.7 / 31.2 ms | about 4.5% at min |
| build + drain | 49.2 / 50.0 ms | 46.9 / 47.8 ms | about 4.7% at min |

These experiments size the prize: roughly 4–5% for carrier-style code and roughly 11% for this match-style fingertree site. **They do not validate the current pass**, which captures neither spelling today; they bound the payoff of the early/late architecture described below.

The reason is structural. PR #537's carrier is a `[value]` struct (`Ins<T>`), while v1 requires an RC-boxed shared compound root with a consuming `rc.dec`. The natural source example therefore has no root box/decrement for this pass to rewrite. Supporting spilled value records plus member-wise release scheduling is follow-up scope, not part of this PoC.

An instrumented default-pipeline scan gives the exact current activation surface:

| surface | successful rewrites |
|---|---:|
| all 11 `reussir-lang/benchmark` programs | 0 |
| full `std` + `core` release build via `rene` | 0 |
| 160 non-PartialMove frontend fixtures | 25 in 5 files |

The five fixtures are `wavl_fold_traverse.rr` (18), `array_struct_materialize.rr` (4), `closure_struct_materialize.rr` (1), `example_hm_queue.rr` (1), and `issue_213_noop_deallocate_null.rr` (1). Only the last two retain a final-IR difference; the other rewrites converge to byte-identical output after cancellation, expansion, and LLVM lowering.

In the measured default pipeline, PartialMove activates on no benchmark or library code, and on shared-compound patterns in five frontend fixtures (25 rewrites, two with final-code effects). This does **not** imply that partial moves are uncommon: the benchmark and library inputs are already performance-tuned and often spell projections eagerly, so their null result is regression-neutrality evidence rather than evidence against the method. The fixture hits demonstrate that the natural pattern exists outside the pass's dedicated tests.

PR #537's own history demonstrates that selection effect. Its natural lazy `[value]` carrier spelling measured 388,373,901 instructions and 620 ms for build-and-drain (+3.9% instructions versus the enum baseline). Commit `46c55a3f` then hand-projected every carrier field before the call—the scheduling an internals-aware user must currently perform—and measured 361,043,483 instructions and 570 ms. The current in-tree null comes after that manual optimization; it cannot be read as evidence that the method has no payoff.

The dedicated source-level test activates only under direct pass invocation because the default pipeline's inliner dissolves that particular shape first. Reaching the natural lazy `[value]` spelling from PR #537 still requires the value-carrier extension described below.

Value-carrier support alone is not sufficient at the current pass position. The default inliner runs before token instantiation, dispatch fusion, and PartialMove; it inlines the non-recursive `consume` helper in the source test and the non-recursive `bal_*_ins` helper in the WAVL workload. Those calls are the barriers that make the lazy projections visible in source. After inlining, their region-heavy bodies replace the calls, while v1 deliberately rejects region/control-flow crossings. A production value-carrier extension therefore also needs an early, pre-inliner scheduling phase (or an equivalent pass split); the late phase must remain after dispatch fusion to preserve the existing tagged-then-compound dependency.

If v1 lands first, it should be understood as the **late half of that deliberate two-stage architecture**, not as the complete optimization: dispatch fusion independently exposes adjacent compound-consumption sites that only a post-dispatch phase can fuse. The complementary early phase would schedule value carriers while their source-level call barriers still exist. Current default-pipeline coverage is fixture-level rather than benchmark/library-level, so the focused coverage is labelled explicitly and should remain maintained as the early phase broadens production activation.

## Tests and validation

Lit coverage pins:

- a late projection across a call on a shared compound carrier
- duplicate projection multiplicity
- incomplete-transfer rejection
- MayAlias uniqueness-observer rejection
- source lowering followed by direct PartialMove invocation
- the required dispatch-fusion -> partial-move pipeline dependency

Validation completed before the deterministic-base refresh:

- native MLIR 22 build and focused lit tests: PASS
- Ubuntu x64, Ubuntu ARM64, macOS, and Windows hosted pipelines: PASS
- deterministic benchmark compiles: SAME across repeats
- full 11-program benchmark-suite IR scan: byte-identical base/PR output for every program
- instrumented default-pipeline scan: 0 benchmark hits, 0 `std`/`core` hits, and 25 frontend-fixture hits in 5 files (2 with final-code effects)

The direct source test is not evidence of default-pipeline activation: `-Oaggressive` inlines its helper calls before PartialMove runs and produces zero hits.

The current head is a rebase-only refresh onto #547; its hosted matrix is running again.

## Promotion decision

- [x] dedicated pass split and pipeline dependency preserved
- [x] focused native and hosted validation
- [x] deterministic A/B with no regression
- [ ] decide whether to land v1 as shared-carrier infrastructure or add a pre-inliner value-carrier scheduling phase before promotion
- [ ] decide whether the always-on local postcondition is sufficient for the PoC or needs a dedicated post-cancellation ownership verifier
