### PR TITLE
[backend] lower array ownership with SCF loops

### DIFF
--- a/include/Reussir/Conversion/Passes.td
+++ b/include/Reussir/Conversion/Passes.td
@@ -177,6 +177,7 @@ def ReussirAcquireDropExpansionPass : Pass<"reussir-acquire-drop-expansion"> {
               "`rc-decrement-expansion` pass)">,
   ];
   let dependentDialects = ["::reussir::ReussirDialect",
+                           "::mlir::scf::SCFDialect",
                            "::mlir::sync::SyncDialect"];
 }
 

--- a/include/Reussir/IR/ReussirOps.h
+++ b/include/Reussir/IR/ReussirOps.h
@@ -87,10 +87,9 @@ mlir::LogicalResult emitOwnershipAcquisition(mlir::Value value,
                                              mlir::OpBuilder &builder,
                                              mlir::Location loc);
 
-/// Emits a perfectly nested `scf.for` loop over a statically shaped Reussir
-/// array view. `emitElement` is invoked once in the innermost loop with a
-/// reference to the current element.
-mlir::LogicalResult emitArrayElementLoopNest(
+/// Traverses a statically shaped Reussir array view and invokes `emitElement`
+/// with a reference to each element.
+mlir::LogicalResult emitArrayElementTraversal(
     mlir::Value view, mlir::OpBuilder &builder, mlir::Location loc,
     llvm::function_ref<mlir::LogicalResult(mlir::OpBuilder &, mlir::Location,
                                            mlir::Value)>

--- a/include/Reussir/IR/ReussirOps.h
+++ b/include/Reussir/IR/ReussirOps.h
@@ -18,6 +18,7 @@
 #ifndef REUSSIR_IR_REUSSIROPS_H
 #define REUSSIR_IR_REUSSIROPS_H
 
+#include <llvm/ADT/STLFunctionalExtras.h>
 #include <llvm/IR/Module.h>
 #include <mlir/Bytecode/BytecodeOpInterface.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
@@ -85,6 +86,15 @@ void inheritSanitizerPassthrough(mlir::ModuleOp moduleOp,
 mlir::LogicalResult emitOwnershipAcquisition(mlir::Value value,
                                              mlir::OpBuilder &builder,
                                              mlir::Location loc);
+
+/// Emits a perfectly nested `scf.for` loop over a statically shaped Reussir
+/// array view. `emitElement` is invoked once in the innermost loop with a
+/// reference to the current element.
+mlir::LogicalResult emitArrayElementLoopNest(
+    mlir::Value view, mlir::OpBuilder &builder, mlir::Location loc,
+    llvm::function_ref<mlir::LogicalResult(mlir::OpBuilder &, mlir::Location,
+                                           mlir::Value)>
+        emitElement);
 
 //===----------------------------------------------------------------------===//
 // createDtorIfNotExists

--- a/lib/Conversion/AcquireDropExpansion/AcquireDropExpansion.cpp
+++ b/lib/Conversion/AcquireDropExpansion/AcquireDropExpansion.cpp
@@ -119,37 +119,13 @@ private:
                                                  arrayType.getElementType()),
                            op.getRef())
                            .getView();
-    auto recurse = [&](auto &&self, mlir::Value currentView,
-                       ArrayType currentType) -> mlir::LogicalResult {
-      for (int64_t index :
-           llvm::seq<int64_t>(0, currentType.getShape().front())) {
-        auto idx =
-            mlir::arith::ConstantIndexOp::create(rewriter, op.getLoc(), index);
-        if (currentType.getRank() == 1) {
-          RefType projectedRefType = rewriter.getType<RefType>(
-              currentType.getElementType(), Capability::unspecified);
-          auto projected = ReussirArrayProjectOp::create(
-              rewriter, op.getLoc(), projectedRefType, currentView,
-              idx.getResult());
-          if (!isTriviallyCopyable(currentType.getElementType()))
-            ReussirRefDropOp::create(rewriter, op.getLoc(),
-                                     projected.getProjected());
-          continue;
-        }
-        auto droppedType = currentType.dropFront();
-        auto projected = ReussirArrayProjectOp::create(
-            rewriter, op.getLoc(),
-            mlir::MemRefType::get(droppedType.getShape(),
-                                  droppedType.getElementType()),
-            currentView, idx.getResult());
-        if (mlir::failed(
-                self(self, projected.getProjected(), currentType.dropFront())))
-          return mlir::failure();
-      }
-      return mlir::success();
-    };
-
-    if (mlir::failed(recurse(recurse, view, arrayType)))
+    if (mlir::failed(emitArrayElementLoopNest(
+            view, rewriter, op.getLoc(),
+            [&](mlir::OpBuilder &bodyBuilder, mlir::Location bodyLoc,
+                mlir::Value elementRef) {
+              ReussirRefDropOp::create(bodyBuilder, bodyLoc, elementRef);
+              return mlir::success();
+            })))
       return mlir::failure();
     rewriter.eraseOp(op);
     return mlir::success();

--- a/lib/Conversion/AcquireDropExpansion/AcquireDropExpansion.cpp
+++ b/lib/Conversion/AcquireDropExpansion/AcquireDropExpansion.cpp
@@ -119,7 +119,7 @@ private:
                                                  arrayType.getElementType()),
                            op.getRef())
                            .getView();
