### PR TITLE
[compiler][link] fix BFD runtime archive ordering

### DIFF
--- a/crates/reussir-compiler/src/driver/link.rs
+++ b/crates/reussir-compiler/src/driver/link.rs
@@ -93,6 +93,21 @@ fn add_native_staticlib(
     whole_archive: bool,
     triple: &str,
 ) -> Result<(), String> {
+    // ld64 implements neither the GNU `-l:exact-file` form rustc's
+    // `+verbatim` modifier selects nor anything like it, so the native-library
+    // spelling cannot name these archives on Apple targets at all. It does not
+    // need to: ld64 resolves archive members regardless of command-line
+    // position, so the ordering problem this function exists to fix is a
+    // GNU-BFD-only problem, and the direct-path spelling is sound there.
+    // `-force_load` carries the whole-archive semantics.
+    if triple.contains("-apple-") {
+        if whole_archive {
+            cmd.arg(format!("-Clink-arg=-Wl,-force_load,{}", archive.display()));
+        } else {
+            cmd.arg(format!("-Clink-arg={}", archive.display()));
+        }
+        return Ok(());
+    }
     let name = archive.file_name().ok_or_else(|| {
         format!(
             "cannot link archive `{}` without a file name",

--- a/crates/reussir-compiler/src/driver/link.rs
+++ b/crates/reussir-compiler/src/driver/link.rs
@@ -67,6 +67,70 @@ impl ScratchMembers {
     pub(crate) fn finish(self, output: &Path, triple: &str) -> Result<(), String> {
         write_archive(output, &self.members, triple)
     }
+
+    /// Archive the members for a linked product, keeping the scratch
+    /// directory alive until rustc has consumed it.
+    pub(crate) fn link_archive(&self, triple: &str) -> Result<PathBuf, String> {
+        let name = if triple.contains("-windows") && triple.contains("msvc") {
+            format!("{}-link-input.lib", self.stem)
+        } else {
+            format!("lib{}-link-input.a", self.stem)
+        };
+        let path = self.dir.path().join(name);
+        write_archive(&path, &self.members, triple)?;
+        Ok(path)
+    }
+}
+
+/// Hand an archive to rustc as a native static library. Native libraries are
+/// ordered before Rust dependency rlibs in the final linker invocation;
+/// `-C link-arg=<archive>` is appended after them instead, which leaves GNU
+/// BFD unable to revisit an earlier runtime rlib when the archive introduces a
+/// new reference.
+fn add_native_staticlib(
+    cmd: &mut std::process::Command,
+    archive: &Path,
+    whole_archive: bool,
+    triple: &str,
+) -> Result<(), String> {
+    let name = archive.file_name().ok_or_else(|| {
+        format!(
+            "cannot link archive `{}` without a file name",
+            archive.display()
+        )
+    })?;
+    let parent = archive
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    cmd.arg("-L").arg(format!("native={}", parent.display()));
+    let name = name.to_string_lossy();
+    // wasm-ld does not implement the GNU `-l:exact-file` form rustc's
+    // `+verbatim` modifier selects. Rene's wasm archives use the conventional
+    // `lib<name>.a` spelling, so hand rustc the logical library name there.
+    let (modifiers, name) = if triple.starts_with("wasm") {
+        let name = name
+            .strip_prefix("lib")
+            .and_then(|name| name.strip_suffix(".a"))
+            .ok_or_else(|| {
+                format!(
+                    "wasm static archive `{}` must be named `lib<name>.a`",
+                    archive.display()
+                )
+            })?;
+        let modifiers = if whole_archive {
+            "static:+whole-archive"
+        } else {
+            "static"
+        };
+        (modifiers, name)
+    } else if whole_archive {
+        ("static:+whole-archive,+verbatim", name.as_ref())
+    } else {
+        ("static:+verbatim", name.as_ref())
+    };
+    cmd.arg("-l").arg(format!("{modifiers}={name}"));
+    Ok(())
 }
 
 /// The launcher a Reussir executable is built around, embedded at compile
@@ -166,16 +230,26 @@ pub(crate) fn link_product(
         }
         cmd.arg(format!("-Clinker={}", linker.display()));
     }
-    for member in &scratch.members {
-        cmd.arg(format!("-Clink-arg={}", member.display()));
-    }
+    // Put this compilation's objects into one whole-archived native library.
+    // The launcher references `__reussir_main`, but a dynlib's empty shim has
+    // no reference that would extract its exports; whole-archive preserves the
+    // previous direct-object behavior for both products. More importantly,
+    // rustc places native libraries before dependency rlibs, giving the linker
+    // the dependency order it needs: product, Reussir packages, runtime. This
+    // is a DAG requirement: rene terminates on dependency cycles but does not
+    // reject them, and no linear archive order can resolve a cycle under a
+    // single-pass linker. Manual `--link-lib` callers share the documented
+    // dependency-order contract and the same limitation.
+    let product_archive = scratch.link_archive(triple)?;
+    add_native_staticlib(&mut cmd, &product_archive, true, triple)?;
     // Dependency staticlibs (`--link-lib`), after this compilation's own
     // members: declared extern symbols — dependency ground functions, and
-    // the mono-exported private helpers their shipped bodies reach —
-    // resolve here. Named by path like the runtime archive below, and for
-    // the same reason.
+    // the mono-exported private helpers their shipped bodies reach — resolve
+    // here. These must be native libraries rather than trailing raw link args:
+    // the runtime rlib follows them and resolves the references they add even
+    // under a single-pass archive linker such as GNU BFD.
     for lib in &cli.link_libs {
-        cmd.arg(format!("-Clink-arg={}", lib.display()));
+        add_native_staticlib(&mut cmd, lib, false, triple)?;
     }
 
     // The runtime.

--- a/crates/reussir-compiler/tests/driver.rs
+++ b/crates/reussir-compiler/tests/driver.rs
@@ -522,8 +522,10 @@ fn passes_the_target_to_linking_rustc() {
 /// Product and package archives must reach rustc as native static libraries,
 /// before the runtime rlib. A trailing `-C link-arg=<archive>` makes GNU BFD
 /// scan the runtime first and never revisit it when the package archive adds a
-/// new runtime reference.
-#[cfg(unix)]
+/// new runtime reference. Not on Apple hosts: ld64 has no `-l:exact-file`
+/// form, resolves archives regardless of position, and keeps the direct-path
+/// spelling — covered by `passes_link_inputs_as_paths_on_apple` below.
+#[cfg(all(unix, not(target_os = "macos")))]
 #[test]
 fn passes_link_inputs_before_the_runtime_rlib() {
     let dir = scratch("link-archive-order");
@@ -600,6 +602,77 @@ fn passes_link_inputs_before_the_runtime_rlib() {
             .iter()
             .any(|arg| arg == &format!("-Clink-arg={}", dependency.display())),
         "dependency archive remained a trailing raw link arg: {args:#?}"
+    );
+}
+
+/// The Apple spelling of the same link: ld64 cannot be handed exact archive
+/// names through `-l` (no GNU `-l:` form), and does not need the reordering —
+/// it resolves archive members regardless of position. Product archives keep
+/// whole-archive semantics through `-force_load`; package archives stay
+/// direct paths.
+#[cfg(target_os = "macos")]
+#[test]
+fn passes_link_inputs_as_paths_on_apple() {
+    let dir = scratch("link-archive-apple");
+    let input = dir.path().join("program.ll");
+    std::fs::write(&input, "define void @__reussir_main() {\n  ret void\n}\n")
+        .expect("write LLVM IR");
+    let runtime = dir.path().join("libreussir_rt.rlib");
+    std::fs::write(&runtime, "").expect("write fake runtime");
+    let deps = dir.path().join("deps");
+    std::fs::create_dir(&deps).expect("create dependency directory");
+    let dependency = deps.join("libdependency.a");
+    std::fs::write(&dependency, "").expect("write fake dependency archive");
+    let rustc = shell_script(
+        dir.path(),
+        "record-link-rustc",
+        "printf '%s\n' \"$@\" > \"$FAKE_RUSTC_LOG\"\n\
+         previous=''\n\
+         for arg in \"$@\"; do\n\
+           if [ \"$previous\" = '-o' ]; then : > \"$arg\"; fi\n\
+           previous=\"$arg\"\n\
+         done\n",
+    );
+    let log = dir.path().join("rustc-args");
+    let output_path = dir.path().join("program");
+    let output = Command::new(env!("CARGO_BIN_EXE_rrc"))
+        .args([
+            input.as_os_str(),
+            "-o".as_ref(),
+            output_path.as_os_str(),
+            "--emit".as_ref(),
+            "executable".as_ref(),
+            "--polyffi-rust-path".as_ref(),
+            rustc.as_os_str(),
+            "--polyffi-libdir".as_ref(),
+            dir.path().as_os_str(),
+            "--link-lib".as_ref(),
+            dependency.as_os_str(),
+        ])
+        .env("FAKE_RUSTC_LOG", &log)
+        .output()
+        .expect("spawn rrc");
+    assert!(
+        output.status.success(),
+        "link driver failed:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let args: Vec<_> = read(&log).lines().map(str::to_owned).collect();
+    assert!(
+        args.iter().any(|arg| {
+            arg.starts_with("-Clink-arg=-Wl,-force_load,") && arg.ends_with("-link-input.a")
+        }),
+        "no force-loaded product archive: {args:#?}"
+    );
+    assert!(
+        args.iter()
+            .any(|arg| arg == &format!("-Clink-arg={}", dependency.display())),
+        "dependency archive not passed by path: {args:#?}"
+    );
+    assert!(
+        !args.iter().any(|arg| arg.contains("+verbatim")),
+        "verbatim native-library spelling reached an Apple link: {args:#?}"
     );
 }
 

--- a/crates/reussir-compiler/tests/driver.rs
+++ b/crates/reussir-compiler/tests/driver.rs
@@ -511,6 +511,96 @@ fn passes_the_target_to_linking_rustc() {
     );
     assert!(output_path.is_file(), "recording rustc did not make output");
     assert_recorded_target(&log, "wasm32-wasip1");
+    let args = read(&log);
+    assert!(
+        args.lines()
+            .any(|arg| arg == "static:+whole-archive=program-link-input"),
+        "wasm product archive did not use its logical library name:\n{args}"
+    );
+}
+
+/// Product and package archives must reach rustc as native static libraries,
+/// before the runtime rlib. A trailing `-C link-arg=<archive>` makes GNU BFD
+/// scan the runtime first and never revisit it when the package archive adds a
+/// new runtime reference.
+#[cfg(unix)]
+#[test]
+fn passes_link_inputs_before_the_runtime_rlib() {
+    let dir = scratch("link-archive-order");
+    let input = dir.path().join("program.ll");
+    std::fs::write(&input, "define void @__reussir_main() {\n  ret void\n}\n")
+        .expect("write LLVM IR");
+    let runtime = dir.path().join("libreussir_rt.rlib");
+    std::fs::write(&runtime, "").expect("write fake runtime");
+    let deps = dir.path().join("deps");
+    std::fs::create_dir(&deps).expect("create dependency directory");
+    let dependency = deps.join("libdependency.a");
+    std::fs::write(&dependency, "").expect("write fake dependency archive");
+    let rustc = shell_script(
+        dir.path(),
+        "record-link-rustc",
+        "printf '%s\n' \"$@\" > \"$FAKE_RUSTC_LOG\"\n\
+         previous=''\n\
+         for arg in \"$@\"; do\n\
+           if [ \"$previous\" = '-o' ]; then : > \"$arg\"; fi\n\
+           previous=\"$arg\"\n\
+         done\n",
+    );
+    let log = dir.path().join("rustc-args");
+    let output_path = dir.path().join("program");
+    let output = Command::new(env!("CARGO_BIN_EXE_rrc"))
+        .args([
+            input.as_os_str(),
+            "-o".as_ref(),
+            output_path.as_os_str(),
+            "--emit".as_ref(),
+            "executable".as_ref(),
+            "--polyffi-rust-path".as_ref(),
+            rustc.as_os_str(),
+            "--polyffi-libdir".as_ref(),
+            dir.path().as_os_str(),
+            "--link-lib".as_ref(),
+            dependency.as_os_str(),
+        ])
+        .env("FAKE_RUSTC_LOG", &log)
+        .output()
+        .expect("spawn rrc");
+    assert!(
+        output.status.success(),
+        "link driver failed:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let args: Vec<_> = read(&log).lines().map(str::to_owned).collect();
+    let product = args
+        .iter()
+        .position(|arg| {
+            arg.starts_with("static:+whole-archive,+verbatim=") && arg.ends_with("-link-input.a")
+        })
+        .unwrap_or_else(|| panic!("no whole-archived product input: {args:#?}"));
+    let package = args
+        .iter()
+        .position(|arg| arg == "static:+verbatim=libdependency.a")
+        .unwrap_or_else(|| panic!("no native dependency archive: {args:#?}"));
+    let runtime = args
+        .iter()
+        .position(|arg| arg.starts_with("--extern=reussir_rt="))
+        .unwrap_or_else(|| panic!("no runtime rlib: {args:#?}"));
+    assert!(
+        product < package && package < runtime,
+        "expected product, package, runtime order: {args:#?}"
+    );
+    assert!(
+        args.windows(2)
+            .any(|pair| { pair[0] == "-L" && pair[1] == format!("native={}", deps.display()) }),
+        "dependency search path missing: {args:#?}"
+    );
+    assert!(
+        !args
+            .iter()
+            .any(|arg| arg == &format!("-Clink-arg={}", dependency.display())),
+        "dependency archive remained a trailing raw link arg: {args:#?}"
+    );
 }
 
 /// `--scan-deps` describes the package source graph — `lib.rr` plus


### PR DESCRIPTION
## Summary

- archive rrc&#39;s generated product members and pass the archive to rustc as one whole-archived native library
- pass Reussir package archives through rustc&#39;s native-library interface in product -&gt; packages -&gt; runtime order
- use logical `lib.a` names for wasm-ld, which does not support GNU&#39;s exact-file `-l:` form
- keep the direct-path spelling on Apple targets: ld64 implements no `-l:` form at all, and resolves archive members regardless of command-line position, so the ordering constraint does not exist there; `-force_load` carries the product archive&#39;s whole-archive semantics
- add driver regressions for native archive ordering (non-Apple unix), the Apple spelling, and wasm spelling

## Root cause

`-C link-arg=` puts Reussir package archives after Rust dependency rlibs in rustc&#39;s final link line. GNU BFD scans archives once from left to right, so it did not revisit `libreussir_rt.rlib` after `libstd.a` introduced the new `reussir_rt::hash` references. The runtime archive and the rene-baked source were both current; the definitions were present and had the exact crate disambiguator the consumer referenced.

The linear ordering relies on `--link-lib`&#39;s existing dependency-order contract. Cyclic package graphs have no valid linear order under a single-pass linker; rene currently terminates on such cycles rather than rejecting them, so they remain a link-time error.

## Verification

On a clean Linux aarch64 build at `8c88997` with LLVM 22 and the pinned Rust nightly:

- reproduced `rene/std_hash_test.rr` failing under GNU BFD before the change
- confirmed the same exact-artifact probe links when only `-fuse-ld=lld` changes
- `rene/std_hash_test.rr`: PASS after the change
- `rene/wasi_threads.rr`: PASS
- `rrc-test`: 36 tests passed
- full `check`: 457 passed, 32 unsupported, 0 failed
- `ctest --test-dir build --output-on-failure`: 30 passed

The first CI round confirmed the ordering fix on ubuntu-arm (previously red `std_hash_test` now green) and exposed the macOS regression the Apple bullet above fixes: every ld64 link died with `ld: library 'libtest_utils.a' not found`, because `+verbatim` degrades to a plain `-l` there. After the fix, `extern_link.rr`, `rene/build.rr`, and `rene/std_hash_test.rr` pass locally on Linux x86-64 (driver suite 24/24, clippy and fmt clean); the macOS CI job validates the ld64 path.

Windows validation is via CI; the implementation leaves platform linker spelling to rustc, and the generated product archive is whole-archived exactly once.
