### PR TITLE
[frontend][tests] `&&` and `||` short-circuit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 ### Language
 
+- `&&` and `||` now short-circuit. Elaboration desugars them into the
+  conditional — `l && r` to `if l { r } else { false }` and `l || r` to
+  `if l { true } else { r }` — so the right operand becomes a branch body
+  and lowers to `scf.if` like every other conditional. They previously
+  elaborated to `ArithOp::And`/`Or` alongside the bitwise operators and
+  emitted `arith.andi`/`arith.ori`, which evaluate both operands: a guard
+  such as `d != 0 && n / d > 1` divided by zero, and an early-exit
+  traversal written with `||` visited every node. The eager `ArithOp`
+  forms stay reachable from hand-written HIR/MIR text, where they keep
+  their bitwise meaning.
 - Record fields now carry visibility: fields default to private and accept a
   leading `pub` marker. A private field is accessible (projection,
   assignment, construction) only from the record's defining module and its

--- a/crates/reussir-core/src/semi/check.rs
+++ b/crates/reussir-core/src/semi/check.rs
@@ -506,7 +506,12 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
     /// Binary operators synthesize:
     /// (ARITH) `op∈{+,-,*,/,%}`: `l ⇒ T`, `Num ⊳ T`, `r ⇐ T`, result `T`.
     /// (BIT) `op∈{&,|,^,<<,>>}`: `l ⇒ T`, `Integral ⊳ T`, `r ⇐ T`, result `T`.
-    /// (LOGIC) `op∈{&&,||}`: `l ⇐ Bool`, `r ⇐ Bool`, result `Bool`.
+    /// (LOGIC) `op∈{&&,||}`: `l ⇐ Bool`, `r ⇐ Bool`, result `Bool`, and the
+    /// pair desugars to (IF) so it short-circuits — `l && r` elaborates to
+    /// `if l { r } else { false }` and `l || r` to `if l { true } else { r }`,
+    /// putting the right operand in a branch that only runs when the left one
+    /// leaves the answer open. The strict `ArithOp::And`/`Or` remain reachable
+    /// from hand-written HIR/MIR text, where they mean the eager bitwise form.
     /// (CMP-SCALAR) comparisons with `l ⇒ T` for scalar-or-hole `T`: `r ⇐ T`, result
     /// `Bool`, lowered intrinsically; equality registers `PartialEq ⊳ T`, orderings
     /// `PartialOrd ⊳ T`.