-    if (mlir::failed(emitArrayElementLoopNest(
+    if (mlir::failed(emitArrayElementTraversal(
             view, rewriter, op.getLoc(),
             [&](mlir::OpBuilder &bodyBuilder, mlir::Location bodyLoc,
                 mlir::Value elementRef) {

--- a/lib/IR/ReussirOps.cpp
+++ b/lib/IR/ReussirOps.cpp
@@ -3193,7 +3193,7 @@ mlir::LogicalResult emitOwnershipAcquisition(mlir::Value value,
 static mlir::LogicalResult
 emitArrayOwnershipAcquisition(mlir::Value view, mlir::OpBuilder &builder,
                               mlir::Location loc) {
-  return emitArrayElementLoopNest(
+  return emitArrayElementTraversal(
       view, builder, loc,
       [&](mlir::OpBuilder &bodyBuilder, mlir::Location bodyLoc,
           mlir::Value elementRef) {
@@ -3201,7 +3201,9 @@ emitArrayOwnershipAcquisition(mlir::Value view, mlir::OpBuilder &builder,
       });
 }
 
-mlir::LogicalResult emitArrayElementLoopNest(
+static constexpr int64_t kArrayOwnershipUnrollThreshold = 4;
+
+mlir::LogicalResult emitArrayElementTraversal(
     mlir::Value view, mlir::OpBuilder &builder, mlir::Location loc,
     llvm::function_ref<mlir::LogicalResult(mlir::OpBuilder &, mlir::Location,
                                            mlir::Value)>
@@ -3209,6 +3211,39 @@ mlir::LogicalResult emitArrayElementLoopNest(
   auto viewType = llvm::cast<mlir::MemRefType>(view.getType());
   ArrayType arrayType = ArrayType::get(
       builder.getContext(), viewType.getShape(), viewType.getElementType());
+
+  if (viewType.getNumElements() < kArrayOwnershipUnrollThreshold) {
+    auto emitDimension =
+        [&](auto &&self, mlir::Value currentView, ArrayType currentType,
+            mlir::OpBuilder &currentBuilder) -> mlir::LogicalResult {
+      int64_t extent = currentType.getShape().front();
+      for (int64_t index : llvm::seq<int64_t>(0, extent)) {
+        auto indexValue =
+            mlir::arith::ConstantIndexOp::create(currentBuilder, loc, index);
+        if (currentType.getRank() == 1) {
+          RefType elementRefType = RefType::get(currentBuilder.getContext(),
+                                                currentType.getElementType(),
+                                                Capability::unspecified);
+          auto elementRef = ReussirArrayProjectOp::create(
+              currentBuilder, loc, elementRefType, currentView, indexValue);
+          if (mlir::failed(
+                  emitElement(currentBuilder, loc, elementRef.getProjected())))
+            return mlir::failure();
+        } else {
+          ArrayType nestedType = currentType.dropFront();
+          auto nestedView = ReussirArrayProjectOp::create(
+              currentBuilder, loc, getArrayViewMemRefType(nestedType),
+              currentView, indexValue);
+          if (mlir::failed(self(self, nestedView.getProjected(), nestedType,
+                                currentBuilder)))
+            return mlir::failure();
+        }
+      }
+      return mlir::success();
+    };
+    return emitDimension(emitDimension, view, arrayType, builder);
+  }
+
   auto lower = mlir::arith::ConstantIndexOp::create(builder, loc, 0);
   auto step = mlir::arith::ConstantIndexOp::create(builder, loc, 1);
   llvm::SmallVector<mlir::Value> lowerBounds(arrayType.getRank(), lower);

--- a/lib/IR/ReussirOps.cpp
+++ b/lib/IR/ReussirOps.cpp
@@ -32,6 +32,7 @@
 #include <llvm/Support/raw_ostream.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/Dialect/LLVMIR/LLVMAttrs.h>
+#include <mlir/Dialect/SCF/IR/SCF.h>
 #include <mlir/IR/Attributes.h>
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/BuiltinAttributes.h>
@@ -3192,31 +3193,60 @@ mlir::LogicalResult emitOwnershipAcquisition(mlir::Value value,
 static mlir::LogicalResult
 emitArrayOwnershipAcquisition(mlir::Value view, mlir::OpBuilder &builder,
                               mlir::Location loc) {
+  return emitArrayElementLoopNest(
+      view, builder, loc,
+      [&](mlir::OpBuilder &bodyBuilder, mlir::Location bodyLoc,
+          mlir::Value elementRef) {
+        return emitOwnershipAcquisition(elementRef, bodyBuilder, bodyLoc);
+      });
+}
+
+mlir::LogicalResult emitArrayElementLoopNest(
+    mlir::Value view, mlir::OpBuilder &builder, mlir::Location loc,
+    llvm::function_ref<mlir::LogicalResult(mlir::OpBuilder &, mlir::Location,
+                                           mlir::Value)>
+        emitElement) {
   auto viewType = llvm::cast<mlir::MemRefType>(view.getType());
   ArrayType arrayType = ArrayType::get(
       builder.getContext(), viewType.getShape(), viewType.getElementType());
-  auto *context = builder.getContext();
-  for (int64_t index : llvm::seq<int64_t>(0, arrayType.getShape().front())) {
-    auto idx = mlir::arith::ConstantIndexOp::create(builder, loc, index);
-    if (arrayType.getRank() == 1) {
-      RefType projectedType = RefType::get(context, arrayType.getElementType(),
-                                           Capability::unspecified);
-      auto elementRef = ReussirArrayProjectOp::create(
-          builder, loc, projectedType, view, idx.getResult());
-      if (emitOwnershipAcquisition(elementRef.getProjected(), builder, loc)
-              .failed())
-        return mlir::failure();
-      continue;
-    }
+  auto lower = mlir::arith::ConstantIndexOp::create(builder, loc, 0);
+  auto step = mlir::arith::ConstantIndexOp::create(builder, loc, 1);
+  llvm::SmallVector<mlir::Value> lowerBounds(arrayType.getRank(), lower);
+  llvm::SmallVector<mlir::Value> upperBounds;
+  llvm::SmallVector<mlir::Value> steps(arrayType.getRank(), step);
+  upperBounds.reserve(arrayType.getRank());
+  for (int64_t extent : arrayType.getShape())
+    upperBounds.push_back(
+        mlir::arith::ConstantIndexOp::create(builder, loc, extent));
 
-    auto projectedType = getArrayViewMemRefType(arrayType.dropFront());
-    auto nestedView = ReussirArrayProjectOp::create(builder, loc, projectedType,
-                                                    view, idx.getResult());
-    if (emitArrayOwnershipAcquisition(nestedView.getProjected(), builder, loc)
-            .failed())
-      return mlir::failure();
-  }
-  return mlir::success();
+  mlir::LogicalResult bodyResult = mlir::success();
+  mlir::scf::buildLoopNest(
+      builder, loc, lowerBounds, upperBounds, steps,
+      [&](mlir::OpBuilder &bodyBuilder, mlir::Location bodyLoc,
+          mlir::ValueRange indices) {
+        mlir::Value currentView = view;
+        ArrayType currentType = arrayType;
+        for (mlir::Value index : indices) {
+          if (currentType.getRank() == 1) {
+            RefType elementRefType = RefType::get(bodyBuilder.getContext(),
+                                                  currentType.getElementType(),
+                                                  Capability::unspecified);
+            currentView = ReussirArrayProjectOp::create(bodyBuilder, bodyLoc,
+                                                        elementRefType,
+                                                        currentView, index)
+                              .getProjected();
+          } else {
+            currentType = currentType.dropFront();
+            currentView =
+                ReussirArrayProjectOp::create(
+                    bodyBuilder, bodyLoc, getArrayViewMemRefType(currentType),
+                    currentView, index)
+                    .getProjected();
+          }
+        }
+        bodyResult = emitElement(bodyBuilder, bodyLoc, currentView);
+      });
+  return bodyResult;
 }
 
 //===----------------------------------------------------------------------===//

--- a/tests/integration/conversion/array_managed_elements.mlir
+++ b/tests/integration/conversion/array_managed_elements.mlir
@@ -1,9 +1,10 @@
-// RUN: %reussir-opt %s --reussir-acquire-drop-expansion | %FileCheck %s --check-prefix=ACQ2D --check-prefix=DROP32
+// RUN: %reussir-opt %s --reussir-acquire-drop-expansion | %FileCheck %s --check-prefix=ACQ2D --check-prefix=UNROLL3 --check-prefix=DROP32
 // RUN: %reussir-opt %s --reussir-convert-to-std --reussir-acquire-drop-expansion | %FileCheck %s --check-prefix=CLONE
 // RUN: %reussir-opt %s --reussir-acquire-drop-expansion --convert-scf-to-cf | %FileCheck %s --check-prefix=CF
 
 !elt = !reussir.rc<i64>
 !arr2 = !reussir.array<2 x !elt>
+!arr3 = !reussir.array<3 x !elt>
 !arr32 = !reussir.array<32 x !elt>
 !arr2x2 = !reussir.array<2 x 2 x !elt>
 !rc_arr2 = !reussir.rc<!arr2>
@@ -18,6 +19,21 @@ module {
   // ACQ2D: reussir.rc.inc
   func.func @acquire_2d(%xs: !reussir.ref<!arr2x2>) {
     reussir.ref.acquire (%xs : !reussir.ref<!arr2x2>)
+    return
+  }
+
+  // UNROLL3-LABEL: func.func @drop_3(
+  // UNROLL3-NOT: scf.for
+  // UNROLL3: reussir.rc.dec
+  // UNROLL3-NOT: scf.for
+  // UNROLL3: reussir.rc.dec
+  // UNROLL3-NOT: scf.for
+  // UNROLL3: reussir.rc.dec
+  // UNROLL3-NOT: scf.for
+  // UNROLL3-NOT: reussir.rc.dec
+  // UNROLL3: return
+  func.func @drop_3(%xs: !reussir.ref<!arr3>) {
+    reussir.ref.drop (%xs : !reussir.ref<!arr3>)
     return
   }
 
@@ -51,9 +67,12 @@ module {
   // CLONE: %[[DST_BORROW:.+]] = reussir.rc.borrow(%[[CLONED]] : !reussir.rc<!reussir.array<2 x !reussir.rc<i64>>>) : !reussir.ref<!reussir.array<2 x !reussir.rc<i64>>>
   // CLONE: reussir.ref.memcpy %[[SRC_BORROW]] to %[[DST_BORROW]] : <!reussir.array<2 x !reussir.rc<i64>>> to <!reussir.array<2 x !reussir.rc<i64>>>
   // CLONE: %[[CLONED_VIEW:.+]] = reussir.array.view(%[[DST_BORROW]] : !reussir.ref<!reussir.array<2 x !reussir.rc<i64>>>) : memref<2x!reussir.rc<i64>>
-  // CLONE: scf.for %[[CLONE_INDEX:.+]] =
-  // CLONE: reussir.array.project(%[[CLONED_VIEW]]{{.*}}) [%[[CLONE_INDEX]] : index]
+  // CLONE-NOT: scf.for
+  // CLONE: reussir.array.project(%[[CLONED_VIEW]]
   // CLONE: reussir.rc.inc
+  // CLONE: reussir.array.project(%[[CLONED_VIEW]]
+  // CLONE: reussir.rc.inc
+  // CLONE-NOT: scf.for
   // CLONE: %[[COUNT:.+]] = reussir.rc.fetch(%arg0 : !reussir.rc<!reussir.array<2 x !reussir.rc<i64>>>) : index
   // CLONE: reussir.rc.set(%arg0 : !reussir.rc<!reussir.array<2 x !reussir.rc<i64>>>,
   // CLONE: scf.yield %[[CLONED]] : !reussir.rc<!reussir.array<2 x !reussir.rc<i64>>>

--- a/tests/integration/conversion/array_managed_elements.mlir
+++ b/tests/integration/conversion/array_managed_elements.mlir
@@ -1,37 +1,42 @@
-// RUN: %reussir-opt %s --reussir-acquire-drop-expansion | %FileCheck %s --check-prefix=ACQ2D --check-prefix=DROP1D
+// RUN: %reussir-opt %s --reussir-acquire-drop-expansion | %FileCheck %s --check-prefix=ACQ2D --check-prefix=DROP32
 // RUN: %reussir-opt %s --reussir-convert-to-std --reussir-acquire-drop-expansion | %FileCheck %s --check-prefix=CLONE
+// RUN: %reussir-opt %s --reussir-acquire-drop-expansion --convert-scf-to-cf | %FileCheck %s --check-prefix=CF
 
 !elt = !reussir.rc<i64>
 !arr2 = !reussir.array<2 x !elt>
+!arr32 = !reussir.array<32 x !elt>
 !arr2x2 = !reussir.array<2 x 2 x !elt>
 !rc_arr2 = !reussir.rc<!arr2>
 
 module {
   // ACQ2D-LABEL: func.func @acquire_2d(
-  // ACQ2D: reussir.array.view
-  // ACQ2D: reussir.array.project
-  // ACQ2D: reussir.array.project
-  // ACQ2D: reussir.rc.inc
-  // ACQ2D: reussir.array.project
-  // ACQ2D: reussir.rc.inc
-  // ACQ2D: reussir.array.project
-  // ACQ2D: reussir.array.project
-  // ACQ2D: reussir.rc.inc
-  // ACQ2D: reussir.array.project
+  // ACQ2D: %[[VIEW:.+]] = reussir.array.view
+  // ACQ2D: scf.for %[[ROW:.+]] =
+  // ACQ2D: scf.for %[[COLUMN:.+]] =
+  // ACQ2D: %[[ROW_VIEW:.+]] = reussir.array.project(%[[VIEW]]{{.*}}) [%[[ROW]] : index]
+  // ACQ2D: %[[ELEMENT:.+]] = reussir.array.project(%[[ROW_VIEW]]{{.*}}) [%[[COLUMN]] : index]
   // ACQ2D: reussir.rc.inc
   func.func @acquire_2d(%xs: !reussir.ref<!arr2x2>) {
     reussir.ref.acquire (%xs : !reussir.ref<!arr2x2>)
     return
   }
 
-  // DROP1D-LABEL: func.func @drop_1d(
-  // DROP1D: reussir.array.view
-  // DROP1D: reussir.array.project
-  // DROP1D: reussir.rc.dec
-  // DROP1D: reussir.array.project
-  // DROP1D: reussir.rc.dec
-  func.func @drop_1d(%xs: !reussir.ref<!arr2>) {
-    reussir.ref.drop (%xs : !reussir.ref<!arr2>)
+  // DROP32-LABEL: func.func @drop_32(
+  // DROP32: %[[DROP_VIEW:.+]] = reussir.array.view
+  // DROP32: scf.for %[[INDEX:.+]] =
+  // DROP32: reussir.array.project(%[[DROP_VIEW]]{{.*}}) [%[[INDEX]] : index]
+  // DROP32: reussir.rc.dec
+  // DROP32-NOT: reussir.rc.dec
+  // DROP32: return
+  // CF-LABEL: func.func @drop_32(
+  // CF: cf.br ^[[HEADER:bb[0-9]+]](
+  // CF: ^[[HEADER]](%[[IV:[0-9]+]]: index):
+  // CF: cf.cond_br
+  // CF: reussir.array.project{{.*}}[%[[IV]] : index]
+  // CF: reussir.rc.dec
+  // CF: cf.br ^[[HEADER]](
+  func.func @drop_32(%xs: !reussir.ref<!arr32>) {
+    reussir.ref.drop (%xs : !reussir.ref<!arr32>)
     return
   }
 
@@ -45,8 +50,9 @@ module {
   // CLONE: %[[CLONED:.+]] = reussir.rc.create value(%[[POISON]] : !reussir.array<2 x !reussir.rc<i64>>) token(%[[TOKEN]] : !reussir.token<align : 8, size : 24>) : !reussir.rc<!reussir.array<2 x !reussir.rc<i64>>>
   // CLONE: %[[DST_BORROW:.+]] = reussir.rc.borrow(%[[CLONED]] : !reussir.rc<!reussir.array<2 x !reussir.rc<i64>>>) : !reussir.ref<!reussir.array<2 x !reussir.rc<i64>>>
   // CLONE: reussir.ref.memcpy %[[SRC_BORROW]] to %[[DST_BORROW]] : <!reussir.array<2 x !reussir.rc<i64>>> to <!reussir.array<2 x !reussir.rc<i64>>>
-  // CLONE: reussir.array.view(%[[DST_BORROW]] : !reussir.ref<!reussir.array<2 x !reussir.rc<i64>>>) : memref<2x!reussir.rc<i64>>
-  // CLONE: reussir.rc.inc
+  // CLONE: %[[CLONED_VIEW:.+]] = reussir.array.view(%[[DST_BORROW]] : !reussir.ref<!reussir.array<2 x !reussir.rc<i64>>>) : memref<2x!reussir.rc<i64>>
+  // CLONE: scf.for %[[CLONE_INDEX:.+]] =
+  // CLONE: reussir.array.project(%[[CLONED_VIEW]]{{.*}}) [%[[CLONE_INDEX]] : index]
   // CLONE: reussir.rc.inc
   // CLONE: %[[COUNT:.+]] = reussir.rc.fetch(%arg0 : !reussir.rc<!reussir.array<2 x !reussir.rc<i64>>>) : index
   // CLONE: reussir.rc.set(%arg0 : !reussir.rc<!reussir.array<2 x !reussir.rc<i64>>>,


### PR DESCRIPTION
## Summary

- fully unroll ownership traversal for arrays with fewer than 4 total elements and use perfectly nested `scf.for` operations built by `scf::buildLoopNest` for arrays of 4 elements or more
- share the array traversal between acquire, clone, and drop paths
- preserve the Reussir high-level → SCF → CF pipeline and add regression coverage for the unrolled side, the 4-element boundary, multidimensional acquisition, 32-element drop, clone acquisition, and SCF-to-CF conversion

## Code generation and compilation

For the exported `HashMap<Key, i64>::insert` specialization:

| Metric | Compile-time unrolling | Thresholded SCF lowering | Change |
|---|---:|---:|---:|
| Aggressive object text | 94,492 B | 26,278 B | -72.2% |
| Default object text | 71,046 B | 19,654 B | -72.3% |
| Aggressive + reuse compile median | 1,347 ms | 289 ms | 4.66x faster |
| Default compile median | 1,048 ms | 223 ms | 4.69x faster |

Compilation timings are end-to-end object generation with 3 warmups and 20 alternating samples per compiler/profile. The size measurements remain unchanged with the threshold because A4 is on the structured side of the boundary.

## Testing

- `cmake --build build --target reussir-opt rrc -j 2`
- `python3 tests/integration/lit -sv build/tests/integration/` — 502 passed, 6 unsupported

Unit tests were not run per request.