### PR TITLE
[core][std] trait associated functions; Hasher::default and from_entropy

### DIFF
--- a/crates/reussir-core/src/semi.rs
+++ b/crates/reussir-core/src/semi.rs
@@ -2572,14 +2572,22 @@ trait A { fn n(self: Self); }",
 
     #[test]
     fn trait_member_rejections() {
+        // A method without a leading `self` is not a rejection anymore: it
+        // is an associated function, receiver-less with every parameter
+        // positional.
         elaborate_source("trait T { fn m(x: i64) -> i64; }", |elab| {
-            assert!(
-                elab.reports.iter().any(|r| r
-                    .message
-                    .contains("a trait method must take `self` as its first parameter")),
-                "{:#?}",
-                elab.reports
-            );
+            assert!(!elab.has_errors(), "{:#?}", elab.reports);
+            let def = (0..elab.defs.len() as u32)
+                .map(crate::semi::ty::DefId)
+                .find(|d| {
+                    elab.defs.info(*d).kind == crate::semi::resolve::DefKind::Trait
+                        && elab.sym(elab.defs.path(*d).name()) == "T"
+                })
+                .expect("trait def");
+            let id = elab.traits.trait_by_def(def).expect("registered");
+            let m = &elab.traits.trait_def(id).methods[0];
+            assert_eq!(m.receiver, None);
+            assert_eq!(m.params.len(), 1);
         });
         elaborate_source(
             "trait T { fn m(self: Self); fn m(self: Self) -> i64; }",
@@ -2658,10 +2666,15 @@ trait A { fn n(self: Self); }",
                     )
                     .expect("registered");
                 let def = elab.traits.trait_def(id);
-                let forms: Vec<ReceiverForm> = def.methods.iter().map(|m| m.receiver).collect();
+                let forms: Vec<Option<ReceiverForm>> =
+                    def.methods.iter().map(|m| m.receiver).collect();
                 assert_eq!(
                     forms,
-                    [ReceiverForm::Value, ReceiverForm::Arc, ReceiverForm::Flex]
+                    [
+                        Some(ReceiverForm::Value),
+                        Some(ReceiverForm::Arc),
+                        Some(ReceiverForm::Flex)
+                    ]
                 );
                 assert!(def.methods[2].is_regional);
             },

--- a/crates/reussir-core/src/semi/check.rs
+++ b/crates/reussir-core/src/semi/check.rs
@@ -1820,9 +1820,20 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 );
                 return Some(self.poison(span));
             };
-            // The receiver's own type drives dispatch (it may be `Arc<Self>`
-            // or `[flex] Self`); the prefix only selected the candidate.
+            // The prefix constrains the receiver: unify them — up to the arc
+            // peel, and carrying the receiver's own flexivity refinement —
+            // so `Box::get(p)` on a `Pair` errors rather than silently
+            // dispatching on `Pair`'s impl after selecting by `Box`.
             let receiver = self.infer_expr(recv_src);
+            let resolved = self.infer.shallow_resolve(receiver.ty);
+            let peeled = self.peel_arc(resolved);
+            let expected = match (self_ty.kind(), peeled.kind()) {
+                (TyKind::Record { def, args, .. }, TyKind::Record { flex, .. }) => {
+                    self.tcx.mk_record(*def, args, *flex)
+                }
+                _ => self_ty,
+            };
+            self.expect(peeled, expected, span);
             return Some(self.dispatch_trait_method(tid, midx, receiver, &fc.args[1..], span));
         }
         Some(self.assoc_trait_call(tid, midx, self_ty, &fc.args, span))

--- a/crates/reussir-core/src/semi/check.rs
+++ b/crates/reussir-core/src/semi/check.rs
@@ -776,6 +776,13 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             {
                 return done;
             }
+            // `Type::f(…)` / `G::f(…)` — the prefix names a type whose
+            // traits (impls or bounds) declare `f`.
+            if !fc.name.segments.is_empty()
+                && let Some(done) = self.try_type_assoc_call(fc, span)
+            {
+                return done;
+            }
             let hint = if fc.name.segments.is_empty() {
                 self.function_suggestion(fc.name.basename)
             } else {
@@ -1207,6 +1214,21 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         args: &[surface::Expr],
         span: Option<Span>,
     ) -> Expr<'tcx> {
