### PR TITLE
[backend][rt] four compiler fixes and a Vec addition from the array stress work

### DIFF
--- a/crates/reussir-rt/src/collections/vec.rs
+++ b/crates/reussir-rt/src/collections/vec.rs
@@ -46,4 +46,48 @@ impl<T: Clone> Vec<T> {
         self.0.make_mut()[index] = value;
         self
     }
+    /// Inserts at `index`, shifting the tail right. Copy-on-write like
+    /// every other owning operation: a shared box is cloned once, then the
+    /// single shift happens in place — the node-editing primitive a
+    /// bitmap-compressed trie needs (`set` alone cannot grow a node).
+    pub fn insert_at(mut self, index: usize, value: T) -> Self {
+        self.0.make_mut().insert(index, value);
+        self
+    }
+    /// Removes at `index`, shifting the tail left; the counterpart of
+    /// [`Self::insert_at`].
+    pub fn remove_at(mut self, index: usize) -> Self {
+        self.0.make_mut().remove(index);
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn insert_and_remove_shift_around_index() {
+        let v = Vec::new().push(1).push(3);
+        let v = v.insert_at(1, 2);
+        assert_eq!(v.len(), 3);
+        assert_eq!(v.get(0), Some(1));
+        assert_eq!(v.get(1), Some(2));
+        assert_eq!(v.get(2), Some(3));
+        let v = v.remove_at(0);
+        assert_eq!(v.len(), 2);
+        assert_eq!(v.get(0), Some(2));
+        assert_eq!(v.get(1), Some(3));
+    }
+
+    #[test]
+    fn insert_at_copies_a_shared_box() {
+        let a = Vec::new().push(10).push(30);
+        let b = a.clone().insert_at(1, 20);
+        // The snapshot is untouched; only the edited copy grew.
+        assert_eq!(a.len(), 2);
+        assert_eq!(a.get(1), Some(30));
+        assert_eq!(b.len(), 3);
+        assert_eq!(b.get(1), Some(20));
+    }
 }

--- a/include/Reussir/Transformation/Passes.td
+++ b/include/Reussir/Transformation/Passes.td
@@ -274,7 +274,21 @@ def ReussirDefaultInlinerPass
     inlines) and unrolls recursion one level, the posture LLVM's own inliner
     takes. Region simplification stays off in the callable optimizer to
     match the rest of the pipeline's canonicalization policy.
+
+    The other load-bearing part is the callee size cap. The inliner works
+    bottom-up, so by the time a caller is processed its callees already
+    contain everything inlined into *them*; with no cap, each level of the
+    call tree copies its callees' fully-inlined bodies into every call
+    site, and module size grows geometrically in call-tree depth — the
+    acquire/drop expansions that run later then multiply whatever was
+    duplicated. The cap lets small helpers inline everywhere (where the
+    rc-pairing passes profit from seeing through the call) while the big
+    already-inlined bodies stay shared.
   }];
+  let options =
+      [Option<"maxCalleeOps", "max-callee-ops", "unsigned", "256",
+              "Only inline callees with at most this many operations "
+              "(counted recursively through nested regions).">];
 }
 
 #endif // REUSSIR_TRANSFORMATION_PASSES_TD

--- a/lib/Conversion/AcquireDropExpansion/AcquireDropExpansion.cpp
+++ b/lib/Conversion/AcquireDropExpansion/AcquireDropExpansion.cpp
@@ -155,12 +155,22 @@ private:
     return mlir::success();
   }
 
