### PR TITLE
[core][codegen][backend] rc elements in arrays, with per-op ownership

### DIFF
--- a/crates/reussir-codegen/src/lower/expr.rs
+++ b/crates/reussir-codegen/src/lower/expr.rs
@@ -3302,6 +3302,11 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
                 .result(0)
                 .expect("load result")
                 .into();
+            // An rc element is shared with the array: the caller receives an
+            // owned +1 reference, the payload keeps its own.
+            if self.tys.is_managed_rc(e.ty) {
+                self.emit_inc(then, loaded, e.ty)?;
+            }
             then.append_operation(scf::r#yield(&[loaded], loc));
             Ok(())
         })
@@ -3326,12 +3331,24 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
             .ok_or_else(|| LoweringError("array element is unit".into()))?;
         let memref_ty = self.memref_of(base.ty)?;
         let rc_ty = self.tys.mlir_ty(base.ty)?;
+        let elem_ty = args[rank + 1].ty;
         self.guarded(block, ok, rc_ty, |then| {
             let body = Block::new(&[(memref_ty, loc)]);
             let view = body
                 .argument(0)
                 .expect("with_unique_view body takes the view")
                 .into();
+            // The store overwrites the old element: for an rc element that
+            // reference is the payload's own, released here — inside the
+            // unique view, so the slot is not shared with another array.
+            if self.tys.is_managed_rc(elem_ty) {
+                let old = body
+                    .append_operation(memref::load(view, &idxs, loc))
+                    .result(0)
+                    .expect("load result")
+                    .into();
+                self.emit_dec(&body, old, elem_ty)?;
+            }
             body.append_operation(memref::store(value, view, &idxs, loc));
             body.append_operation(builders::scf_yield(None, loc));
             let region = Region::new();
@@ -3399,7 +3416,22 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
         let rc_val = self.fresh_array(block, e.ty)?;
         let view = self.array_view_of(block, rc_val, e.ty)?;
         let dims = Self::array_dims(e.ty)?;
-        self.splat_nest(block, view, value, dims, Vec::new())?;
+        // An rc element is stored `∏dims` times but arrives owned once: the
+        // nest retains before every store, and the surplus reference — the
+        // consumed operand's own — is released after the fill.
+        let elem_ty = args[0].ty;
+        let elem_rc = self.tys.is_managed_rc(elem_ty);
+        self.splat_nest(
+            block,
+            view,
+            value,
+            dims,
+            Vec::new(),
+            elem_rc.then_some(elem_ty),
+        )?;
+        if elem_rc {
+            self.emit_dec(block, value, elem_ty)?;
+        }
         Ok(rc_val)
     }
 
@@ -3411,9 +3443,15 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
         value: Value<'c, 'b>,
         dims: &[u64],
         ivs: Vec<Value<'c, 'b>>,
+        elem_rc: Option<Ty<'tcx>>,
     ) -> Result<()> {
         let loc = self.loc();
         if dims.is_empty() {
+            // Each stored slot holds its own reference (the fill's caller
+            // settles the consumed operand's surplus).
+            if let Some(ty) = elem_rc {
+                self.emit_inc(block, value, ty)?;
+            }
             block.append_operation(memref::store(value, view, &ivs, loc));
             return Ok(());
         }
@@ -3425,7 +3463,7 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
             let iv = inner.argument(0).expect("loop induction variable").into();
             let mut ivs2: Vec<Value<'c, '_>> = ivs.to_vec();
             ivs2.push(iv);
-            self.splat_nest(&inner, view, value, &dims[1..], ivs2)?;
+            self.splat_nest(&inner, view, value, &dims[1..], ivs2, elem_rc)?;
             inner.append_operation(scf::r#yield(&[], loc));
         }
         let region = Region::new();

--- a/crates/reussir-codegen/src/lower/ty.rs
+++ b/crates/reussir-codegen/src/lower/ty.rs
@@ -458,11 +458,13 @@ impl<'c, 'p, 'tcx> TypeCtx<'c, 'p, 'tcx> {
 
     /// The `!reussir.array<dims x elem>` payload type of an array-typed `ty`
     /// (the type inside its `rc` box, and the element type of its views).
+    /// Full type lowering: an rc element's slot is its `!reussir.rc<…>`
+    /// pointer, a scalar's the scalar itself.
     pub(super) fn array_inner_of(&self, ty: Ty<'tcx>) -> Result<Type<'c>> {
         let TyKind::Array { elem, dims } = *ty.kind() else {
             return err("array payload requested for a non-array type");
         };
-        let elem = scalar_ty(self.context, elem)?;
+        let elem = self.mlir_ty(elem)?;
         let shape: Vec<i64> = dims.iter().map(|&d| d as i64).collect();
         Ok(array(&shape, elem))
     }

--- a/crates/reussir-core/src/full/mono.rs
+++ b/crates/reussir-core/src/full/mono.rs
@@ -2392,10 +2392,57 @@ impl<'a, 'tcx> Driver<'a, 'tcx> {
                 args: self.lower_slice(args, subst),
             },
             ExprKind::Closure(c) => M::Closure(self.lower_closure(c, subst)),
-            ExprKind::ArrayOp { op, args } => M::ArrayOp {
-                op: *op,
-                args: self.lower_slice(args, subst),
-            },
+            ExprKind::ArrayOp { op, args } => {
+                // The ground half of the array element checks: semi lets a
+                // generic element through, so an instantiation is the first
+                // point where `[T; n]` can ground to an inadmissible element
+                // — or where `tabulate`/`fold` (whose raw views carry no
+                // per-element ownership hooks) can meet an rc element.
+                use crate::intrinsic::ArrayFn;
+                use crate::semi::ty::TyKind;
+                use crate::semi::ty_eval::{array_element_rejection, is_plain_scalar_or_deferred};
+                let arg0 = args.first().map(|a| subst_ty(self.tcx, a.ty, subst));
+                let elem = match op {
+                    // `splat`'s one argument *is* an element value.
+                    ArrayFn::Splat => arg0,
+                    // `tabulate`'s kernel returns the element.
+                    ArrayFn::Tabulate => arg0.and_then(|t| match t.kind() {
+                        TyKind::Closure { ret, .. } => Some(*ret),
+                        _ => None,
+                    }),
+                    // Everything else operates on an array base.
+                    _ => arg0.and_then(|t| match t.kind() {
+                        TyKind::Array { elem, .. } => Some(*elem),
+                        _ => None,
+                    }),
+                };
+                if let Some(elem) = elem {
+                    if let Some(why) = array_element_rejection(
+                        |def| self.record_defs.get(&def).map(|r| r.default_cap),
+                        elem,
+                    ) {
+                        self.error(
+                            span,
+                            format!(
+                                "this instantiation grounds an array element type that is \
+                                 not supported ({why}); elements must be plain scalars or \
+                                 `[shared]` records"
+                            ),
+                        );
+                    } else if matches!(op, ArrayFn::Tabulate | ArrayFn::Fold)
+                        && !is_plain_scalar_or_deferred(elem)
+                    {
+                        self.error(
+                            span,
+                            format!("`{}` does not support rc element types yet", op.as_str()),
+                        );
+                    }
+                }
+                M::ArrayOp {
+                    op: *op,
+                    args: self.lower_slice(args, subst),
+                }
+            }
             ExprKind::Match(scrut, tree) => {
                 M::Match(self.lower_ref(scrut, subst), self.lower_tree(tree, subst))
             }

--- a/crates/reussir-core/src/semi/check.rs
+++ b/crates/reussir-core/src/semi/check.rs
@@ -2863,6 +2863,23 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             );
             return self.poison(span);
         }
+        // `tabulate` fills the payload through the raw view with no
+        // per-element ownership hooks, so rc elements stay out of it; a
+        // deferred (generic) element re-checks at monomorphization. `splat`
+        // supports them (its lowering retains per stored slot).
+        if op == ArrayFn::Tabulate
+            && !crate::semi::ty_eval::is_plain_scalar_or_deferred(self.infer.shallow_resolve(elem))
+        {
+            self.error(
+                span,
+                format!(
+                    "`tabulate` does not support rc element types yet; found `{}` \
+                     (build with `splat` and `set` instead)",
+                    self.ty_display(elem)
+                ),
+            );
+            return self.poison(span);
+        }
         match op {
             ArrayFn::Splat => {
                 let v = self.check_expr(&fc.args[0], elem);
@@ -2903,6 +2920,23 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         let TyKind::Array { elem, dims } = *bty.kind() else {
             unreachable!("routed here only for array bases");
         };
+        // `fold` runs the payload through a borrowed view with no
+        // per-element ownership hooks, so rc elements stay out of it (the
+        // supported traffic is `splat`/`get`/`set`). A deferred (generic)
+        // element re-checks at monomorphization.
+        if method == "fold"
+            && !crate::semi::ty_eval::is_plain_scalar_or_deferred(self.infer.shallow_resolve(elem))
+        {
+            self.error(
+                span,
+                format!(
+                    "`fold` does not support rc element types yet; found `{}` \
+                     (use `get` in a recursive loop instead)",
+                    self.ty_display(elem)
+                ),
+            );
+            return self.poison(span);
+        }
         let rank = dims.len();
         let i64_ty = self.tcx.mk_int(crate::semi::ty::IntTy::Signed(64));
         match method {

--- a/crates/reussir-core/src/semi/ty_eval.rs
+++ b/crates/reussir-core/src/semi/ty_eval.rs
@@ -250,6 +250,11 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         arc_inner_rejection(|def| self.records.get(&def).map(|r| r.default_cap), t)
     }
 
+    /// [`array_element_rejection`] against this elaborator's record table.
+    pub(crate) fn array_element_rejection(&self, t: Ty<'tcx>) -> Option<&'static str> {
+        array_element_rejection(|def| self.records.get(&def).map(|r| r.default_cap), t)
+    }
+
     /// Evaluate a statically shaped array type (`[f64; 512]`,
     /// `[f64; 5, 16, 8]`) into a [`TyKind::Array`].
     pub(crate) fn eval_array_type(
@@ -264,13 +269,15 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             return self.tcx.mk(TyKind::Bottom);
         }
         let elem = self.eval_type(elem);
-        // Phase A restricts elements to plain scalars: views over the
-        // payload must be free of reference-count traffic.
-        if !is_plain_scalar_or_deferred(elem) {
+        // Elements are plain scalars or shared rc boxes; anything whose
+        // payload would need member-wise treatment through a view stays
+        // rejected (a rejection names why).
+        if let Some(why) = self.array_element_rejection(elem) {
             self.error(
                 Some(span),
                 format!(
-                    "non-scalar array element types are not supported yet; found `{}`",
+                    "array element type `{}` is not supported yet ({why}); \
+                     elements must be plain scalars or `[shared]` records",
                     self.ty_display(elem)
                 ),
             );
@@ -412,8 +419,8 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
 /// rejected; `Record`/`Closure`/`Array`/`Cell` are valid inners, and
 /// `Generic`/`Hole`/`Bottom` are deferred (resolved/checked later) so this never
 /// reports a false positive on a not-yet-ground type.
-/// Whether `t` qualifies as a Phase-A array element: a plain scalar, or a
-/// generic/hole deferred to the monomorphization-time groundness check.
+/// Whether `t` qualifies as an array element on the scalar side: a plain
+/// scalar, or a generic/hole deferred to the monomorphization-time check.
 pub(crate) fn is_plain_scalar_or_deferred(t: Ty<'_>) -> bool {
     matches!(
         t.kind(),
@@ -425,6 +432,38 @@ pub(crate) fn is_plain_scalar_or_deferred(t: Ty<'_>) -> bool {
             | TyKind::Hole(_)
             | TyKind::Bottom
     )
+}
+
+/// Why `t` cannot be an array element, or `None` when it can: a plain
+/// scalar, or a shared rc box — a `[shared]` record (struct or enum), whose
+/// payload slot is one pointer the acquire/drop expansions already walk.
+/// Value records (member-wise rc traffic through a view), regional records
+/// (region lifetimes), cells, closures, and `Arc` (atomic context through a
+/// plain view) stay rejected. Generic/hole/bottom defer to the
+/// monomorphization-time check, exactly like [`arc_inner_rejection`].
+pub fn array_element_rejection<'tcx>(
+    cap_of: impl FnOnce(DefId) -> Option<DefaultCap>,
+    t: Ty<'tcx>,
+) -> Option<&'static str> {
+    if is_plain_scalar_or_deferred(t) {
+        return None;
+    }
+    match t.kind() {
+        TyKind::Record { def, flex, .. } => match flex {
+            Flexivity::Flex | Flexivity::Rigid => Some("a regional record"),
+            _ => match cap_of(*def) {
+                Some(DefaultCap::Shared) | None => None,
+                Some(DefaultCap::Value) => Some("a `[value]` record"),
+                Some(DefaultCap::Regional) => Some("a `[regional]` record"),
+            },
+        },
+        TyKind::Arc(_) => Some("an `Arc`"),
+        TyKind::Cell { .. } => Some("a cell"),
+        TyKind::Closure { .. } => Some("a closure"),
+        TyKind::Array { .. } => Some("a nested rc array"),
+        TyKind::Str => Some("a string"),
+        _ => Some("not a scalar or `[shared]` record"),
+    }
 }
 
 /// Why `t` cannot be the inner of an `Arc`, or `None` when it can — a shared

--- a/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
+++ b/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
@@ -1422,14 +1422,24 @@ struct ReussirArrayProjectConversionPattern
     auto resultDesc = mlir::MemRefDescriptor::poison(rewriter, loc, resultType);
     resultDesc.setAllocatedPtr(rewriter, loc,
                                srcDesc.allocatedPtr(rewriter, loc));
-    resultDesc.setAlignedPtr(rewriter, loc, srcDesc.alignedPtr(rewriter, loc));
 
+    // The projected type keeps the static identity layout (offset 0), and
+    // consumers such as `getStridedElementPtr` fold that static offset —
+    // the descriptor's runtime offset field is dead to them. Carry the row
+    // shift in the aligned pointer itself instead.
     auto offset = srcDesc.offset(rewriter, loc);
     auto stride0 = srcDesc.stride(rewriter, loc, 0);
     auto delta =
         mlir::arith::MulIOp::create(rewriter, loc, adaptor.getIndex(), stride0);
-    auto newOffset = mlir::arith::AddIOp::create(rewriter, loc, offset, delta);
-    resultDesc.setOffset(rewriter, loc, newOffset);
+    auto shift = mlir::arith::AddIOp::create(rewriter, loc, offset, delta);
+    mlir::Type llvmElemTy =
+        converter->convertType(resultMemRefType.getElementType());
+    auto llvmPtrTy = mlir::LLVM::LLVMPointerType::get(rewriter.getContext());
+    auto shifted = mlir::LLVM::GEPOp::create(
+        rewriter, loc, llvmPtrTy, llvmElemTy, srcDesc.alignedPtr(rewriter, loc),
+        mlir::ValueRange{shift.getResult()});
+    resultDesc.setAlignedPtr(rewriter, loc, shifted);
+    resultDesc.setConstantOffset(rewriter, loc, 0);
 
     for (int64_t i = 0, e = resultMemRefType.getRank(); i < e; ++i) {
       resultDesc.setSize(rewriter, loc, i, srcDesc.size(rewriter, loc, i + 1));

--- a/tests/integration/frontend/array_errors.rr
+++ b/tests/integration/frontend/array_errors.rr
@@ -7,8 +7,10 @@
 
 import core::intrinsic::array;
 
-// CHECK-DAG: non-scalar array element types are not supported yet
-struct S { x: i32 }
+// A `[shared]` record element is legal now; a `[value]` record still is
+// not — its payload would need member-wise rc traffic through the view.
+// CHECK-DAG: array element type `S` is not supported yet (a `[value]` record)
+struct [value] S { x: i32 }
 fn bad_elem(a : [S; 4]) -> i64 { 0 }
 
 // An array member is fine (one shared rc box, like a closure member), but a

--- a/tests/integration/frontend/array_rc_elements.c
+++ b/tests/integration/frontend/array_rc_elements.c
@@ -1,0 +1,28 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+extern long test_splat_get_ffi(void);
+extern long test_cow_ffi(void);
+extern long test_unique_overwrite_ffi(void);
+extern long test_rank2_ffi(void);
+extern long test_rank2_cow_ffi(void);
+extern long test_roundtrip_ffi(void);
+extern long test_generic_ffi(void);
+
+static void expect(const char *name, long got, long want) {
+  if (got != want) {
+    fprintf(stderr, "%s: got %ld, want %ld\n", name, got, want);
+    exit(1);
+  }
+}
+
+int main(void) {
+  expect("splat_get", test_splat_get_ffi(), 14);
+  expect("cow", test_cow_ffi(), 20);
+  expect("unique_overwrite", test_unique_overwrite_ffi(), 111);
+  expect("rank2", test_rank2_ffi(), 40);
+  expect("rank2_cow", test_rank2_cow_ffi(), 10);
+  expect("roundtrip", test_roundtrip_ffi(), 31);
+  expect("generic", test_generic_ffi(), 3);
+  return 0;
+}

--- a/tests/integration/frontend/array_rc_elements.rr
+++ b/tests/integration/frontend/array_rc_elements.rr
@@ -1,0 +1,89 @@
+// Arrays over rc elements (issue #344 phase B, first slice): `splat`, `get`,
+// and `set` carry the reference counts — `get` returns an owned +1 element,
+// `set` releases the slot it overwrites inside the unique view, `splat`
+// retains per stored slot, the copy-on-write clone acquires every element,
+// and the array's drop releases them. `tabulate`/`fold` still reject rc
+// elements (their raw views carry no per-element hooks).
+
+// RUN: %rrc %s -o %t.o --relocation-mode pic
+// RUN: %cc %t.o %S/array_rc_elements.c -o %t.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
+// RUN: %t.exe
+// RUN: %rrc %s -o %t.opt.o --relocation-mode pic -Oaggressive
+// RUN: %cc %t.opt.o %S/array_rc_elements.c -o %t.opt.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
+// RUN: %t.opt.exe
+
+import core::intrinsic::array;
+
+pub enum List { Nil, Cons(i64, List) }
+
+fn len(l : List) -> i64 {
+    match l { List::Nil => 0, List::Cons(_, t) => 1 + len(t) }
+}
+
+fn sum(l : List) -> i64 {
+    match l { List::Nil => 0, List::Cons(h, t) => h + sum(t) }
+}
+
+// splat shares one element across every slot; get hands back an owned copy.
+pub fn test_splat_get() -> i64 {
+    let a = array::splat<[List; 4]>(List::Cons { 7, List::Nil });
+    sum(array::get(a, 0)) + sum(array::get(a, 3))
+}
+extern "C" trampoline "test_splat_get_ffi" = test_splat_get;
+
+// Copy-on-write: `a` stays live across the set, so the update clones — and
+// the clone owns its own references to every element.
+pub fn test_cow() -> i64 {
+    let a = array::splat<[List; 4]>(List::Nil);
+    let b = array::set(a, 1, List::Cons { 1, List::Cons { 2, List::Nil } });
+    len(array::get(b, 1)) * 10 + len(array::get(a, 1))
+}
+extern "C" trampoline "test_cow_ffi" = test_cow;
+
+// A unique array updates in place; the overwritten element is released.
+pub fn test_unique_overwrite() -> i64 {
+    let a = array::splat<[List; 3]>(List::Cons { 9, List::Nil });
+    let a = array::set(a, 0, List::Nil);
+    let a = array::set(a, 0, List::Cons { 5, List::Cons { 6, List::Nil } });
+    sum(array::get(a, 0)) * 10 + len(array::get(a, 2))
+}
+extern "C" trampoline "test_unique_overwrite_ffi" = test_unique_overwrite;
+
+// Rank-2 copy-on-write: the clone's acquire walks every row (the row
+// projection advances the aligned pointer, the bug its first user found).
+pub fn test_rank2_cow() -> i64 {
+    let a = array::splat<[List; 2, 3]>(List::Cons { 8, List::Nil });
+    let b = array::set(a, 1, 1, List::Nil);
+    len(array::get(a, 1, 1)) * 10 + len(array::get(b, 1, 1))
+}
+extern "C" trampoline "test_rank2_cow_ffi" = test_rank2_cow;
+
+// Rank-2: the fill nest and the projection chain carry the counts the same.
+pub fn test_rank2() -> i64 {
+    let m = array::splat<[List; 2, 3]>(List::Cons { 4, List::Nil });
+    let m = array::set(m, 1, 2, List::Nil);
+    sum(array::get(m, 0, 0)) * 10 + len(array::get(m, 1, 2))
+}
+extern "C" trampoline "test_rank2_ffi" = test_rank2;
+
+// Elements flow through calls and rebuilds: take an element out, extend it,
+// store it back — the old slot reference released, the new one owned.
+fn extend(l : List, x : i64) -> List { List::Cons { x, l } }
+
+pub fn test_roundtrip() -> i64 {
+    let a = array::splat<[List; 2]>(List::Cons { 1, List::Nil });
+    let e = array::get(a, 0);
+    let a = array::set(a, 1, extend(e, 2));
+    sum(array::get(a, 1)) * 10 + len(array::get(a, 0))
+}
+extern "C" trampoline "test_roundtrip_ffi" = test_roundtrip;
+
+// A generic element defers the admissibility check to monomorphization;
+// grounding at a shared record is admissible and works end to end.
+fn generic_pick<T>(a : [T; 2]) -> T { array::get(a, 0) }
+
+pub fn test_generic() -> i64 {
+    let a = array::splat<[List; 2]>(List::Cons { 3, List::Nil });
+    sum(generic_pick(a))
+}
+extern "C" trampoline "test_generic_ffi" = test_generic;

--- a/tests/integration/frontend/array_rc_elements_errors.rr
+++ b/tests/integration/frontend/array_rc_elements_errors.rr
@@ -1,0 +1,31 @@
+// RUN: %not %rrc %s --emit hir -o - 2>&1 | %FileCheck %s
+
+import core::intrinsic::array;
+
+pub enum List { Nil, Cons(i64, List) }
+pub struct [value] Pair { a : i64, b : i64 }
+
+// A `[value]` record's payload would need member-wise rc traffic through
+// the view; only plain scalars and `[shared]` records are elements.
+// CHECK-DAG: array element type `Pair` is not supported yet (a `[value]` record)
+pub fn value_elem(p : Pair) -> [Pair; 4] {
+    array::splat<[Pair; 4]>(p)
+}
+
+// A closure is not an element either.
+// CHECK-DAG: is not supported yet (a closure)
+pub fn closure_elem() -> i64 {
+    let a = array::splat<[(i64) -> i64; 2]>(|x : i64| x);
+    0
+}
+
+// The raw-view operations stay scalar-only over rc elements.
+// CHECK-DAG: `tabulate` does not support rc element types yet
+pub fn tab() -> [List; 4] {
+    array::tabulate<[List; 4]>(|i| List::Nil)
+}
+
+// CHECK-DAG: `fold` does not support rc element types yet
+pub fn fold_over(a : [List; 4]) -> i64 {
+    array::fold(a, 0, |acc, x| acc)
+}

--- a/tests/integration/frontend/array_rc_elements_mono_errors.rr
+++ b/tests/integration/frontend/array_rc_elements_mono_errors.rr
@@ -1,0 +1,18 @@
+// RUN: %not %rrc %s --emit mir -o - 2>&1 | %FileCheck %s
+
+// The deferred half of the array element checks: a generic element passes
+// the concrete-annotation check, so the instantiation is where `fold` over
+// an rc element — or an inadmissible element type — first grounds.
+
+import core::intrinsic::array;
+
+pub enum List { Nil, Cons(i64, List) }
+
+fn generic_fold<T>(a : [T; 4], z : i64) -> i64 {
+    array::fold(a, z, |acc, x| acc)
+}
+
+// CHECK: `fold` does not support rc element types yet
+pub fn trigger(a : [List; 4]) -> i64 {
+    generic_fold(a, 0)
+}

--- a/tests/integration/sanitizer/e2e/array_rc_elements.rr
+++ b/tests/integration/sanitizer/e2e/array_rc_elements.rr
@@ -1,0 +1,21 @@
+// REQUIRES: asan
+// ASan+LSan gate over frontend/array_rc_elements.rr: every reference the
+// array traffic touches must balance — get's owned result, set's release of
+// the overwritten slot, splat's per-slot retains, the copy-on-write clone's
+// per-element acquires, and the drop glue's releases. A missed release is a
+// leak here; a double release a use-after-free.
+
+// RUN: %rrc %S/../../frontend/array_rc_elements.rr -o %t.none.ll -t llvm-ir --relocation-mode pic -Onone
+// RUN: %cc %asan_flags -c -x ir %t.none.ll -o %t.none.o
+// RUN: %cc %asan_flags %t.none.o %S/../../frontend/array_rc_elements.c %reussir_rt_asan -o %t.none.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.none.exe
+
+// RUN: %rrc %S/../../frontend/array_rc_elements.rr -o %t.default.ll -t llvm-ir --relocation-mode pic -Odefault
+// RUN: %cc %asan_flags -c -x ir %t.default.ll -o %t.default.o
+// RUN: %cc %asan_flags %t.default.o %S/../../frontend/array_rc_elements.c %reussir_rt_asan -o %t.default.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.default.exe
+
+// RUN: %rrc %S/../../frontend/array_rc_elements.rr -o %t.aggr.ll -t llvm-ir --relocation-mode pic -Oaggressive --reuse-across-call
+// RUN: %cc %asan_flags -c -x ir %t.aggr.ll -o %t.aggr.o
+// RUN: %cc %asan_flags %t.aggr.o %S/../../frontend/array_rc_elements.c %reussir_rt_asan -o %t.aggr.exe %rpath_flag %rpath_san_flag %extra_sys_libs
+// RUN: %asan_env %t.aggr.exe


### PR DESCRIPTION
Third of the series (#545, #546): arrays admit **shared rc elements**, with `splat`/`get`/`set` carrying the reference counts and `tabulate`/`fold` explicitly rejecting them, per plan.

## What is admitted

A `[shared]` record (struct or enum) — one pointer per slot, which the existing MLIR acquire/drop expansions already know how to walk. Everything whose payload would need member-wise rc traffic through a raw view stays rejected with a named reason: `[value]` records, regional records, cells, closures, strings, `Arc`, nested arrays.

## Ownership contract

- **`get`** returns an owned +1 element: the load retains; the payload keeps its own reference.
- **`set`** releases the element it overwrites, inside `array.with_unique_view` — the slot is provably unshared there on both paths, since the clone&#39;s memcpy+acquire retained every element first.
- **`splat`** stores its one consumed operand into every slot: the fill nest retains per store and the surplus original reference is released after the fill.
- **Copy-on-write and drop** needed no new mechanism: `emitArrayOwnershipAcquisition` and the per-slot drop expansion existed — unexercised — and the frontend now emits payloads they walk. The array payload type lowers its element through full type lowering (`!reussir.rc<…>` slots) instead of the scalar-only path.

`tabulate`/`fold` reject rc elements at check time, and — new — at **monomorphization** for generic elements: the &quot;deferred to mono&quot; half of the element admissibility check previously had no enforcement at all, so a generic `[T; n]` could ground to any element type silently. The backstop also validates element admissibility itself, mirroring the `arc_inner_rejection` two-phase pattern.

## The bug the double-check found

The requested re-verification caught a real memory-safety defect — in **pre-existing code**. The new ASan gate double-freed on rank-2 arrays; six-distinct-element isolation showed the drop glue walking row 0 twice and row 1 never. Root cause: `ArrayProjectOp`&#39;s rank&gt;1 lowering wrote the row shift into the memref descriptor&#39;s runtime *offset field*, while the projected type advertises a static identity layout — so `getStridedElementPtr` folds the static zero and never reads the field. Every row projection was a no-op. Phase-A scalar arrays never emit per-slot glue, so the path had zero users until now.

The first commit fixes it by carrying the shift in the aligned pointer (and pinning the descriptor offset at the zero its type claims). Verified in both directions: the pre-fix compiler double-frees the isolation binaries; the fixed one runs them clean under ASan+LSan, and rank-2 scalar `set` (also previously untested — Phase A only ever set rank-1) is confirmed correct before and after.

## Tests

- `frontend/array_rc_elements.rr` + C harness, exact values at `-Onone` and `-Oaggressive`: splat/get/set, rank-2, copy-on-write at ranks 1 and 2 (the rank-2 case pins the fixed projection in the clone&#39;s acquire), unique in-place overwrite, elements flowing through calls and back into slots, and a generic element instantiated at a shared record.
- `sanitizer/e2e/array_rc_elements.rr`: the same binary under ASan+LSan at `-Onone`/`-Odefault`/`-Oaggressive --reuse-across-call`. This is the gate that found the projection bug.
- `frontend/array_rc_elements_errors.rr`: the element gate (value record, closure) and the per-op `tabulate`/`fold` rejections.
- `frontend/array_rc_elements_mono_errors.rr`: the mono backstop through a generic instantiation.
- `frontend/array_errors.rr` updated: a plain (shared-by-default) struct element is now legal by design, so its rejection case uses a `[value]` record.

Local verification on this head: the 30 affected lit tests (arrays, bitwise, trait-assoc, wavl, heap, hash) all pass; the full suite passes 489/498 with the two known local-environment failures (`cells_sync_parallel`&#39;s libomp startup leak, and a stale-binary repl artifact that disappears on rebuild — both documented in #545); `ctest` 30/30; 462 core unit tests; clippy and fmt clean.

Follow-ups, not in this PR: `tabulate`/`fold` over rc elements (per-element hooks through the kernel path), and runtime-length arrays — the remaining prerequisite for the CHAMP hash map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JrRGzJEYiq9fnXA6r76VaS

---
_Generated by [Claude Code](https://claude.ai/code/session_01JrRGzJEYiq9fnXA6r76VaS)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/557"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788936985&installation_model_id=426051&pr_number=557&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F557&signature=61bb9e595264820e4b86227fa388e976a9776d816c8cc38f897da7a7ac05fe49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->