+        // An associated function has no receiver slot: dot dispatch (and the
+        // UFCS spelling that feeds a receiver here) cannot reach it.
+        if self.traits.trait_def(tid).methods[midx].receiver.is_none() {
+            let mname = self.traits.trait_def(tid).methods[midx].name;
+            let shown = self.trait_display(tid);
+            let m = self.sym(mname);
+            self.error(
+                span,
+                format!(
+                    "`{m}` is an associated function of `{shown}` (no receiver); \
+                     call it as `{shown}::{m}(…)` or `Type::{m}(…)`"
+                ),
+            );
+            return self.poison(span);
+        }
         let raw = self.infer.resolve(receiver.ty);
         let peeled = self.peel_arc(raw);
         if let TyKind::Generic(_) = peeled.kind() {
@@ -1635,6 +1657,15 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             );
             return Some(self.poison(span));
         }
+        // An associated function: no receiver argument, and `Self` comes
+        // from context — a fresh hole that unification solves (the result
+        // type mentions `Self` in every interesting case, e.g. `default()
+        // -> Self`), left generic in a bounded function, ground otherwise.
+        if self.traits.trait_def(tid).methods[midx].receiver.is_none() {
+            self.record_use(fc.name.basename);
+            let self_ty = self.infer.new_hole_ty();
+            return Some(self.assoc_trait_call(tid, midx, self_ty, &fc.args, span));
+        }
         let Some(recv_src) = fc.args.first() else {
             let shown = self.trait_display(tid);
             self.error(
@@ -1646,6 +1677,155 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         self.record_use(fc.name.basename);
         let receiver = self.infer_expr(recv_src);
         Some(self.dispatch_trait_method(tid, midx, receiver, &fc.args[1..], span))
+    }
+
+    /// An associated-function call with `Self = self_ty`: every argument is
+    /// positional, and the call is always the serializable deferred
+    /// [`ExprKind::TraitCall`] — a generic `Self` resolves per instance at
+    /// monomorphization, and a ground (or ground-by-unification) `Self`
+    /// resolves there identically, so one form covers both.
+    fn assoc_trait_call(
+        &mut self,
+        tid: TraitId,
+        midx: usize,
+        self_ty: Ty<'tcx>,
+        args: &[surface::Expr],
+        span: Option<Span>,
+    ) -> Expr<'tcx> {
+        let tdef = self.traits.trait_def(tid);
+        if !tdef.params.is_empty() {
+            let shown = self.trait_display(tid);
+            self.error(
+                span,
+                format!(
+                    "cannot call an associated function of multi-parameter \
+                     trait `{shown}` without a concrete trait reference"
+                ),
+            );
+            return self.poison(span);
+        }
+        let trait_def_id = tdef.def;
+        let self_param = tdef.self_param;
+        let sig = tdef.methods[midx].clone();
+        debug_assert!(sig.receiver.is_none(), "assoc_trait_call needs no receiver");
+        if sig.is_regional && !self.inside_region {
+            self.error(span, "cannot call a regional function outside of a region");
+        }
+        let mut inst = self.instantiate(&sig.generics, &[], span);
+        inst.insert(self_param, self_ty);
+        if args.len() != sig.params.len() {
+            self.error(
+                span,
+                format!(
+                    "associated function `{}` expects {} argument(s), got {}",
+                    self.sym(sig.name),
+                    sig.params.len(),
+                    args.len()
+                ),
+            );
+        }
+        let out: Vec<Expr<'tcx>> = args
+            .iter()
+            .zip(&sig.params)
+            .map(|(arg, &pty)| {
+                let expected = self.infer.instantiate_ty(pty, &inst);
+                self.check_expr(arg, expected)
+            })
+            .collect();
+        let ty_args: Vec<Ty<'tcx>> = std::iter::once(self_ty)
+            .chain(self.inst_args(&sig.generics, &inst))
+            .collect();
+        let result = self.infer.instantiate_ty(sig.ret, &inst);
+        // The bound obligation is what turns an unimplemented `Self` into a
+        // real diagnostic (and constrains a hole `Self` like any bound).
+        self.register_bound(tid, self_ty, span);
+        self.mk_expr(
+            ExprKind::TraitCall {
+                trait_def: trait_def_id,
+                method: midx as u32,
+                ty_args,
+                args: out,
+            },
+            result,
+            span,
+        )
+    }
+
+    /// The `Type::f(…)` / `G::f(…)` spellings: the path prefix names a type
+    /// — a generic parameter in scope or a record — and `f` resolves among
+    /// the traits that type implements (or that bound it). An associated
+    /// function calls with `Self` fixed to the named type; a method with a
+    /// receiver dispatches UFCS style, its first argument the receiver.
+    /// `None` when the prefix names no type — the caller keeps its
+    /// unknown-function diagnostic.
+    fn try_type_assoc_call(
+        &mut self,
+        fc: &surface::FuncCall,
+        span: Option<Span>,
+    ) -> Option<Expr<'tcx>> {
+        let (tname, prefix) = fc.name.segments.split_last()?;
+        let self_ty = if prefix.is_empty()
+            && let Some(&g) = self.generic_names.get(tname)
+        {
+            self.tcx.mk_generic(g)
+        } else {
+            let tpath = surface::Path {
+                basename: *tname,
+                segments: prefix.iter().copied().collect(),
+            };
+            let def = self.resolve_record_ref(&tpath)?;
+            // A generic record's arguments are holes for unification to
+            // solve; the common associated-function shapes mention them in
+            // the parameters or the result.
+            let rec = &self.records[&def];
+            let default_cap = rec.default_cap;
+            let n = rec.ty_params.len();
+            let args: Vec<Ty<'tcx>> = (0..n).map(|_| self.infer.new_hole_ty()).collect();
+            let flex = match default_cap {
+                crate::semi::ctxt::DefaultCap::Value | crate::semi::ctxt::DefaultCap::Shared => {
+                    Flexivity::Irrelevant
+                }
+                crate::semi::ctxt::DefaultCap::Regional => Flexivity::Rigid,
+            };
+            self.tcx.mk_record(def, &args, flex)
+        };
+        let name = fc.name.basename;
+        let cands = match self_ty.kind() {
+            TyKind::Generic(g) => self.generic_trait_candidates(*g, name),
+            _ => self.ground_trait_candidates(self_ty, name),
+        };
+        let (tid, midx) = match cands[..] {
+            [] => return None,
+            [one] => one,
+            [(a, _), (b, _), ..] => {
+                self.ambiguous_method_error(name, self_ty, a, b, span);
+                return Some(self.poison(span));
+            }
+        };
+        if !fc.ty_args.is_empty() {
+            self.error(
+                span,
+                "type arguments on a trait-method call are not supported yet",
+            );
+            return Some(self.poison(span));
+        }
+        self.record_use(name);
+        if self.traits.trait_def(tid).methods[midx].receiver.is_some() {
+            // UFCS: `Type::method(recv, args…)`.
+            let Some(recv_src) = fc.args.first() else {
+                let m = self.sym(name);
+                self.error(
+                    span,
+                    format!("`{m}` takes its receiver as the first argument"),
+                );
+                return Some(self.poison(span));
+            };
+            // The receiver's own type drives dispatch (it may be `Arc<Self>`
+            // or `[flex] Self`); the prefix only selected the candidate.
+            let receiver = self.infer_expr(recv_src);
+            return Some(self.dispatch_trait_method(tid, midx, receiver, &fc.args[1..], span));
+        }
+        Some(self.assoc_trait_call(tid, midx, self_ty, &fc.args, span))
     }
 
     /// (APP) `Γ ⊢ callee(args) ⇒ (ClosureCall{hc,[hᵢ]} : R)`: synthesize the callee to