+  // Whether a decrement of this rc type may carry a reuse token — the
+  // mirror of `ReussirRcDecOp::shouldProduceToken`, which the verifier
+  // enforces on any token-carrying dec this pass creates: only shared
+  // boxes whose payload the program lays out itself donate their memory.
+  // FFI objects release through their foreign cleanup hook and closures
+  // through their vtable, so neither can hand its box out as a token.
+  static bool decMayProduceToken(RcType rcType) {
+    return rcType.getCapability() == Capability::shared &&
+           !llvm::isa<FFIObjectType, ClosureType>(rcType.getElementType());
+  }
+
   mlir::LogicalResult rewriteDropRc(RcType rcType, ReussirRefDropOp op,
                                     mlir::PatternRewriter &rewriter) const {
     // Replace drop of ref rc with load then dec
     NullableType nullableType = nullptr;
-    if (rcType.getCapability() != Capability::rigid &&
-        !llvm::isa<ClosureType>(rcType.getElementType())) {
+    if (decMayProduceToken(rcType)) {
       auto layout = mlir::DataLayout::closest(op.getOperation());
       RcBoxType rcBoxType = rcType.getInnerBoxType();
       size_t size = layout.getTypeSize(rcBoxType).getFixedValue();
@@ -284,7 +294,7 @@ private:
           {nullableType.getPtrTy()}, {op.getLoc()});
       rewriter.setInsertionPointToStart(nonNullBlock);
       NullableType retNullableTy = nullptr;
-      if (rcType.getCapability() != Capability::rigid) {
+      if (decMayProduceToken(rcType)) {
         auto layout = mlir::DataLayout::closest(op.getOperation());
         RcBoxType rcBoxType = rcType.getInnerBoxType();
         size_t size = layout.getTypeSize(rcBoxType).getFixedValue();

--- a/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
+++ b/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
@@ -318,18 +318,36 @@ mlir::Value createEntryBlockAlloca(mlir::ConversionPatternRewriter &rewriter,
 // slot in such a function can end up inside a loop TailCallElimination
 // later builds around the recursion, so a fill-once claim about the slot
 // (invariant.start) would be violated by the next iteration's store.
-bool enclosingFunctionIsSelfRecursive(mlir::Operation *op) {
+//
+// The scan walks the whole enclosing function, and a function fresh out of
+// the inliner can carry thousands of spill sites — re-walking per site is
+// quadratic and dominates the conversion on such modules. Callers with many
+// queries pass a cache keyed on the function op; the answer only depends on
+// the callee symbols inside, which conversion preserves. (The function op
+// itself may be replaced mid-conversion — func.func to llvm.func — which
+// merely splits the cache key: one extra walk, still sound.)
+bool enclosingFunctionIsSelfRecursive(
+    mlir::Operation *op,
+    llvm::DenseMap<mlir::Operation *, bool> *cache = nullptr) {
   auto func = op->getParentOfType<mlir::FunctionOpInterface>();
   if (!func)
     return true;
+  if (cache)
+    if (auto it = cache->find(func); it != cache->end())
+      return it->second;
   llvm::StringRef name = mlir::SymbolTable::getSymbolName(func).getValue();
   bool found = false;
   func.walk([&](mlir::CallOpInterface call) {
     auto callee = llvm::dyn_cast_if_present<mlir::SymbolRefAttr>(
         call.getCallableForCallee());
-    if (callee && callee.getLeafReference().getValue() == name)
+    if (callee && callee.getLeafReference().getValue() == name) {
       found = true;
+      return mlir::WalkResult::interrupt();
+    }
+    return mlir::WalkResult::advance();
   });
+  if (cache)
+    (*cache)[func] = found;
   return found;
 }
 
@@ -1047,6 +1065,13 @@ struct ReussirRefSpilledConversionPattern
     : public mlir::OpConversionPattern<ReussirRefSpilledOp> {
   using OpConversionPattern::OpConversionPattern;
 
+  // Self-recursion answers, one entry per enclosing function. The driver
+  // applies this pattern once per spill site; without the cache each site
+  // re-walks its whole function (see enclosingFunctionIsSelfRecursive).
+  // Mutable because matchAndRewrite is const; the conversion driver is
+  // single-threaded, so unsynchronized access is fine.
+  mutable llvm::DenseMap<mlir::Operation *, bool> selfRecursionCache;
+
   mlir::LogicalResult
   matchAndRewrite(ReussirRefSpilledOp op, OpAdaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
@@ -1073,7 +1098,7 @@ struct ReussirRefSpilledConversionPattern
     // very site, and the next iteration's refill of the (entry-block,
     // per-frame) slot would violate the invariant.
     mlir::LLVM::StoreOp::create(rewriter, loc, value, allocaOp);
-    if (!enclosingFunctionIsSelfRecursive(op))
+    if (!enclosingFunctionIsSelfRecursive(op, &selfRecursionCache))
       mlir::LLVM::InvariantStartOp::create(
           rewriter, loc, dataLayout.getTypeABIAlignment(valueType), allocaOp);
     rewriter.replaceOp(op, allocaOp);

--- a/lib/IR/ReussirOps.cpp
+++ b/lib/IR/ReussirOps.cpp
@@ -2355,14 +2355,22 @@ mlir::LogicalResult ReussirScfYieldOp::verify() {
   mlir::Type yieldedType = getValue() ? getValue().getType() : mlir::Type{};
   mlir::Type expectedType = mlir::Type{};
   bool allowImplicitArrayResult = false;
-  // The rdlock check looks at the immediate parent (not the nearest ancestor
-  // of a type): an rdlock body may itself sit inside a dispatch region, and
-  // this yield belongs to the rdlock.
+  // The rdlock and with-unique-view checks look at the immediate parent
+  // (not the nearest ancestor of a type): either body may itself sit inside
+  // a dispatch region — a `set` in a match arm is the everyday case — and
+  // this yield belongs to the op whose single-block body it terminates.
   if (auto rdlockParent = llvm::dyn_cast_if_present<ReussirCellRdlockOp>(
           getOperation()->getParentOp()))
     expectedType = rdlockParent.getOutput() ? rdlockParent.getOutput().getType()
                                             : mlir::Type{};
-  else if (auto nullableParent =
+  else if (auto arrayParent =
+               llvm::dyn_cast_if_present<ReussirArrayWithUniqueViewOp>(
+                   getOperation()->getParentOp())) {
+    expectedType = arrayParent.getResult() ? arrayParent.getResult().getType()
+                                           : mlir::Type{};
+    allowImplicitArrayResult =
+        expectedType && expectedType == arrayParent.getArray().getType();
+  } else if (auto nullableParent =
           getOperation()->getParentOfType<ReussirNullableDispatchOp>())
     expectedType = nullableParent.getValue()
                        ? nullableParent.getValue().getType()

--- a/lib/Transformation/DefaultInliner/DefaultInliner.cpp
+++ b/lib/Transformation/DefaultInliner/DefaultInliner.cpp
@@ -46,6 +46,20 @@ void addCanonicalizerWithoutRegionSimplification(mlir::OpPassManager &pm) {
   pm.addPass(mlir::createCanonicalizerPass(config));
 }
 
+// Whether the callable region holds at most `limit` operations, counted
+// recursively through nested regions. The walk stops as soon as the limit
+// is crossed, so a query costs O(limit) however large the callee is.
+bool calleeIsSmall(mlir::Region *callable, unsigned limit) {
+  if (!callable)
+    return false;
+  unsigned count = 0;
+  auto result = callable->walk([&](mlir::Operation *) {
+    return ++count > limit ? mlir::WalkResult::interrupt()
+                           : mlir::WalkResult::advance();
+  });
+  return !result.wasInterrupted();
+}
+
 struct DefaultInlinerPass
     : public impl::ReussirDefaultInlinerPassBase<DefaultInlinerPass> {
   using Base::Base;
@@ -59,13 +73,18 @@ struct DefaultInlinerPass
                                      /*maxInliningIterations=*/1);
     mlir::CallGraph &callGraph = getAnalysis<mlir::CallGraph>();
     // Nested (callable-optimizer) pipelines run through the pass's own
-    // instrumented pipeline runner; profitability matches the upstream
-    // pass's default of no cost threshold.
+    // instrumented pipeline runner. Profitability caps the callee's size:
+    // bottom-up processing means an uncapped policy re-copies each level's
+    // fully-inlined bodies into every caller, growing the module
+    // geometrically in call-tree depth (see the pass description).
     mlir::Inliner inliner(
         getOperation(), callGraph, *this, getAnalysisManager(),
         [this](mlir::Pass &, mlir::OpPassManager &pipeline,
                mlir::Operation *op) { return runPipeline(pipeline, op); },
-        config, [](const mlir::Inliner::ResolvedCall &) { return true; });
+        config, [this](const mlir::Inliner::ResolvedCall &call) {
+          return calleeIsSmall(call.targetNode->getCallableRegion(),
+                               maxCalleeOps);
+        });
     if (mlir::failed(inliner.doInlining()))
       signalPassFailure();
   }

--- a/tests/integration/frontend/array_set_in_match.c
+++ b/tests/integration/frontend/array_set_in_match.c
@@ -1,0 +1,13 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+extern long test_set_in_match(long x);
+
+int main(void) {
+  long got = test_set_in_match(7);
+  if (got != 1) {
+    fprintf(stderr, "set_in_match: got %ld, want 1\n", got);
+    exit(1);
+  }
+  return 0;
+}

--- a/tests/integration/frontend/array_set_in_match.rr
+++ b/tests/integration/frontend/array_set_in_match.rr
@@ -1,0 +1,40 @@
+// Regression test: `array::set` inside a match arm. The set's copy-on-write
+// body terminates with a `reussir.scf.yield` whose immediate parent is the
+// `with_unique_view` op, but the whole construct sits inside the match's
+// dispatch region — the yield verifier used to resolve its owner with
+// `getParentOfType`, find the dispatch ancestor first, and reject the (valid)
+// value-less yield with "parent operation expected a value".
+
+// RUN: %rrc %s -o %t.o --relocation-mode pic
+// RUN: %cc %t.o %S/array_set_in_match.c -o %t.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
+// RUN: %t.exe
+// RUN: %rrc %s -o %t.opt.o --relocation-mode pic -Oaggressive
+// RUN: %cc %t.opt.o %S/array_set_in_match.c -o %t.opt.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
+// RUN: %t.opt.exe
+
+import core::intrinsic::array;
+
+pub enum Node { Empty, Leaf(i64), Branch([Node; 4]) }
+
+struct [value] Rem { node : Node, removed : bool }
+
+fn del(n : Node, i : i64) -> Rem {
+    match n {
+        Node::Empty => Rem { node: Node::Empty, removed: false },
+        Node::Leaf(_) => Rem { node: Node::Empty, removed: true },
+        Node::Branch(arr) => {
+            let child = array::get(arr, i);
+            let below = del(child, i);
+            let node = below.node;
+            let removed = below.removed;
+            Rem { node: Node::Branch { array::set(arr, i, node) }, removed }
+        }
+    }
+}
+
+pub fn test_set_in_match(x : i64) -> i64 {
+    let a = array::splat<[Node; 4]>(Node::Leaf { x });
+    let out = del(Node::Branch { a }, 2);
+    if out.removed { 1 } else { 0 }
+}
+extern "C" trampoline "test_set_in_match" = test_set_in_match;

--- a/tests/integration/frontend/ffi_member_drop.rr
+++ b/tests/integration/frontend/ffi_member_drop.rr
@@ -1,0 +1,50 @@
+// UNSUPPORTED: darwin
+// Regression test: an FFI object stored inside a record/variant member,
+// released through the transitive drop glue. The acquire/drop expansion
+// used to give the member's `rc.dec` a reuse-token result whenever the box
+// was not rigid — but an FFI box releases through its foreign cleanup hook
+// and cannot donate its memory, so the verifier (correctly) rejected the
+// dec and the whole compilation ICE'd. The token predicate now mirrors
+// `shouldProduceToken`.
+
+// RUN: %rrc %s -o %t.o --relocation-mode pic
+// RUN: %rrc %s -o %t.opt.o --relocation-mode pic -Oaggressive
+
+extern "rust" [{
+    use reussir_rt::collections::vec::Vec as RVec;
+}];
+
+#[ffi(rust = "::reussir_rt::collections::vec::Vec")]
+pub struct Vec<T>;
+
+#[ffi(import)]
+pub fn new<T>() -> Vec<T> [{ RVec::new() }];
+
+#[ffi(import)]
+pub fn push<T>(v: Vec<T>, x: T) -> Vec<T> [{ RVec::push(v, x) }];
+
+#[ffi(import)]
+pub fn len<T>(v: Vec<T>) -> u64 [{ v.len() as u64 }];
+
+// The FFI box sits in a variant arm (and, transitively, in a compound):
+// dropping `Holder` runs the record drop glue over the `Vec` member — the
+// dec that must not carry a token.
+pub enum Holder {
+    Nothing,
+    Payload(u64, Vec<i64>)
+}
+
+pub struct Wrapped { tag : u64, inner : Holder }
+
+fn touch(w : Wrapped) -> u64 {
+    // Consume one field and let the rest drop through the glue.
+    w.tag
+}
+
+pub fn main() -> i64 {
+    let h = Holder::Payload { 7, push(new<i64>(), 42) };
+    let w = Wrapped { tag: 1, inner: h };
+    touch(w) as i64
+}
+
+extern "C" trampoline "reussir_main" = main;


### PR DESCRIPTION
Stacked on #557 (first two commits are that PR's). The language/runtime fixes found by the array hashmap stress work (#558 carries the stress test itself, stacked on this).

1. **Yield-owner mis-resolution** (`ReussirScfYieldOp::verify`): the verifier resolved a `with_unique_view` body's yield with `getParentOfType`, so when the whole construct sat inside a match arm the dispatch *ancestor* won and any `array::set` in a match arm was rejected with "parent operation expected a value". Immediate-parent check first, as the rdlock case already did; regression test `frontend/array_set_in_match.rr`.

2. **Quadratic `ref.spilled` lowering**: every spill site walked its entire enclosing function to decide whether `invariant.start` is sound. Post-inlining functions carry thousands of spill sites, so convert-to-llvm alone burned minutes. The answer is now memoized per enclosing function, and the walk stops at the first self call.

3. **Uncapped default inliner**: profitability accepted every resolved call, so bottom-up SCC processing copied each level's fully-inlined bodies into every caller — module size geometric in call-tree depth. On the stress package one inlining round turned 1.7&nbsp;MB of IR into 30&nbsp;MB, the acquire/drop expansions multiplied that to 69&nbsp;MB of LLVM dialect (an 886k-line `main`), and LLVM's O2 CVP/LazyValueInfo pass ground on it past a 5-minute kill. Profitability now caps callees at `max-callee-ops` (default 256, counted recursively, O(limit) per query): small helpers — where the rc-pairing passes profit from seeing through the call — still inline everywhere, big already-inlined bodies stay shared. Compile time of the stress package at `-O default`/`-O aggressive`: killed-after-5-minutes → **5&nbsp;s**.

4. **Reuse token minted for FFI-object decrements**: the acquire/drop expansion attached a reuse-token result to a member's `rc.dec` whenever the box was not rigid (the nullable path did not even exclude closures), but an FFI box releases through its foreign cleanup hook and cannot donate its memory — so any record holding an FFI object ICE'd the moment its drop glue was expanded, at every opt level. Both creation sites now share a predicate mirroring `shouldProduceToken`; regression test `frontend/ffi_member_drop.rr`.

5. **`reussir_rt::collections::vec::Vec::{insert_at, remove_at}`**: the copy-on-write vector could replace a slot (`set`) but not grow or shrink at an index, so a bitmap-compressed trie node over the FFI vector had to rebuild through a push loop. Same linear COW contract as the other owning operations; unit tests cover the shift and the shared-box copy.

## Testing

- Full integration lit suite: 506/507 locally (the one failure is the known `cells_sync_parallel` libomp startup leak, local-env, pre-existing).
- `reussir-ut` (30 C++ unit tests), `cargo test -p reussir-codegen` (21 e2e), `cargo test -p reussir-rt` (32 unit tests incl. the new coverage) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JrRGzJEYiq9fnXA6r76VaS

---
_Generated by [Claude Code](https://claude.ai/code/session_01JrRGzJEYiq9fnXA6r76VaS)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/559"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788965295&installation_model_id=426051&pr_number=559&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F559&signature=616e436bb682a5e0379e74246d1ef1e691e9ca8bf9be244349e5b0599d03773d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->