### PR TITLE
[transform] make token reuse ordering deterministic

### DIFF
--- a/lib/Transformation/TokenReuse/TokenReuse.cpp
+++ b/lib/Transformation/TokenReuse/TokenReuse.cpp
@@ -25,6 +25,7 @@
 #include <bit>
 #include <cstddef>
 #include <functional>
+#include <tuple>
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #include <immer/set.hpp>
@@ -204,14 +205,38 @@ ValueSet intersect(const ValueSet &lhs, const ValueSet &rhs) {
   return res;
 }
 
-unsigned
-getDfsOrder(const mlir::DenseMap<mlir::Operation *, unsigned> &dfsOrder,
-            mlir::Value token) {
-  if (auto *defOp = token.getDefiningOp())
-    return dfsOrder.lookup(defOp);
+// A total order over token values. The DFS number alone is not one: the
+// sibling results of a widened expanded-decrement `scf.if` share a defining
+// op and therefore a DFS number, so an equal-score comparison keyed on DFS
+// alone stays tied and the winner falls through to `availableTokens`'s
+// iteration order — a pointer-hash order that varies with ASLR, making the
+// chosen donor (and the emitted IR) differ between runs on the same input.
+// Extending the key with the result/argument number breaks every such tie
+// deterministically; the leading DFS component is unchanged, so the
+// heuristic's "prefer the most recent producer" behavior is preserved.
+std::tuple<unsigned, unsigned, unsigned>
+tokenOrderKey(const mlir::DenseMap<mlir::Operation *, unsigned> &dfsOrder,
+              mlir::Value token) {
+  if (auto result = mlir::dyn_cast<mlir::OpResult>(token))
+    return {dfsOrder.lookup(result.getOwner()), 0, result.getResultNumber()};
   if (auto blockArg = mlir::dyn_cast<mlir::BlockArgument>(token))
-    return dfsOrder.lookup(blockArg.getOwner()->getParentOp());
-  return 0;
+    return {dfsOrder.lookup(blockArg.getOwner()->getParentOp()), 1,
+            blockArg.getArgNumber()};
+  return {0, 2, 0};
+}
+
+// Materialize a pending-token set before any order-sensitive action. Besides
+// donor selection, frees recorded at calls, branch exits, and region exits
+// become operations in this order; iterating the pointer-hashed set directly
+// would make otherwise identical compilations emit different IR.
+llvm::SmallVector<mlir::Value> tokensInStableOrder(
+    const ValueSet &tokens,
+    const mlir::DenseMap<mlir::Operation *, unsigned> &dfsOrder) {
+  llvm::SmallVector<mlir::Value> ordered(tokens.begin(), tokens.end());
+  llvm::sort(ordered, [&](mlir::Value lhs, mlir::Value rhs) {
+    return tokenOrderKey(dfsOrder, lhs) < tokenOrderKey(dfsOrder, rhs);
+  });
+  return ordered;
 }
 
 // A call sits in tail position when nothing observable runs after it on any
@@ -402,7 +427,8 @@ struct TokenReusePass : public impl::ReussirTokenReusePassBase<TokenReusePass> {
         // skip intrinsic calls
         if (!funcCall ||
             !funcCall.getCallee().starts_with("core::intrinsic::")) {
-          for (auto token : availableTokens)
+          for (mlir::Value token :
+               tokensInStableOrder(availableTokens, dfsOrder))
             frees.push_back({token, &op});
           availableTokens = {};
           for (auto &nestedRegion : op.getRegions())
@@ -426,7 +452,8 @@ struct TokenReusePass : public impl::ReussirTokenReusePassBase<TokenReusePass> {
             intersection = intersect(intersection, branchResults[i]);
 
           for (size_t i = 0; i < branchResults.size(); ++i) {
-            for (auto val : branchResults[i]) {
+            for (mlir::Value val :
+                 tokensInStableOrder(branchResults[i], dfsOrder)) {
               if (!intersection.count(val)) {
                 mlir::Block &block = op.getRegion(i).front();
                 frees.push_back({val, block.getTerminator()});
@@ -476,8 +503,8 @@ struct TokenReusePass : public impl::ReussirTokenReusePassBase<TokenReusePass> {
                                     acceptor, aliasAnalyzer);
               if (score >= 0 && (score > bestScore ||
                                  (score == bestScore && bestToken &&
-                                  getDfsOrder(dfsOrder, tokenVal) >
-                                      getDfsOrder(dfsOrder, bestToken)))) {
+                                  tokenOrderKey(dfsOrder, tokenVal) >
+                                      tokenOrderKey(dfsOrder, bestToken)))) {
                 bestScore = score;
                 bestToken = tokenVal;
                 bestRealloc = (score < kReallocEnsureCutoff);
@@ -500,8 +527,8 @@ struct TokenReusePass : public impl::ReussirTokenReusePassBase<TokenReusePass> {
                                       aliasAnalyzer);
                 if (score >= 0 && (score > bestScore ||
                                    (score == bestScore && bestToken &&
-                                    getDfsOrder(dfsOrder, tokenVal) >
-                                        getDfsOrder(dfsOrder, bestToken)))) {
+                                    tokenOrderKey(dfsOrder, tokenVal) >
+                                        tokenOrderKey(dfsOrder, bestToken)))) {
                   bestScore = score;
                   bestToken = tokenVal;
                   bestRealloc = (score < kReallocEnsureCutoff);
@@ -532,15 +559,16 @@ struct TokenReusePass : public impl::ReussirTokenReusePassBase<TokenReusePass> {
     // Collect tokens to free first, then erase them. Modifying the immer::set
     // during iteration would invalidate iterators (use-after-free).
     llvm::SmallVector<mlir::Value> tokensToFree;
-    for (auto token : availableTokens) {
+    for (mlir::Value token : tokensInStableOrder(availableTokens, dfsOrder)) {
       if (!region.getParentOp() ||
           !domInfo.properlyDominates(token, region.getParentOp())) {
-        frees.push_back({token, terminator});
         tokensToFree.push_back(token);
       }
     }
-    for (auto token : tokensToFree)
+    for (auto token : tokensToFree) {
+      frees.push_back({token, terminator});
       availableTokens = availableTokens.erase(token);
+    }
     return availableTokens;
   }
 

--- a/tests/integration/conversion/token_reuse_escape.mlir
+++ b/tests/integration/conversion/token_reuse_escape.mlir
@@ -23,11 +23,14 @@ module @test attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<
     // CHECK: } else {
     // CHECK: scf.yield %{{.+}}, %{{.+}} :
     // CHECK: } {reussir.expanded_decrement}
-    // Both creates reuse: one token each, no fresh allocation.
-    // CHECK: reussir.token.ensure
+    // Both creates reuse: equal-score sibling results are selected in stable
+    // token order (later result first), never pointer-hash iteration order.
+    // CHECK: %[[ENSURE_A:.+]] = reussir.token.ensure(%[[TOKS]]#1
     // CHECK-NEXT: reussir.rc.create
-    // CHECK: reussir.token.ensure
+    // CHECK-SAME: token(%[[ENSURE_A]]
+    // CHECK: %[[ENSURE_B:.+]] = reussir.token.ensure(%[[TOKS]]#0
     // CHECK-NEXT: reussir.rc.create
+    // CHECK-SAME: token(%[[ENSURE_B]]
     // CHECK-NOT: reussir.token.alloc
     func.func @escape(%o: !rcOuter, %va: !inner, %vb: !inner) -> (!rcInner, !rcInner) {
         %prev = reussir.rc.fetch (%o : !rcOuter) : index
@@ -67,5 +70,26 @@ module @test attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<
         %tkb = reussir.token.alloc : !tk
         %b = reussir.rc.create value(%vb : !inner) token(%tkb : !tk) : !rcInner
         return %a, %b : !rcInner, !rcInner
+    }
+
+    // Unconsumed sibling tokens are recorded and emitted in the same stable
+    // result-number order. Both frees sink into the unique branch; the
+    // pointer-hash order of the pending-token set must not swap them.
+    // CHECK-LABEL: func.func @stable_free_order
+    // CHECK-SAME: (%{{.+}}: i1, %[[A:.+]]: !reussir.token{{.*}}, %[[B:.+]]: !reussir.token
+    // CHECK: scf.if
+    // CHECK: reussir.token.free(%[[A]] : !reussir.token
+    // CHECK-NEXT: reussir.token.free(%[[B]] : !reussir.token
+    func.func @stable_free_order(%condition: i1, %a: !tk, %b: !tk) {
+        %tokens:2 = scf.if %condition -> (!reussir.nullable<!tk>, !reussir.nullable<!tk>) {
+            %na = reussir.nullable.create (%a : !tk) : !reussir.nullable<!tk>
+            %nb = reussir.nullable.create (%b : !tk) : !reussir.nullable<!tk>
+            scf.yield %na, %nb : !reussir.nullable<!tk>, !reussir.nullable<!tk>
+        } else {
+            %nulla = reussir.nullable.create : !reussir.nullable<!tk>
+            %nullb = reussir.nullable.create : !reussir.nullable<!tk>
+            scf.yield %nulla, %nullb : !reussir.nullable<!tk>, !reussir.nullable<!tk>
+        } {reussir.expanded_decrement}
+        return
     }
 }


### PR DESCRIPTION
## Summary

- totally order token-reuse candidates by DFS position, value kind, and result/argument number
- use that order for equal-score donor selection and every free-emission path
- cover deterministic sibling-result reuse and deterministic sibling-token frees

Equal-score sibling results share a defining operation, so the previous DFS-only tie-break could still fall through to the pointer-hashed pending-token set. ASLR then changed donor pairing or free order between otherwise identical compiler invocations.

The three paths that emit an enumerated token set now sort it explicitly. The acceptor path emits one selected winner instead, so its determinism depends on `tokenOrderKey` remaining a total order; the implementation comment and commit message record that invariant.

## Validation

- focused `token_reuse_escape.mlir` lit test: PASS
- `functional-queue`: three independent compiler processes produced byte-identical IR
- `fingertree`: three independent compiler processes produced byte-identical IR
- negative control on pre-fix `main`: the new order assertion was flaky-red (7 failures / 3 passes across 10 runs), demonstrating that it binds to the ASLR-dependent degree of freedom rather than passing vacuously

The negative control cannot be solid-red by construction: the bug nondeterministically chooses either sibling order.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/547"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788749158&installation_model_id=426051&pr_number=547&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F547&signature=254c3a86d82708657995356a76c3e4b4e00ff98d979769255f9f046d948f746f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->