--- a/crates/reussir-core/src/semi/ctxt.rs
+++ b/crates/reussir-core/src/semi/ctxt.rs
@@ -2971,27 +2971,33 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             return;
         }
         // Receiver: form parity, not type equality (flexivity refinement and
-        // the arc peel make the spellings differ structurally).
-        let impl_form = {
-            let (_, pty) = &proto.params[0];
-            match pty.kind() {
-                TyKind::Arc(_) => ReceiverForm::Arc,
-                _ if self.is_flex(*pty) => ReceiverForm::Flex,
-                _ => ReceiverForm::Value,
-            }
-        };
-        if impl_form != sig.receiver {
-            let want = match sig.receiver {
-                ReceiverForm::Value => "self: Self",
-                ReceiverForm::Arc => "self: Arc<Self>",
-                ReceiverForm::Flex => "self: [flex] Self",
+        // the arc peel make the spellings differ structurally). An associated
+        // function (no receiver in the trait) has no slot to compare — every
+        // parameter is positional, and a stray `self`-typed first parameter
+        // would already fail the positional type check below.
+        if let Some(sig_form) = sig.receiver {
+            let impl_form = {
+                let (_, pty) = &proto.params[0];
+                match pty.kind() {
+                    TyKind::Arc(_) => ReceiverForm::Arc,
+                    _ if self.is_flex(*pty) => ReceiverForm::Flex,
+                    _ => ReceiverForm::Value,
+                }
             };
-            self.error(
-                span,
-                format!("the receiver of `{name}` must be `{want}` to match trait `{tr}`"),
-            );
+            if impl_form != sig_form {
+                let want = match sig_form {
+                    ReceiverForm::Value => "self: Self",
+                    ReceiverForm::Arc => "self: Arc<Self>",
+                    ReceiverForm::Flex => "self: [flex] Self",
+                };
+                self.error(
+                    span,
+                    format!("the receiver of `{name}` must be `{want}` to match trait `{tr}`"),
+                );
+            }
         }
-        for (i, ((_, ity), &sty)) in proto.params.iter().zip(&sig.params).enumerate().skip(1) {
+        let skip = sig.receiver.is_some() as usize;
+        for (i, ((_, ity), &sty)) in proto.params.iter().zip(&sig.params).enumerate().skip(skip) {
             let want = crate::semi::traits::subst::replace_generics(self.tcx, sty, &map);
             if *ity != want {
                 self.error(
@@ -3495,14 +3501,10 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         self.generic_names.clear();
         self.self_alias = None;
 
-        let Some(receiver) = receiver else {
-            self.error(
-                mspan,
-                "a trait method must take `self` as its first parameter",
-            );
-            return None;
-        };
-        if receiver == ReceiverForm::Flex && !func.is_regional {
+        // No leading `self` parameter is an *associated function*: every
+        // parameter is ordinary, and the call forms are `Trait::f(…)`,
+        // `Type::f(…)`, and `G::f(…)` rather than dot dispatch.
+        if receiver == Some(ReceiverForm::Flex) && !func.is_regional {
             self.error(
                 mspan,
                 "a `[flex] Self` receiver requires a `regional fn`: a flex \

--- a/crates/reussir-core/src/semi/hir.rs
+++ b/crates/reussir-core/src/semi/hir.rs
@@ -318,7 +318,8 @@ pub struct TraitMethodText<'tcx> {
     pub regional: bool,
     pub name: String,
     pub generics: Vec<(GenericId, Option<String>)>,
-    pub receiver: crate::semi::traits::def::ReceiverForm,
+    /// `None` is an associated function (no receiver).
+    pub receiver: Option<crate::semi::traits::def::ReceiverForm>,
     pub params: Vec<Ty<'tcx>>,
     pub ret: Ty<'tcx>,
     pub span: Option<Span>,

--- a/crates/reussir-core/src/semi/hir/build.rs
+++ b/crates/reussir-core/src/semi/hir/build.rs
@@ -694,9 +694,10 @@ impl<'tcx> Builder<'_, 'tcx> {
                     name: m.name.clone(),
                     generics: self.text_generics(&m.generics),
                     receiver: match m.receiver {
-                        raw::RecvForm::Value => ReceiverForm::Value,
-                        raw::RecvForm::Arc => ReceiverForm::Arc,
-                        raw::RecvForm::Flex => ReceiverForm::Flex,
+                        raw::RecvForm::Value => Some(ReceiverForm::Value),
+                        raw::RecvForm::Arc => Some(ReceiverForm::Arc),
+                        raw::RecvForm::Flex => Some(ReceiverForm::Flex),
+                        raw::RecvForm::None => None,
                     },
                     params: self.tys(&m.params),
                     ret: self.ty(&m.ret),

--- a/crates/reussir-core/src/semi/hir/grammar.lalrpop
+++ b/crates/reussir-core/src/semi/hir/grammar.lalrpop
@@ -213,6 +213,9 @@ TraitMethodSig: raw::TraitMethodItem =
 RecvForm: raw::RecvForm = {
     "Arc" => raw::RecvForm::Arc,
     "flex" => raw::RecvForm::Flex,
+    // An associated function: no receiver at all (`fn f !(…)`), as opposed
+    // to the unmarked by-value `self`.
+    "!" => raw::RecvForm::None,
 };
 
 /// An impl item: the trait reference carries its full argument list

--- a/crates/reussir-core/src/semi/hir/print.rs
+++ b/crates/reussir-core/src/semi/hir/print.rs
@@ -373,9 +373,11 @@ impl<'a> Printer<'a> {
             .map(|m| {
                 let regional = if m.regional { "regional " } else { "" };
                 let recv = match m.receiver {
-                    crate::semi::traits::def::ReceiverForm::Value => "",
-                    crate::semi::traits::def::ReceiverForm::Arc => " Arc",
-                    crate::semi::traits::def::ReceiverForm::Flex => " flex",
+                    Some(crate::semi::traits::def::ReceiverForm::Value) => "",
+                    Some(crate::semi::traits::def::ReceiverForm::Arc) => " Arc",
+                    Some(crate::semi::traits::def::ReceiverForm::Flex) => " flex",
+                    // An associated function: no receiver, tagged `!`.
+                    None => " !",
                 };
                 let params: Vec<Doc<'static>> = m.params.iter().map(|p| self.ty(*p)).collect();
                 text(format!("{regional}fn {}", m.name))

--- a/crates/reussir-core/src/semi/hir/raw.rs
+++ b/crates/reussir-core/src/semi/hir/raw.rs
@@ -61,12 +61,14 @@ pub struct TraitMethodItem {
     pub span: Option<Span>,
 }
 
-/// The serialized receiver form tag; `Value` is the unmarked default.
+/// The serialized receiver form tag; `Value` is the unmarked default, and
+/// `None` (spelled `!`) is an associated function without a receiver.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum RecvForm {
     Value,
     Arc,
     Flex,
+    None,
 }
 
 /// An impl item: trait path + full argument list (`args[0]` = self type)

--- a/crates/reussir-core/src/semi/traits/def.rs
+++ b/crates/reussir-core/src/semi/traits/def.rs
@@ -24,18 +24,30 @@ pub enum ReceiverForm {
 }
 
 /// A method declared by a trait. Bodies live on the impl side (Phase 1+).
-/// Parameters are positional (`params[0]` is the receiver): conformance is
-/// positional and no bodies exist, so names would serialize dead weight.
+/// Parameters are positional (`params[0]` is the receiver when one exists):
+/// conformance is positional and no bodies exist, so names would serialize
+/// dead weight.
 #[derive(Clone, Debug)]
 pub struct MethodSig<'tcx> {
     pub name: TokenKey,
     /// The method's own generics, following the trait's in the binder.
     pub generics: Vec<(TokenKey, GenericId)>,
-    pub receiver: ReceiverForm,
+    /// `None` is an associated function: no receiver, every parameter
+    /// ordinary, called as `Trait::f(…)` / `Type::f(…)` rather than by dot
+    /// dispatch.
+    pub receiver: Option<ReceiverForm>,
     pub params: Vec<Ty<'tcx>>,
     pub ret: Ty<'tcx>,
     pub is_regional: bool,
     pub span: Option<Span>,
+}
+
+impl<'tcx> MethodSig<'tcx> {
+    /// The non-receiver parameters: everything after the receiver slot, or
+    /// all of them for an associated function.
+    pub fn value_params(&self) -> &[Ty<'tcx>] {
+        &self.params[self.receiver.is_some() as usize..]
+    }
 }
 
 /// An associated type declaration. Reserved so the IR can grow into projections

--- a/library/std/src/hash.rr
+++ b/library/std/src/hash.rr
@@ -86,6 +86,16 @@ pub trait Hasher {
     fn write<T: Hash>(self: Self, value: T) -> Self;
     /// The digest of everything written so far.
     fn finish(self: Self) -> u64;
+    /// A fresh hasher under the implementation's default seed. An
+    /// associated function: generic containers construct their hasher
+    /// through it (`H::default()`), the stand-in for a builder trait until
+    /// associated types exist.
+    fn default() -> Self;
+    /// A fresh hasher seeded from caller-supplied entropy. What
+    /// distinguishes it from a fixed seed is the caller's contract: pass
+    /// something an adversary cannot predict (its dispersion is the
+    /// implementation's problem), and equal entropy yields equal digests.
+    fn from_entropy(entropy: u64) -> Self;
 }
 
 /// A type that can feed itself to any `Hasher`.
@@ -154,6 +164,8 @@ impl Hasher for FastHasher {
     }
     fn write<T: Hash>(self: Self, value: T) -> Self { value.hash(self) }
     fn finish(self: Self) -> u64 { fast_finish(self) }
+    fn default() -> Self { fast_new() }
+    fn from_entropy(entropy: u64) -> Self { fast_with_seed(entropy) }
 }
 
 /// Creates a `FastHasher` with rapidhash's default seed.
@@ -218,6 +230,8 @@ impl Hasher for StrongHasher {
     }
     fn write<T: Hash>(self: Self, value: T) -> Self { value.hash(self) }
     fn finish(self: Self) -> u64 { strong_finish(self) }
+    fn default() -> Self { strong_new() }
+    fn from_entropy(entropy: u64) -> Self { strong_with_seed(entropy) }
 }
 
 /// Creates a `StrongHasher` with rapidhash's default seed.

--- a/tests/integration/frontend/trait_assoc_fn.rr
+++ b/tests/integration/frontend/trait_assoc_fn.rr
@@ -1,0 +1,72 @@
+// Trait associated functions: a trait method without a `self` receiver,
+// implemented per type and callable three ways — `Trait::f(…)` with `Self`
+// solved from context, `Type::f(…)` with `Self` named by the path prefix,
+// and `G::f(…)` on a generic bounded by the trait. The textual HIR tags a
+// receiver-less method `!` and round-trips.
+
+// RUN: %rrc %s --emit hir --no-source-locations -o %t.hir
+// RUN: %FileCheck %s --check-prefix=HIR < %t.hir
+// RUN: %rrc %t.hir --emit mir --no-source-locations -o -
+// RUN: %rrc %s --emit mir --no-source-locations -o %t.mir
+// RUN: %rrc %t.mir --emit llvm-ir -Onone -o %t.ll
+// RUN: %FileCheck %s --check-prefix=LLVM < %t.ll
+
+// HIR: trait #Maker
+// HIR-DAG: fn make ! () -> $0
+// HIR-DAG: fn make_with ! (i64) -> $0
+// HIR-DAG: fn get ($0) -> i64
+pub trait Maker {
+    fn make() -> Self;
+    fn make_with(seed: i64) -> Self;
+    fn get(self: Self) -> i64;
+}
+
+pub struct Box { value: i64 }
+pub struct Pair { a: i64, b: i64 }
+
+impl Maker for Box {
+    fn make() -> Self { Box { value: 7 } }
+    fn make_with(seed: i64) -> Self { Box { value: seed } }
+    fn get(self: Self) -> i64 { self.value }
+}
+
+impl Maker for Pair {
+    fn make() -> Self { Pair { a: 1, b: 2 } }
+    fn make_with(seed: i64) -> Self { Pair { a: seed, b: seed } }
+    fn get(self: Self) -> i64 { self.a + self.b }
+}
+
+// `G::f()`: deferred to monomorphization, one instance per ground `Self`.
+fn fresh<M: Maker>() -> M { M::make() }
+fn seeded<M: Maker>(seed: i64) -> M { M::make_with(seed) }
+
+// `Trait::f()`: `Self` solved by the annotated binding.
+pub fn via_trait() -> i64 {
+    let b : Box = Maker::make();
+    b.get()
+}
+
+// `Type::f(…)`: `Self` named by the prefix; the result chains like any call.
+pub fn via_type() -> i64 {
+    Box::make_with(35).get() + Pair::make().get()
+}
+
+pub fn via_generic() -> i64 {
+    let b : Box = fresh();
+    let p : Pair = seeded(4);
+    b.get() + p.get()
+}
+
+// UFCS through the type prefix still reaches receiver-carrying methods.
+pub fn ufcs(b : Box) -> i64 {
+    Box::get(b)
+}
+
+// 7 + (35 + 3) + (7 + 8) + 7 = 67, fully folded at -Onone? No — but each
+// instance must exist; the LLVM check pins the three mangled instances.
+// LLVM-DAG: @_RNvNvC5Maker3Box4make
+// LLVM-DAG: @_RNvNvC5Maker4Pair4make
+// LLVM-DAG: @_RNvNvC5Maker3Box9make_with
+pub fn total(b : Box) -> i64 {
+    via_trait() + via_type() + via_generic() + ufcs(b)
+}

--- a/tests/integration/frontend/trait_assoc_fn_errors.rr
+++ b/tests/integration/frontend/trait_assoc_fn_errors.rr
@@ -25,6 +25,16 @@ pub fn unsolved() -> i64 {
     0
 }
 
+// The UFCS prefix constrains the receiver: selecting by one type and
+// dispatching on another is an error, not a silent re-selection.
+pub struct Duo { a: i64 }
+impl Maker for Duo {
+    fn make() -> Self { Duo { a: 1 } }
+    fn get(self: Self) -> i64 { self.a }
+}
+// CHECK-DAG: type mismatch: expected `Box`, found `Duo`
+pub fn wrong_prefix(d : Duo) -> i64 { Box::get(d) }
+
 // The implementation must actually provide the receiver-less form: an impl
 // method with a receiver against a receiver-less trait signature is a
 // parameter-count mismatch.

--- a/tests/integration/frontend/trait_assoc_fn_errors.rr
+++ b/tests/integration/frontend/trait_assoc_fn_errors.rr
@@ -1,0 +1,37 @@
+// RUN: %not %rrc %s --emit hir -o - 2>&1 | %FileCheck %s
+
+pub trait Maker {
+    fn make() -> Self;
+    fn get(self: Self) -> i64;
+}
+
+pub struct Box { value: i64 }
+
+impl Maker for Box {
+    fn make() -> Self { Box { value: 7 } }
+    fn get(self: Self) -> i64 { self.value }
+}
+
+pub struct Plain { x: i64 }
+
+// An associated function has no receiver, so dot dispatch cannot reach it.
+// CHECK-DAG: `make` is an associated function of `Maker` (no receiver); call it as `Maker::make
+pub fn dotted(b : Box) -> Box { b.make() }
+
+// `Self` must be constrained by context.
+// CHECK-DAG: type annotations needed
+pub fn unsolved() -> i64 {
+    let x = Maker::make();
+    0
+}
+
+// The implementation must actually provide the receiver-less form: an impl
+// method with a receiver against a receiver-less trait signature is a
+// parameter-count mismatch.
+pub trait Zero {
+    fn zero() -> Self;
+}
+// CHECK-DAG: method `zero` takes 1 parameter(s); trait `Zero` requires 0
+impl Zero for Plain {
+    fn zero(self: Self) -> Self { self }
+}

--- a/tests/integration/rene/std_hash_test.rr
+++ b/tests/integration/rene/std_hash_test.rr
@@ -40,3 +40,11 @@
 // PROPS-NEXT: 1
 // PROPS-NEXT: 1
 // PROPS-NEXT: 1
+// the associated constructors (default/from_entropy) agree with
+// the free ones, through a generic consumer and type prefixes
+// PROPS-NEXT: 1
+// PROPS-NEXT: 1
+// PROPS-NEXT: 1
+// PROPS-NEXT: 1
+// PROPS-NEXT: 1
+// PROPS-NEXT: 1

--- a/tests/integration/rene/std_hash_test/src/lib.rr
+++ b/tests/integration/rene/std_hash_test/src/lib.rr
@@ -97,6 +97,27 @@ fn test_properties() {
     let branch = base.write_u64(2).finish();
     wb(base.finish() == std::hash::fast_hasher().write_u64(1).finish());
     wb(branch != base.finish());
+    // The associated constructors: a generic consumer builds its hasher
+    // through the trait — the hash-container pattern — and the type-
+    // prefixed forms agree with the free constructors.
+    wb(digest_of<FastHasher, Point>(Point { x: 3, y: 4 }) ==
+        std::hash::fast_hash(Point { x: 3, y: 4 }));
+    wb(digest_of<StrongHasher, Point>(Point { x: 3, y: 4 }) ==
+        std::hash::strong_hash(Point { x: 3, y: 4 }));
+    wb(FastHasher::from_entropy(99).write_u64(5).finish() ==
+        std::hash::fast_hasher_seeded(99).write_u64(5).finish());
+    wb(StrongHasher::from_entropy(99).write_u64(5).finish() ==
+        std::hash::strong_hasher_seeded(99).write_u64(5).finish());
+    wb(FastHasher::from_entropy(99).write_u64(5).finish() !=
+        FastHasher::default().write_u64(5).finish());
+    let via_trait : FastHasher = Hasher::default();
+    wb(via_trait.write_u64(1234).finish() == std::hash::fast_hash_u64(1234));
+}
+
+// The hash-container construction pattern: the hasher type is a bound,
+// and the consumer builds it with `H::default()`.
+fn digest_of<H : Hasher, T : Hash>(value : T) -> u64 {
+    value.hash(H::default()).finish()
 }
 
 #[main]

--- a/tests/integration/repl-rs/trait_assoc_fn.repl
+++ b/tests/integration/repl-rs/trait_assoc_fn.repl
@@ -1,0 +1,66 @@
+// REQUIRES: rrepl
+// RUN: %rrepl -i %s -lerror -Onone | %FileCheck %s
+// RUN: %rrepl -i %s -lerror | %FileCheck %s
+
+:{
+pub trait Maker {
+    fn make() -> Self;
+    fn make_with(seed: i64) -> Self;
+    fn get(self: Self) -> i64;
+}
+}:
+// CHECK: Definition added.
+
+:{
+pub struct Box { value: i64 }
+}:
+// CHECK: Definition added.
+
+:{
+impl Maker for Box {
+    fn make() -> Self { Box { value: 7 } }
+    fn make_with(seed: i64) -> Self { Box { value: seed } }
+    fn get(self: Self) -> i64 { self.value }
+}
+}:
+// CHECK: Definition added.
+
+// `Type::f(…)`: `Self` named by the path prefix.
+Box::make().get()
+// CHECK: 7 : i64
+
+Box::make_with(41).get()
+// CHECK: 41 : i64
+
+// `Trait::f()`: `Self` solved from the annotated binding.
+:{
+fn trait_form() -> i64 {
+    let b : Box = Maker::make();
+    b.get()
+}
+}:
+// CHECK: Definition added.
+
+trait_form()
+// CHECK: 7 : i64
+
+// `G::f()`: per-instance resolution at monomorphization.
+:{
+fn fresh<M: Maker>(seed: i64) -> M { M::make_with(seed) }
+}:
+// CHECK: Definition added.
+
+:{
+fn generic_form() -> i64 {
+    let b : Box = fresh(11);
+    b.get()
+}
+}:
+// CHECK: Definition added.
+
+generic_form()
+// CHECK: 11 : i64
+
+// UFCS through the type prefix reaches ordinary methods too.
+Box::get(Box::make_with(5))
+// CHECK: 5 : i64


### PR DESCRIPTION
Second of the three PRs toward the hash map: a trait method without a leading `self` is now an **associated function** — no receiver, every parameter positional — with the three call forms the container work needs.

## Call forms

- **`Trait::f(…)`** — `Self` comes from context: a fresh inference hole that unification solves. The interesting signatures mention `Self` in the result (`default() -> Self`), so `let h : FastHasher = Hasher::default();` pins it; an unconstrained `Self` reports `type annotations needed`, not an ICE.
- **`Type::f(…)`** — `Self` fixed by the path prefix: a record (its generics instantiated as holes for unification) or a generic parameter in scope, with `f` resolved among the traits that type implements. The same spelling doubles as **UFCS** for ordinary methods — `Box::get(b)` — with the first argument as the receiver.
- **`G::f(…)`** — on a generic bounded by the trait, deferred to monomorphization exactly like dot dispatch on a generic receiver.

Dot dispatch cannot reach an associated function; `b.make()` redirects: ```make` is an associated function of `Maker` (no receiver); call it as `Maker::make(…)` or `Type::make(…)```.

## One dispatch mechanism, not two

Every associated call lowers to the existing serializable `TraitCall` form. Mono&#39;s resolver already selects the impl by ground `Self` and never looked at receivers — so a `Self` that was written (`Box::make`), inferred (`Maker::make` + annotation), or instantiated (`M::make`) all resolve through the same judgment, and the check-time work is only candidate selection plus the registered bound obligation that turns an unimplemented `Self` into a real diagnostic.

## Representation

`MethodSig.receiver` becomes `Option<ReceiverForm>` (`None` = associated). Conformance skips the receiver-form check for receiver-less signatures and checks parameter types from position zero — an impl that sneaks a `self` in fails the parameter-count comparison with a plain message (pinned in the error test). The textual HIR tags the receiver-less form `!`:

```
trait #Maker {
    fn make ! () -> $0;
    fn get ($0) -> i64;
}
```

— the unmarked spelling stays by-value `self`, and the form round-trips through re-entry (exercised in the lit test).

## `Hasher::default` / `Hasher::from_entropy`

The intended use, per the series plan: `fn default() -> Self` and `fn from_entropy(entropy: u64) -> Self` on `std::hash::Hasher`, implemented for both hashers over the existing FFI constructors. This is the builder-trait stand-in until associated types exist — a generic container constructs its hasher as `H::default()`:

```rust
fn digest_of<H : Hasher, T : Hash>(value : T) -> u64 {
    value.hash(H::default()).finish()
}
```

`from_entropy` takes caller-supplied entropy (the caller&#39;s contract is to pass something unpredictable); equal entropy yields equal digests, and the package test pins both hashers&#39; `from_entropy(99)` against `*_hasher_seeded(99)`.

## Tests

- `frontend/trait_assoc_fn.rr`: all three call forms, two impls with per-instance mono symbols pinned in LLVM, UFCS, and the HIR `!` round-trip through re-entry.
- `frontend/trait_assoc_fn_errors.rr`: dot-call redirect, unconstrained `Self`, and an impl whose method wrongly takes a receiver.
- `repl-rs/trait_assoc_fn.repl`: the forms evaluated incrementally.
- `rene/std_hash_test`: extended with `digest_of<H, T>` (the container pattern) and the default/from_entropy equivalences, six new pinned properties.

Full lit suite locally: 486/494 (7 unsupported; the 1 failure is the pre-existing `cells_sync_parallel` libomp startup leak, unrelated — see #545&#39;s notes). 462 core unit tests, clippy, and fmt clean. One unit test updated: `trait_member_rejections` asserted the old &quot;must take `self`&quot; rejection, which is precisely what this PR removes — it now asserts the recorded receiver-less signature.

Stacked series: #545 (bitwise ops) → this → rc-element array plumbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JrRGzJEYiq9fnXA6r76VaS

---
_Generated by [Claude Code](https://claude.ai/code/session_01JrRGzJEYiq9fnXA6r76VaS)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/546"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788732718&installation_model_id=426051&pr_number=546&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F546&signature=9a36e72ac3c438513709823803361e36c3e02f5872031a487b87f9e69203fb1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->