### PR TITLE
DIAGNOSTIC, NEVER MERGE: is wasi_examples hung or just slow?

### DIFF
--- a/.github/workflows/mlir-cpp-test-macos.yml
+++ b/.github/workflows/mlir-cpp-test-macos.yml
@@ -33,7 +33,9 @@ jobs:
           # (tests/integration/rene/wasi_*.rr); CMake finds it on PATH at
           # configure time, which is what turns the `wasmer` lit feature on.
           brew install cmake ninja llvm spdlog googletest python@3 wasmer
-          pip3 install lit --break-system-packages
+          # psutil is required for lit's `--timeout`; without it lit exits
+          # fatally rather than running untimed.
+          pip3 install lit psutil --break-system-packages
 
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/mlir-cpp-test.yml
+++ b/.github/workflows/mlir-cpp-test.yml
@@ -64,7 +64,11 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y cmake ninja-build wget libgtest-dev libgmock-dev libspdlog-dev libgmp-dev
-          sudo pip install lit --break-system-packages
+          # psutil is not optional: lit refuses to start with `--timeout` set
+          # without it ("Setting a timeout per test not supported"), which is
+          # a fatal error rather than a degraded run. The Windows conda env
+          # already carries it for the same reason.
+          sudo pip install lit psutil --break-system-packages
 
       # The engine that runs what the WebAssembly suite builds. The official
       # installer drops the binary in ~/.wasmer/bin; putting that on PATH is

--- a/.github/workflows/mlir-cpp-test.yml
+++ b/.github/workflows/mlir-cpp-test.yml
@@ -153,6 +153,15 @@ jobs:
           ctest --test-dir build --output-on-failure
 
       - name: Run Integration Tests
+        env:
+          # DIAGNOSTIC BRANCH, NEVER MERGE. `rene/wasi_examples.rr` wedged
+          # this job for 5h09m on 2026-08-07 and again on the retrigger,
+          # while the arm sibling passed it in both runs. A 60s cap cannot
+          # distinguish a slow test from a hung one — it reports the cap
+          # either way — so run that test alone with a large one and read
+          # the duration. Completes at ~200s: slow, and the runtime-bake
+          # tax likely explains it. Still running at 1800s: a hang.
+          LIT_OPTS: --timeout=1800 --filter=wasi_examples --time-tests
         run: cmake --build build --target check
 
       - name: Run Sanitizer Integration Tests

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -40,7 +40,9 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y cmake ninja-build wget libgtest-dev libgmock-dev libspdlog-dev libgmp-dev
-          sudo pip install lit --break-system-packages
+          # psutil is required for lit's `--timeout`; without it lit exits
+          # fatally rather than running untimed.
+          sudo pip install lit psutil --break-system-packages
 
       - name: Install LLVM ${{ matrix.llvm-version }}
         run: |
@@ -163,7 +165,9 @@ jobs:
         run: |
           brew update
           brew install cmake ninja llvm spdlog googletest python@3
-          pip3 install lit --break-system-packages
+          # psutil is required for lit's `--timeout`; without it lit exits
+          # fatally rather than running untimed.
+          pip3 install lit psutil --break-system-packages
 
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1


### PR DESCRIPTION
**Do not merge. Do not review as a change.** This branch exists to produce one measurement and then be deleted.

## The question

`rene/wasi_examples.rr` wedged `build (22, ubuntu-24.04)` for **5h09m** on 2026-08-07 — stopped only by a manual cancel — and appears to have wedged the retrigger too. On `ubuntu-24.04-arm`, same commit, same run, that test **passed** both times.

Nothing so far distinguishes **hung** from **very slow**, and the 60s probe in #551 cannot: a TIMEOUT reports the cap, not the duration the test would have taken. `--time-tests` gives real durations for tests that finish and the cap for those that don''t, so the distribution is censored exactly where this question lives.

## The measurement

```yaml
LIT_OPTS: --timeout=1800 --filter=wasi_examples --time-tests
```

One test, both arches, a cap large enough to let it finish if it can.

| outcome | reading |
|---|---|
| completes at ~200s | **slow, not hung.** The runtime-bake tax — measured at 85.4s per cold build directory, 96% of a `rene build` — plausibly covers it |
| still running at 1800s | **hung.** The pipe-buffer deadlock hypothesis stays live: `CompletedInvocation::report` takes the process-wide blocking stderr lock and `write_all`s a buffered diagnostic block, on `compio` worker threads, into a pipe lit does not drain until exit |

`wasi_examples` is the heaviest case in the corpus — four `rene build` invocations cross-compiled to wasm across four packages — which makes it both the maximum-diagnostic-volume case and the one the pipe hypothesis would predict fails first.

## Why on CI rather than a local Linux host

The hang has only ever been observed on the GitHub x64 runner. A clean completion on some other Linux box would be consistent with "no hang" **and** with "wrong environment", which is the ambiguity the measurement exists to remove. @Cindy''s call and the right one.

Cost is bounded: the usual ~28min build plus at most 30min of test.

## What filtering costs, and what it doesn't

`--filter` also removes the suite's system-wide load: normally ~494 tests run in parallel, each spawning compilers. If the wedge is timing-dependent, a machine doing one thing may not hit it.

This does not weaken a **positive** result at all — hanging under *reduced* load is a stronger finding than hanging under contention. It does weaken a clean one, by more than the "it has passed before" caveat already does. A clean completion at ~200s would be consistent with three readings, not two:

1. not hung,
2. intermittent,
3. hangs only under suite-level contention.

Closing off the third needs the same diagnostic with the filter dropped and the 1800s cap kept — full suite, every test reporting a real duration, nothing censored. Much more expensive, so it is worth running only if this cheap version comes back inconclusive.

(@Cindy's point.)

## How to read a clean result

A single completion would not prove there is no hang — this test has passed on x64 before today. Two occurrences in a day suggests it is frequent rather than rare, so one run is decent evidence, but **"intermittent" stays the honest description rather than "resolved"** unless it completes repeatedly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/552"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788759742&installation_model_id=426051&pr_number=552&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F552&signature=b426d5d3e9deefe18507aa54e3fc07be6ac906d6b72025b021f581f59d5e782a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