@@ -542,12 +547,28 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 self.mk_expr(ExprKind::Arith(Box::new(l), aop, Box::new(r)), ty, span)
             }
             BinOp::And | BinOp::Or => {
+                // (LOGIC) is sugar for (IF), which is what makes it
+                // short-circuiting: the right operand becomes a branch body,
+                // so it is evaluated only when the left operand does not
+                // already decide the result. Emitting `Arith` here instead —
+                // `arith.andi`/`arith.ori` — would evaluate both sides, which
+                // is a different language.
                 let bool_ty = self.tcx.mk_bool();
                 let l = self.check_expr(l, bool_ty);
                 let r = self.check_expr(r, bool_ty);
-                let aop = arith_op(op);
+                let shortcut = self.mk_expr(
+                    ExprKind::ConstBool(matches!(op, BinOp::Or)),
+                    bool_ty,
+                    span,
+                );
+                let (t, f) = match op {
+                    // `l && r` ⇒ `if l { r } else { false }`
+                    BinOp::And => (r, shortcut),
+                    // `l || r` ⇒ `if l { true } else { r }`
+                    _ => (shortcut, r),
+                };
                 self.mk_expr(
-                    ExprKind::Arith(Box::new(l), aop, Box::new(r)),
+                    ExprKind::If(Box::new(l), Box::new(t), Box::new(f)),
                     bool_ty,
                     span,
                 )
@@ -3790,8 +3811,12 @@ fn arith_op(op: BinOp) -> ArithOp {
         BinOp::Mul => ArithOp::Mul,
         BinOp::Div => ArithOp::Div,
         BinOp::Mod => ArithOp::Mod,
-        BinOp::And => ArithOp::And,
-        BinOp::Or => ArithOp::Or,
+        // `&&`/`||` deliberately do not route here: (LOGIC) desugars them to
+        // (IF) so they short-circuit, and mapping them onto the eager
+        // `ArithOp::And`/`Or` is exactly the bug that desugaring fixed.
+        BinOp::And | BinOp::Or => {
+            unreachable!("`&&`/`||` elaborate to `If`, never to `Arith`")
+        }
         BinOp::BitAnd => ArithOp::BitAnd,
         BinOp::BitOr => ArithOp::BitOr,
         BinOp::BitXor => ArithOp::BitXor,

--- a/tests/integration/frontend/short_circuit.c
+++ b/tests/integration/frontend/short_circuit.c
@@ -1,0 +1,44 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+/* Each case reports `evaluations of the right operand * 10 + result bit`, so
+   a failure says whether the answer or the path to it was wrong. */
+extern int64_t and_short_ffi(void);
+extern int64_t and_full_ffi(void);
+extern int64_t or_short_ffi(void);
+extern int64_t or_full_ffi(void);
+extern int64_t and_chain_ffi(void);
+extern int64_t mixed_chain_ffi(void);
+extern int64_t guarded_zero_ffi(void);
+extern int64_t guarded_nonzero_ffi(void);
+extern int64_t truth_table_ffi(void);
+
+static void expect(const char *what, int64_t got, int64_t want) {
+  if (got != want) {
+    fprintf(stderr, "FAIL: %s = %lld, want %lld\n", what, (long long)got,
+            (long long)want);
+    abort();
+  }
+}
+
+int main(void) {
+  /* `false && p` — p never runs, result false */
+  expect("and_short", and_short_ffi(), 0);
+  /* `true && p` — p runs once and decides it */
+  expect("and_full", and_full_ffi(), 11);
+  /* `true || p` — p never runs, result true */
+  expect("or_short", or_short_ffi(), 1);
+  /* `false || p` — p runs once and decides it */
+  expect("or_full", or_full_ffi(), 10);
+  /* the first false stops the rest of the chain: one evaluation, not three */
+  expect("and_chain", and_chain_ffi(), 10);
+  /* `true || (p && p)` skips both operands of the right side */
+  expect("mixed_chain", mixed_chain_ffi(), 1);
+  /* the guard holds: a strict `&&` would divide by zero here instead */
+  expect("guarded_zero", guarded_zero_ffi(), 0);
+  expect("guarded_nonzero", guarded_nonzero_ffi(), 1);
+  /* and/or over the full truth table: 0b1000 and 0b1110 */
+  expect("truth_table", truth_table_ffi(), 8 * 100 + 14);
+  return 0;
+}

--- a/tests/integration/frontend/short_circuit.rr
+++ b/tests/integration/frontend/short_circuit.rr
@@ -1,0 +1,154 @@
+// `&&` and `||` short-circuit: the right operand is evaluated only when the
+// left one leaves the answer open. Elaboration desugars the pair into `if`
+// (`l && r` to `if l { r } else { false }`, `l || r` to `if l { true } else
+// { r }`), so the right operand lands in a branch region and lowers to
+// `scf.if` — the same construct every other conditional uses. Before that
+// desugaring both operators emitted `arith.andi`/`arith.ori`, which evaluate
+// both sides.
+//
+// The runtime cases below are the ones a shape check cannot make: a cell
+// counts how many times the right operand actually ran, and `guarded`
+// divides by the very value its left operand tests for zero, so a strict
+// operator traps instead of returning false.
+
+// RUN: %rrc %s --emit hir --no-source-locations -o %t.hir
+// RUN: %FileCheck %s --check-prefix=HIR < %t.hir
+// RUN: %rrc %s --emit mir --no-source-locations -o %t.mir
+// RUN: %FileCheck %s --check-prefix=MIR < %t.mir
+// RUN: %rrc %t.hir --emit mir --no-source-locations -o -
+// RUN: %rrc %s --emit mlir --no-source-locations -o %t.mlir
+// RUN: %FileCheck %s --check-prefix=MLIR < %t.mlir
+
+// RUN: %rrc %s -o %t.o --relocation-mode pic
+// RUN: %cc %t.o %S/short_circuit.c -o %t.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
+// RUN: %t.exe
+// RUN: %rrc %s -o %t.opt.o --relocation-mode pic -Oaggressive
+// RUN: %cc %t.opt.o %S/short_circuit.c -o %t.opt.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
+// RUN: %t.opt.exe
+
+import core::intrinsic::cell;
+
+// The whole operator is one `if` whose else-branch is the constant that
+// settles the result, and whose other branch is the right operand.
+// HIR-LABEL: pub fn #both
+// HIR: if v0 : bool then {
+// HIR-NEXT: v1 : bool
+// HIR-NEXT: } else {
+// HIR-NEXT: false : bool
+pub fn both(a : bool, b : bool) -> bool {
+    a && b
+}
+
+// HIR-LABEL: pub fn #either
+// HIR: if v0 : bool then {
+// HIR-NEXT: true : bool
+// HIR-NEXT: } else {
+// HIR-NEXT: v1 : bool
+pub fn either(a : bool, b : bool) -> bool {
+    a || b
+}
+
+// Neither operator reaches the eager integer forms any more, and both
+// produce a value-carrying `scf.if`.
+// MIR: fn @{{.*}}both
+// MIR: fn @{{.*}}either
+// MLIR-LABEL: func.func @_RC4both
+// MLIR: scf.if %{{.+}} -> (i1)
+// MLIR-LABEL: func.func @_RC6either
+// MLIR: scf.if %{{.+}} -> (i1)
+// MLIR-NOT: arith.andi
+// MLIR-NOT: arith.ori
+
+// Counts its own evaluations, so a test can tell "returned the right answer"
+// from "took the right path to it".
+fn probe(counter : RefCell<i64>, value : bool) -> bool {
+    cell::rmw(counter, |n| n + 1);
+    value
+}
+
+// Each case reports `evaluations * 10 + result`, so a failure names which of
+// the two went wrong rather than collapsing into one boolean.
+fn observe(taken : bool, counter : RefCell<i64>) -> i64 {
+    cell::get(counter) * 10 + (if taken { 1 } else { 0 })
+}
+
+// A false left operand settles `&&`: the right operand must not run.
+pub fn and_short() -> i64 {
+    let c = cell::alloc<RefCell<i64>>(0);
+    let taken = false && probe(c, true);
+    observe(taken, c)
+}
+extern "C" trampoline "and_short_ffi" = and_short;
+
+// A true left operand leaves `&&` open: the right operand decides it.
+pub fn and_full() -> i64 {
+    let c = cell::alloc<RefCell<i64>>(0);
+    let taken = true && probe(c, true);
+    observe(taken, c)
+}
+extern "C" trampoline "and_full_ffi" = and_full;
+
+// A true left operand settles `||`.
+pub fn or_short() -> i64 {
+    let c = cell::alloc<RefCell<i64>>(0);
+    let taken = true || probe(c, false);
+    observe(taken, c)
+}
+extern "C" trampoline "or_short_ffi" = or_short;
+
+// A false left operand leaves `||` open.
+pub fn or_full() -> i64 {
+    let c = cell::alloc<RefCell<i64>>(0);
+    let taken = false || probe(c, false);
+    observe(taken, c)
+}
+extern "C" trampoline "or_full_ffi" = or_full;
+
+// Chained operators short-circuit as a whole: the first false stops `&&` for
+// every operand after it, so exactly one probe runs here.
+pub fn and_chain() -> i64 {
+    let c = cell::alloc<RefCell<i64>>(0);
+    let taken = probe(c, false) && probe(c, true) && probe(c, true);
+    observe(taken, c)
+}
+extern "C" trampoline "and_chain_ffi" = and_chain;
+
+// The mixed chain: `&&` binds tighter, so this is `a || (b && c)`. With `a`
+// true the whole right side is skipped.
+pub fn mixed_chain() -> i64 {
+    let c = cell::alloc<RefCell<i64>>(0);
+    let taken = true || probe(c, true) && probe(c, true);
+    observe(taken, c)
+}
+extern "C" trampoline "mixed_chain_ffi" = mixed_chain;
+
+// The reason the operators exist: the left operand is a precondition for
+// evaluating the right one at all. Under a strict `&&` this divides by zero.
+pub fn guarded(n : i64, d : i64) -> bool {
+    d != 0 && n / d > 1
+}
+
+pub fn guarded_zero() -> i64 {
+    if guarded(10, 0) { 1 } else { 0 }
+}
+extern "C" trampoline "guarded_zero_ffi" = guarded_zero;
+
+pub fn guarded_nonzero() -> i64 {
+    if guarded(10, 2) { 1 } else { 0 }
+}
+extern "C" trampoline "guarded_nonzero_ffi" = guarded_nonzero;
+
+// The values themselves, over the whole truth table, so the desugaring is
+// checked to be the operator it replaced and not merely lazy.
+pub fn truth_table() -> i64 {
+    let and_bits = (if both(true, true) { 8 } else { 0 })
+        + (if both(true, false) { 4 } else { 0 })
+        + (if both(false, true) { 2 } else { 0 })
+        + (if both(false, false) { 1 } else { 0 });
+    let or_bits = (if either(true, true) { 8 } else { 0 })
+        + (if either(true, false) { 4 } else { 0 })
+        + (if either(false, true) { 2 } else { 0 })
+        + (if either(false, false) { 1 } else { 0 });
+    and_bits * 100 + or_bits
+}
+extern "C" trampoline "truth_table_ffi" = truth_table;


### PR DESCRIPTION
## The defect

`&&` and `||` elaborated to `ArithOp::And`/`Or`, alongside the bitwise `&`/`|`, and lowered to `arith.andi`/`arith.ori` — which evaluate **both** operands. The language offered no short-circuiting at all, so the guarding those operators are normally reached for did not work:

```
d != 0 && n / d > 1          // divides by zero when d == 0
opt.is_some() && opt.unwrap() > 0   // runs the unwrap on None
predicate(k) || any(left) || any(right)   // visits every node, never exits early
```

I hit the third one writing an early-exit tree traversal in `std`: a `1e5`-round benchmark that should have been instant ran past 15 minutes, because every `any()` call walked the whole 200k-node set.

## The fix

Elaboration desugars the pair into the conditional it should have been:

- `l && r` → `if l { r } else { false }`
- `l || r` → `if l { true } else { r }`

The right operand becomes a branch body, so it runs only when the left operand leaves the answer open. This needs no new machinery below elaboration — `ExprKind::If` already lowers to a value-carrying `scf.if`, so both operators now go through the same construct as every other conditional:

```mlir
func.func @_RC4both(%arg0: i1, %arg1: i1) -> i1 {
  %0 = scf.if %arg0 -> (i1) {
```

`arith_op` now rejects the two operators outright instead of silently mapping them back onto the eager forms, so the bug cannot be reintroduced by accident.

The eager `ArithOp::And`/`Or` stay in HIR and MIR, reachable from hand-written text, where they keep their bitwise-on-bool meaning.

## Tests

`frontend/short_circuit.rr` covers both halves:

- **Shape** — the `if` in HIR, the `scf.if` in MLIR, and `CHECK-NOT` for any remaining `arith.andi`/`arith.ori`.
- **Behaviour**, which a shape check cannot see — a cell counts how many times the right operand actually ran, across both operators, both outcomes, a chain (`p(false) && p() && p()` runs one probe, not three), a mixed-precedence chain, and the full truth table. `guarded` divides by the very value its left operand tests for zero, so a strict operator traps rather than returning false.

Verified to fire on the unfixed compiler: the counter reads one evaluation where it should read none (`FAIL: and_short = 10, want 0`), and the HIR check finds `&&` where it expects `if`.

Full lit suite: **502 passed, 6 unsupported, 1 failure**. `reussir-core`: 462 unit tests pass.

The one lit failure is `sanitizer/e2e/cells_sync_parallel.rr` (`LeakSanitizer: 112 byte(s) leaked in 1 allocation(s)`), which is pre-existing on `main` and untouched by this change — confirmed by re-running it against unmodified sources.

Separately, `reussir-ut` has a pre-existing failure on `main` too: `ReussirValueTransformTest.RefToNestedArrayOfRcAcquisition` expects 6 projections and 4 increments but counts 0. That looks like fallout from #563 moving array ownership to SCF loops without updating the counting test — flagging it rather than touching it here.

## Note on environment

This repo needs LLVM 22, which the sandbox did not have and `apt.llvm.org` was unreachable from. The Ubuntu-archive `llvm-toolchain-22` packages link a `libMLIR.so` that needs `GLIBC_2.43` against this host's 2.39, so `reussir-opt`/`reussir-translate` could not link from them; conda-forge's `llvmdev=22.1.6` + `mlir=22.1.6` are built against glibc 2.14 and work. Mentioning it in case it helps anyone else reproducing outside CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BS4Vq7uK2ZsmedjfApLr8w

---
_Generated by [Claude Code](https://claude.ai/code/session_01BS4Vq7uK2ZsmedjfApLr8w)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/564"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789062451&installation_model_id=426051&pr_number=564&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F564&signature=ef6515707ad3be5bb2c34d1d0a69318bd249594091a793cd47d08e8f9bea5276"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->