### PR TITLE
[token-reuse] batch escaped-token widening sweeps

### DIFF
--- a/lib/Transformation/TokenReuse/TokenReuse.cpp
+++ b/lib/Transformation/TokenReuse/TokenReuse.cpp
@@ -324,72 +324,81 @@ mlir::TypedValue<RcType> expandedDecProducerRc(mlir::scf::IfOp scfIf,
   return nullptr;
 }
 
-bool escapeTrappedTokensOnce(mlir::func::FuncOp func) {
+bool escapeTrappedTokensSweep(mlir::func::FuncOp func) {
   llvm::SmallVector<mlir::scf::IfOp> worklist;
-  func.walk([&](mlir::scf::IfOp op) {
+  func.walk<mlir::WalkOrder::PostOrder>([&](mlir::scf::IfOp op) {
     if (op->hasAttr(kExpandedDecrementAttr))
       worklist.push_back(op);
   });
+  bool changed = false;
   for (mlir::scf::IfOp outer : worklist) {
-    // Trapped producers: expanded decrements sitting directly in one of the
-    // outer decrement's blocks, with unconsumed token results.
-    llvm::SmallVector<mlir::Value> escaped;
-    mlir::Block *homeBlock = nullptr;
-    for (mlir::Region &region : outer->getRegions()) {
-      for (mlir::Operation &op : region.front()) {
-        auto inner = llvm::dyn_cast<mlir::scf::IfOp>(op);
-        if (!inner || !inner->hasAttr(kExpandedDecrementAttr))
-          continue;
-        for (mlir::OpResult result : inner.getResults())
-          if (isEscapableTokenResult(result)) {
-            if (homeBlock && homeBlock != &region.front())
-              continue; // one home region per widening round; rare
-            homeBlock = &region.front();
-            escaped.push_back(result);
-          }
+    // Keep widening this decrement until neither home region contains a
+    // trapped producer. The post-order worklist then lets its parent consume
+    // the newly exposed results in the same sweep. This is the same
+    // child-before-parent fixed point as the old one-rewrite-per-full-walk
+    // loop, without rescanning the whole function after every widening.
+    while (true) {
+      // Trapped producers: expanded decrements sitting directly in one of the
+      // outer decrement's blocks, with unconsumed token results.
+      llvm::SmallVector<mlir::Value> escaped;
+      mlir::Block *homeBlock = nullptr;
+      for (mlir::Region &region : outer->getRegions()) {
+        for (mlir::Operation &op : region.front()) {
+          auto inner = llvm::dyn_cast<mlir::scf::IfOp>(op);
+          if (!inner || !inner->hasAttr(kExpandedDecrementAttr))
+            continue;
+          for (mlir::OpResult result : inner.getResults())
+            if (isEscapableTokenResult(result)) {
+              if (homeBlock && homeBlock != &region.front())
+                continue; // one home region per widening round; rare
+              homeBlock = &region.front();
+              escaped.push_back(result);
+            }
+        }
       }
-    }
-    if (escaped.empty())
-      continue;
+      if (escaped.empty())
+        break;
 
-    mlir::OpBuilder builder(outer);
-    llvm::SmallVector<mlir::Type> resultTypes(outer.getResultTypes().begin(),
-                                              outer.getResultTypes().end());
-    for (mlir::Value token : escaped)
-      resultTypes.push_back(token.getType());
-    auto widened = mlir::scf::IfOp::create(
-        builder, outer.getLoc(), resultTypes, outer.getCondition(),
-        /*addThenRegion=*/true, /*addElseRegion=*/true);
-    widened->setAttrs(outer->getAttrs());
-    widened.getThenRegion().takeBody(outer.getThenRegion());
-    widened.getElseRegion().takeBody(outer.getElseRegion());
+      mlir::OpBuilder builder(outer);
+      llvm::SmallVector<mlir::Type> resultTypes(outer.getResultTypes().begin(),
+                                                outer.getResultTypes().end());
+      for (mlir::Value token : escaped)
+        resultTypes.push_back(token.getType());
+      auto widened = mlir::scf::IfOp::create(
+          builder, outer.getLoc(), resultTypes, outer.getCondition(),
+          /*addThenRegion=*/true, /*addElseRegion=*/true);
+      widened->setAttrs(outer->getAttrs());
+      widened.getThenRegion().takeBody(outer.getThenRegion());
+      widened.getElseRegion().takeBody(outer.getElseRegion());
 
-    for (mlir::Region &region : widened->getRegions()) {
-      mlir::Operation *yield = region.front().getTerminator();
-      llvm::SmallVector<mlir::Value> operands(yield->getOperands());
-      if (&region.front() == homeBlock) {
-        operands.append(escaped.begin(), escaped.end());
-      } else {
+      for (mlir::Region &region : widened->getRegions()) {
+        mlir::Operation *yield = region.front().getTerminator();
+        llvm::SmallVector<mlir::Value> operands(yield->getOperands());
+        if (&region.front() == homeBlock) {
+          operands.append(escaped.begin(), escaped.end());
+        } else {
+          builder.setInsertionPoint(yield);
+          for (mlir::Value token : escaped)
+            operands.push_back(ReussirNullableCreateOp::create(
+                builder, outer.getLoc(), token.getType(), nullptr));
+        }
         builder.setInsertionPoint(yield);
-        for (mlir::Value token : escaped)
-          operands.push_back(ReussirNullableCreateOp::create(
-              builder, outer.getLoc(), token.getType(), nullptr));
+        mlir::scf::YieldOp::create(builder, yield->getLoc(), operands);
+        yield->erase();
       }
-      builder.setInsertionPoint(yield);
-      mlir::scf::YieldOp::create(builder, yield->getLoc(), operands);
-      yield->erase();
-    }
 
-    for (auto [index, oldResult] : llvm::enumerate(outer.getResults()))
-      oldResult.replaceAllUsesWith(widened.getResult(index));
-    outer.erase();
-    return true;
+      for (auto [index, oldResult] : llvm::enumerate(outer.getResults()))
+        oldResult.replaceAllUsesWith(widened.getResult(index));
+      outer.erase();
+      outer = widened;
+      changed = true;
+    }
   }
-  return false;
+  return changed;
 }
 
 void escapeTrappedTokens(mlir::func::FuncOp func) {
-  while (escapeTrappedTokensOnce(func)) {
+  while (escapeTrappedTokensSweep(func)) {
   }
 }
 

--- a/tests/integration/conversion/token_reuse_escape.mlir
+++ b/tests/integration/conversion/token_reuse_escape.mlir
@@ -72,6 +72,42 @@ module @test attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i64, dense<
         return %a, %b : !rcInner, !rcInner
     }
 
+    // CHECK-LABEL: func.func @escape_chain
+    // A single sweep visits the inner decrement first, then bubbles all three
+    // tokens through the middle and outer joins. This exercises the ordering
+    // invariant needed to avoid a whole-function walk per widening.
+    // CHECK: %[[OUTER:.+]]:3 = scf.if
+    // CHECK: %[[MIDDLE:.+]]:2 = scf.if
+    // CHECK: %[[INNER:.+]] = scf.if
+    // CHECK: scf.yield %{{.+}}, %[[INNER]]
+    // CHECK: scf.yield %{{.+}}, %[[MIDDLE]]#0, %[[MIDDLE]]#1
+    func.func @escape_chain(%outerCond: i1, %middleCond: i1,
+                            %innerCond: i1, %outerToken: !tk,
+                            %middleToken: !tk, %innerToken: !tk) {
+        %outer = scf.if %outerCond -> (!reussir.nullable<!tk>) {
+            %middle = scf.if %middleCond -> (!reussir.nullable<!tk>) {
+                %inner = scf.if %innerCond -> (!reussir.nullable<!tk>) {
+                    %innerNonnull = reussir.nullable.create (%innerToken : !tk) : !reussir.nullable<!tk>
+                    scf.yield %innerNonnull : !reussir.nullable<!tk>
+                } else {
+                    %innerNull = reussir.nullable.create : !reussir.nullable<!tk>
+                    scf.yield %innerNull : !reussir.nullable<!tk>
+                } {reussir.expanded_decrement}
+                %middleNonnull = reussir.nullable.create (%middleToken : !tk) : !reussir.nullable<!tk>
+                scf.yield %middleNonnull : !reussir.nullable<!tk>
+            } else {
+                %middleNull = reussir.nullable.create : !reussir.nullable<!tk>
+                scf.yield %middleNull : !reussir.nullable<!tk>
+            } {reussir.expanded_decrement}
+            %outerNonnull = reussir.nullable.create (%outerToken : !tk) : !reussir.nullable<!tk>
+            scf.yield %outerNonnull : !reussir.nullable<!tk>
+        } else {
+            %outerNull = reussir.nullable.create : !reussir.nullable<!tk>
+            scf.yield %outerNull : !reussir.nullable<!tk>
+        } {reussir.expanded_decrement}
+        return
+    }
+
     // Unconsumed sibling tokens are recorded and emitted in the same stable
     // result-number order. Both frees sink into the unique branch; the
     // pointer-hash order of the pending-token set must not swap them.


### PR DESCRIPTION
## Summary

- replace one full function walk per escaped-token widening with a post-order worklist processed to local fixed point
- preserve the existing child-before-parent widening order and retain the outer fixed-point sweep as a safety confirmation
- add a three-level child-to-parent-to-grandparent escape regression

## Performance

Pinned Linux arm64 fingertree compile at compiler base `5fc1e70`:

- TokenReuse adaptor: 3.029 s -> 0.221 s (13.7x)
- `split_tree`: 1.179 s -> 0.048 s
- `split_tree_by`: 1.233 s -> 0.047 s
- whole compile: 25.59-25.93 s -> 23.30 s

`perf` attributed about 80% of TokenReuse inclusive time to repeated recursive `mlir::detail::walk` calls. Temporary counters showed 1,368 widenings in each split function, which meant 1,369 complete function walks with the old one-rewrite-per-walk loop.

## Quality and correctness

- independently reviewed invariant: a parent widening only adds a use of an escaped child result, so it cannot re-enable the child's `use_empty()` predicate
- exact pre/post fingertree executable SHA-256 is identical
- exact post-TokenReuse textual IR is identical for 116/116 integration MLIR inputs that accept the pass standalone
- current `main` verification: 499 integration tests discovered, zero failures; 30/30 C++ unit tests pass

A pinned perf recording, counters, exact runner, timing streams, and checksummed report are preserved in task #11's Raft thread. Windows cross-target/full-pipeline equivalence validation is running independently.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/554"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788775188&installation_model_id=426051&pr_number=554&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F554&signature=8994bfc42cf7dff66611a48a01094987c1b118b5be8eb3b060c1d768090a6e39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->