### PR TITLE
[std] rebuild WavlMap on a bottom-up zipper; decompose update wrappers first

### DIFF
--- a/library/std/src/collections/pure/wavlmap.rr
+++ b/library/std/src/collections/pure/wavlmap.rr
@@ -1,9 +1,16 @@
 //! A persistent ordered map on a WAVL (weak AVL) tree.
 //!
-//! Same tree discipline as `wavlset` (see there for the measured
-//! rationale for choosing WAVL in its recursive formulation): ranks with
-//! differences of 1 or 2, leaves at rank 0, at most two rotations per
-//! update. Nodes additionally carry the mapped value.
+//! Same tree discipline as `wavlset`: ranks with differences of 1 or 2,
+//! leaves at rank 0, at most two rotations per update. Nodes additionally
+//! carry the mapped value. Unlike `wavlset`, updates run bottom-up over an
+//! explicit zipper rather than by recursion: the recursive formulation
+//! threads a `Changed` result through every level, a shape whose
+//! intermediate binding currently defeats reuse inference (each level then
+//! allocates; ~9% of update time surfaced inside the allocator and the
+//! ordered-map benchmark ran 2.7x slower). The zipper builds one result
+//! value per operation at the point the outcome is decided, keeps every
+//! frame node-sized for 1:1 reuse, and measured fastest of the recursive,
+//! flag-free, and zipper formulations tried.
 //!
 //! Unlike `wavlset`, the map stores the rank as a **field** rather than
 //! encoding its parity in the variant tag, and that difference is
@@ -81,375 +88,358 @@ fn rank<K, V>(t : Tree<K, V>) -> i64 {
     }
 }
 
-fn bal_left_ins<K, V>(
-    r : i64,
-    l : Tree<K, V>,
-    k : K,
-    v : V,
-    rt : Tree<K, V>
-) -> Tree<K, V> {
-    match l {
-        Tree::Leaf => Tree::Node { r, Tree::Leaf, k, v, rt },
-        Tree::Node(lrank, ll, lk, lv, lrt) => {
-            if r - lrank >= 1 {
-                Tree::Node { r, Tree::Node { lrank, ll, lk, lv, lrt }, k, v, rt }
-            } else {
-                if r - rank(rt) == 1 {
-                    Tree::Node {
-                        r + 1,
-                        Tree::Node { lrank, ll, lk, lv, lrt },
-                        k,
-                        v,
-                        rt
-                    }
-                } else {
-                    if lrank - rank(lrt) == 2 {
-                        Tree::Node {
-                            lrank,
-                            ll,
-                            lk,
-                            lv,
-                            Tree::Node { r - 1, lrt, k, v, rt }
-                        }
-                    } else {
-                        match lrt {
-                            Tree::Node(_, lrl, lrk, lrv, lrr) => Tree::Node {
-                                r,
-                                Tree::Node { r - 1, ll, lk, lv, lrl },
-                                lrk,
-                                lrv,
-                                Tree::Node { r - 1, lrr, k, v, rt }
-                            },
-                            Tree::Leaf => core::intrinsic::panic::panic()
-                        }
-                    }
-                }
-            }
-        }
+// The traversal spine, held as an explicit zipper: each frame records
+// the parent's rank and entry plus the sibling not descended into. The
+// descent is a tail-recursive walk that pushes frames; the way back up
+// is `fixup_ins`/`fixup_del`, which promote or demote while a rank rule
+// is violated (amortized O(1) frames) and then fall into `rebuild`, a
+// tight loop that reconstructs the untouched remainder of the spine.
+// Every frame is node-sized, so under uniqueness each rebuilt node
+// reuses a frame's storage and updates allocate nothing.
+enum Path<K, V> {
+    ToL(i64, Path<K, V>, K, V, Tree<K, V>),
+    ToR(i64, Tree<K, V>, K, V, Path<K, V>),
+    Top
+}
+
+fn rebuild<K, V>(z : Path<K, V>, t : Tree<K, V>) -> Tree<K, V> {
+    match z {
+        Path::ToL(r, z1, k, v, rt) => rebuild(z1, Tree::Node { r, t, k, v, rt }),
+        Path::ToR(r, l, k, v, z1) => rebuild(z1, Tree::Node { r, l, k, v, t }),
+        Path::Top => t
     }
 }
 
-fn bal_right_ins<K, V>(
-    r : i64,
-    l : Tree<K, V>,
-    k : K,
-    v : V,
-    rt : Tree<K, V>
-) -> Tree<K, V> {
-    match rt {
-        Tree::Leaf => Tree::Node { r, l, k, v, Tree::Leaf },
-        Tree::Node(rrank, rl, rk, rv, rr) => {
-            if r - rrank >= 1 {
-                Tree::Node { r, l, k, v, Tree::Node { rrank, rl, rk, rv, rr } }
+// Rank fixup after the child under the top frame grew to rank `tr`:
+// promote while the parent would sit at rank difference 0 against a
+// difference-1 sibling, otherwise perform the single or double rotation
+// and stop. Rotation results keep the parent's old rank, so the
+// remaining spine rebuilds unchanged.
+fn fixup_ins<K, V>(z : Path<K, V>, t : Tree<K, V>, tr : i64) -> Tree<K, V> {
+    match z {
+        Path::ToL(r, z1, k, v, rt) =>
+            if r - tr >= 1 {
+                rebuild(z1, Tree::Node { r, t, k, v, rt })
             } else {
-                if r - rank(l) == 1 {
-                    Tree::Node {
-                        r + 1,
-                        l,
-                        k,
-                        v,
-                        Tree::Node { rrank, rl, rk, rv, rr }
-                    }
+                if r - rank(rt) == 1 {
+                    fixup_ins(z1, Tree::Node { r + 1, t, k, v, rt }, r + 1)
                 } else {
-                    if rrank - rank(rl) == 2 {
-                        Tree::Node {
-                            rrank,
-                            Tree::Node { r - 1, l, k, v, rl },
-                            rk,
-                            rv,
-                            rr
-                        }
-                    } else {
-                        match rl {
-                            Tree::Node(_, rll, rlk, rlv, rlr) => Tree::Node {
-                                r,
-                                Tree::Node { r - 1, l, k, v, rll },
-                                rlk,
-                                rlv,
-                                Tree::Node { r - 1, rlr, rk, rv, rr }
+                    match t {
+                        Tree::Node(lrank, ll, lk, lv, lrt) =>
+                            if lrank - rank(lrt) == 2 {
+                                rebuild(z1, Tree::Node {
+                                    lrank,
+                                    ll,
+                                    lk,
+                                    lv,
+                                    Tree::Node { r - 1, lrt, k, v, rt }
+                                })
+                            } else {
+                                match lrt {
+                                    Tree::Node(_, lrl, lrk, lrv, lrr) =>
+                                        rebuild(z1, Tree::Node {
+                                            r,
+                                            Tree::Node { r - 1, ll, lk, lv, lrl },
+                                            lrk,
+                                            lrv,
+                                            Tree::Node { r - 1, lrr, k, v, rt }
+                                        }),
+                                    Tree::Leaf => core::intrinsic::panic::panic()
+                                }
                             },
-                            Tree::Leaf => core::intrinsic::panic::panic()
-                        }
+                        Tree::Leaf => core::intrinsic::panic::panic()
                     }
                 }
-            }
-        }
+            },
+        Path::ToR(r, l, k, v, z1) =>
+            if r - tr >= 1 {
+                rebuild(z1, Tree::Node { r, l, k, v, t })
+            } else {
+                if r - rank(l) == 1 {
+                    fixup_ins(z1, Tree::Node { r + 1, l, k, v, t }, r + 1)
+                } else {
+                    match t {
+                        Tree::Node(rrank, rl, rk, rv, rr) =>
+                            if rrank - rank(rl) == 2 {
+                                rebuild(z1, Tree::Node {
+                                    rrank,
+                                    Tree::Node { r - 1, l, k, v, rl },
+                                    rk,
+                                    rv,
+                                    rr
+                                })
+                            } else {
+                                match rl {
+                                    Tree::Node(_, rll, rlk, rlv, rlr) =>
+                                        rebuild(z1, Tree::Node {
+                                            r,
+                                            Tree::Node { r - 1, l, k, v, rll },
+                                            rlk,
+                                            rlv,
+                                            Tree::Node { r - 1, rlr, rk, rv, rr }
+                                        }),
+                                    Tree::Leaf => core::intrinsic::panic::panic()
+                                }
+                            },
+                        Tree::Leaf => core::intrinsic::panic::panic()
+                    }
+                }
+            },
+        Path::Top => t
     }
 }
 
 struct [value] Changed<K, V> { tree : Tree<K, V>, changed : bool }
 
-fn ins<K : Ord, V>(t : Tree<K, V>, x : K, xv : V) -> Changed<K, V> {
+// The descent is pass-through: the one `Changed` per operation is built
+// where the outcome is decided (fresh leaf or value replace) and tail
+// calls carry it out unchanged, so no per-level result threading exists
+// for the reuse analysis to lose.
+fn ins_at<K : Ord, V>(
+    t : Tree<K, V>,
+    x : K,
+    xv : V,
+    z : Path<K, V>
+) -> Changed<K, V> {
     match t {
         Tree::Leaf => Changed {
-            tree: Tree::Node { 0, Tree::Leaf, x, xv, Tree::Leaf },
+            tree: fixup_ins(z, Tree::Node { 0, Tree::Leaf, x, xv, Tree::Leaf }, 0),
             changed: true
         },
         Tree::Node(r, l, k, v, rt) => match x.cmp(k) {
-            Ordering::Less => {
-                let below = ins(l, x, xv);
-                let sub = below.tree;
-                let changed = below.changed;
-                Changed {
-                    tree: if changed {
-                        bal_left_ins(r, sub, k, v, rt)
-                    } else {
-                        Tree::Node { r, sub, k, v, rt }
-                    },
-                    changed
-                }
-            },
-            Ordering::Greater => {
-                let below = ins(rt, x, xv);
-                let sub = below.tree;
-                let changed = below.changed;
-                Changed {
-                    tree: if changed {
-                        bal_right_ins(r, l, k, v, sub)
-                    } else {
-                        Tree::Node { r, l, k, v, sub }
-                    },
-                    changed
-                }
-            },
+            Ordering::Less => ins_at(l, x, xv, Path::ToL { r, z, k, v, rt }),
+            Ordering::Greater => ins_at(rt, x, xv, Path::ToR { r, l, k, v, z }),
             Ordering::Equal => Changed {
-                tree: Tree::Node { r, l, k, xv, rt },
+                tree: rebuild(z, Tree::Node { r, l, k, xv, rt }),
                 changed: false
             }
         }
     }
 }
 
-fn bal_left_del<K, V>(
-    r : i64,
-    l : Tree<K, V>,
-    k : K,
-    v : V,
-    rt : Tree<K, V>
-) -> Tree<K, V> {
-    let rl = rank(l);
-    if r - rl <= 2 {
-        if r == 1 && rl == 0 - 1 && rank(rt) == 0 - 1 {
-            Tree::Node { 0, l, k, v, rt }
-        } else {
-            Tree::Node { r, l, k, v, rt }
-        }
-    } else {
-        match rt {
-            Tree::Node(yrank, yl, yk, yv, yr) => {
-                if r - yrank == 2 {
-                    Tree::Node {
-                        r - 1,
-                        l,
-                        k,
-                        v,
-                        Tree::Node { yrank, yl, yk, yv, yr }
-                    }
+fn ins<K : Ord, V>(t : Tree<K, V>, x : K, xv : V) -> Changed<K, V> {
+    ins_at(t, x, xv, Path::Top)
+}
+
+// Rank fixup after the child under the top frame shrank: demote or
+// double-demote while a rank-difference-3 violation propagates
+// (amortized O(1) frames), rotate and stop otherwise. The demote cases
+// recurse; every rotation restores the parent's rank so the rest of the
+// spine rebuilds unchanged.
+fn fixup_del<K, V>(z : Path<K, V>, t : Tree<K, V>) -> Tree<K, V> {
+    match z {
+        Path::ToL(r, z1, k, v, rt) => {
+            let tl = rank(t);
+            if r - tl <= 2 {
+                if r == 1 && tl == 0 - 1 && rank(rt) == 0 - 1 {
+                    fixup_del(z1, Tree::Node { 0, t, k, v, rt })
                 } else {
-                    let dyl = yrank - rank(yl);
-                    let dyr = yrank - rank(yr);
-                    if dyl == 2 && dyr == 2 {
-                        Tree::Node {
-                            r - 1,
-                            l,
-                            k,
-                            v,
-                            Tree::Node { yrank - 1, yl, yk, yv, yr }
-                        }
-                    } else {
-                        if dyr == 1 {
-                            let xrank = if rank(l) == 0 - 1 && rank(yl) == 0 - 1 {
-                                0
-                            } else {
-                                r - 1
-                            };
-                            Tree::Node {
-                                r,
-                                Tree::Node { xrank, l, k, v, yl },
-                                yk,
-                                yv,
-                                yr
-                            }
-                        } else {
-                            match yl {
-                                Tree::Node(_, zl, zk, zv, zr) => Tree::Node {
-                                    r,
-                                    Tree::Node { r - 2, l, k, v, zl },
-                                    zk,
-                                    zv,
-                                    Tree::Node { r - 2, zr, yk, yv, yr }
-                                },
-                                Tree::Leaf => core::intrinsic::panic::panic()
-                            }
-                        }
-                    }
+                    rebuild(z1, Tree::Node { r, t, k, v, rt })
                 }
-            },
-            Tree::Leaf => core::intrinsic::panic::panic()
-        }
-    }
-}
-
-fn bal_right_del<K, V>(
-    r : i64,
-    l : Tree<K, V>,
-    k : K,
-    v : V,
-    rt : Tree<K, V>
-) -> Tree<K, V> {
-    let rr = rank(rt);
-    if r - rr <= 2 {
-        if r == 1 && rr == 0 - 1 && rank(l) == 0 - 1 {
-            Tree::Node { 0, l, k, v, rt }
-        } else {
-            Tree::Node { r, l, k, v, rt }
-        }
-    } else {
-        match l {
-            Tree::Node(yrank, yl, yk, yv, yr) => {
-                if r - yrank == 2 {
-                    Tree::Node {
-                        r - 1,
-                        Tree::Node { yrank, yl, yk, yv, yr },
-                        k,
-                        v,
-                        rt
-                    }
-                } else {
-                    let dyl = yrank - rank(yl);
-                    let dyr = yrank - rank(yr);
-                    if dyl == 2 && dyr == 2 {
-                        Tree::Node {
-                            r - 1,
-                            Tree::Node { yrank - 1, yl, yk, yv, yr },
-                            k,
-                            v,
-                            rt
-                        }
-                    } else {
-                        if dyl == 1 {
-                            let xrank = if rank(rt) == 0 - 1 && rank(yr) == 0 - 1 {
-                                0
-                            } else {
-                                r - 1
-                            };
-                            Tree::Node {
-                                r,
-                                yl,
-                                yk,
-                                yv,
-                                Tree::Node { xrank, yr, k, v, rt }
-                            }
+            } else {
+                match rt {
+                    Tree::Node(yrank, yl, yk, yv, yr) =>
+                        if r - yrank == 2 {
+                            fixup_del(z1, Tree::Node {
+                                r - 1,
+                                t,
+                                k,
+                                v,
+                                Tree::Node { yrank, yl, yk, yv, yr }
+                            })
                         } else {
-                            match yr {
-                                Tree::Node(_, zl, zk, zv, zr) => Tree::Node {
-                                    r,
-                                    Tree::Node { r - 2, yl, yk, yv, zl },
-                                    zk,
-                                    zv,
-                                    Tree::Node { r - 2, zr, k, v, rt }
-                                },
-                                Tree::Leaf => core::intrinsic::panic::panic()
+                            let dyl = yrank - rank(yl);
+                            let dyr = yrank - rank(yr);
+                            if dyl == 2 && dyr == 2 {
+                                fixup_del(z1, Tree::Node {
+                                    r - 1,
+                                    t,
+                                    k,
+                                    v,
+                                    Tree::Node { yrank - 1, yl, yk, yv, yr }
+                                })
+                            } else {
+                                if dyr == 1 {
+                                    let xrank = if rank(t) == 0 - 1 && rank(yl) == 0 - 1 {
+                                        0
+                                    } else {
+                                        r - 1
+                                    };
+                                    rebuild(z1, Tree::Node {
+                                        r,
+                                        Tree::Node { xrank, t, k, v, yl },
+                                        yk,
+                                        yv,
+                                        yr
+                                    })
+                                } else {
+                                    match yl {
+                                        Tree::Node(_, zl, zk, zv, zr) =>
+                                            rebuild(z1, Tree::Node {
+                                                r,
+                                                Tree::Node { r - 2, t, k, v, zl },
+                                                zk,
+                                                zv,
+                                                Tree::Node { r - 2, zr, yk, yv, yr }
+                                            }),
+                                        Tree::Leaf => core::intrinsic::panic::panic()
+                                    }
+                                }
                             }
-                        }
-                    }
+                        },
+                    Tree::Leaf => core::intrinsic::panic::panic()
                 }
-            },
-            Tree::Leaf => core::intrinsic::panic::panic()
-        }
-    }
-}
-
-struct [value] DelMin<K, V> { key : K, value : V, tree : Tree<K, V> }
-
-fn del_min<K, V>(t : Tree<K, V>) -> DelMin<K, V> {
-    match t {
-        Tree::Node(_, Tree::Leaf, k, v, rt) =>
-            DelMin { key: k, value: v, tree: rt },
-        Tree::Node(r, l, k, v, rt) => {
-            let least = del_min(l);
-            let m = least.key;
-            let mv = least.value;
-            let sub = least.tree;
-            DelMin { key: m, value: mv, tree: bal_left_del(r, sub, k, v, rt) }
-        },
-        Tree::Leaf => core::intrinsic::panic::panic()
-    }
-}
-
-// The mirror of `del_min`: strip the rightmost entry and rebalance up the
-// right spine.
-fn del_max<K, V>(t : Tree<K, V>) -> DelMin<K, V> {
-    match t {
-        Tree::Node(_, l, k, v, Tree::Leaf) =>
-            DelMin { key: k, value: v, tree: l },
-        Tree::Node(r, l, k, v, rt) => {
-            let greatest = del_max(rt);
-            let m = greatest.key;
-            let mv = greatest.value;
-            let sub = greatest.tree;
-            DelMin { key: m, value: mv, tree: bal_right_del(r, l, k, v, sub) }
-        },
-        Tree::Leaf => core::intrinsic::panic::panic()
-    }
-}
-
-fn remove_root<K, V>(r : i64, l : Tree<K, V>, rt : Tree<K, V>) -> Tree<K, V> {
-    match l {
-        Tree::Leaf => rt,
-        Tree::Node(lrank, ll, lk, lv, lr) => match rt {
-            Tree::Leaf => Tree::Node { lrank, ll, lk, lv, lr },
-            Tree::Node(rrank, rl, rk, rv, rr) => {
-                let least = del_min(Tree::Node { rrank, rl, rk, rv, rr });
-                let m = least.key;
-                let mv = least.value;
-                let sub = least.tree;
-                bal_right_del(
-                    r,
-                    Tree::Node { lrank, ll, lk, lv, lr },
-                    m,
-                    mv,
-                    sub
-                )
             }
+        },
+        Path::ToR(r, l, k, v, z1) => {
+            let tr = rank(t);
+            if r - tr <= 2 {
+                if r == 1 && tr == 0 - 1 && rank(l) == 0 - 1 {
+                    fixup_del(z1, Tree::Node { 0, l, k, v, t })
+                } else {
+                    rebuild(z1, Tree::Node { r, l, k, v, t })
+                }
+            } else {
+                match l {
+                    Tree::Node(yrank, yl, yk, yv, yr) =>
+                        if r - yrank == 2 {
+                            fixup_del(z1, Tree::Node {
+                                r - 1,
+                                Tree::Node { yrank, yl, yk, yv, yr },
+                                k,
+                                v,
+                                t
+                            })
+                        } else {
+                            let dyl = yrank - rank(yl);
+                            let dyr = yrank - rank(yr);
+                            if dyl == 2 && dyr == 2 {
+                                fixup_del(z1, Tree::Node {
+                                    r - 1,
+                                    Tree::Node { yrank - 1, yl, yk, yv, yr },
+                                    k,
+                                    v,
+                                    t
+                                })
+                            } else {
+                                if dyl == 1 {
+                                    let xrank = if rank(t) == 0 - 1 && rank(yr) == 0 - 1 {
+                                        0
+                                    } else {
+                                        r - 1
+                                    };
+                                    rebuild(z1, Tree::Node {
+                                        r,
+                                        yl,
+                                        yk,
+                                        yv,
+                                        Tree::Node { xrank, yr, k, v, t }
+                                    })
+                                } else {
+                                    match yr {
+                                        Tree::Node(_, zl, zk, zv, zr) =>
+                                            rebuild(z1, Tree::Node {
+                                                r,
+                                                Tree::Node { r - 2, yl, yk, yv, zl },
+                                                zk,
+                                                zv,
+                                                Tree::Node { r - 2, zr, k, v, t }
+                                            }),
+                                        Tree::Leaf => core::intrinsic::panic::panic()
+                                    }
+                                }
+                            }
+                        },
+                    Tree::Leaf => core::intrinsic::panic::panic()
+                }
+            }
+        },
+        Path::Top => t
+    }
+}
+
+// Remove the inorder successor along the right subtree's left spine,
+// tracked by an inner zipper. `fixup_del` over the inner spine repairs
+// the splice; resuming through a `ToR` frame continues the same fixup at
+// the removal point, so a rank drop propagates across the join without
+// any per-level result threading.
+fn splice_succ<K, V>(
+    r0 : i64,
+    l0 : Tree<K, V>,
+    z : Path<K, V>,
+    t : Tree<K, V>,
+    rz : Path<K, V>
+) -> Tree<K, V> {
+    match t {
+        Tree::Node(_, Tree::Leaf, mk, mv, mrt) =>
+            fixup_del(Path::ToR { r0, l0, mk, mv, z }, fixup_del(rz, mrt)),
+        Tree::Node(rm, ml, mk, mv, mrt) =>
+            splice_succ(r0, l0, z, ml, Path::ToL { rm, rz, mk, mv, mrt }),
+        Tree::Leaf => core::intrinsic::panic::panic()
+    }
+}
+
+fn remove_at<K, V>(
+    r : i64,
+    l : Tree<K, V>,
+    rt : Tree<K, V>,
+    z : Path<K, V>
+) -> Tree<K, V> {
+    match l {
+        Tree::Leaf => fixup_del(z, rt),
+        ll => match rt {
+            Tree::Leaf => fixup_del(z, ll),
+            rr => splice_succ(r, ll, z, rr, Path::Top)
+        }
+    }
+}
+
+fn del_at<K : Ord, V>(t : Tree<K, V>, x : K, z : Path<K, V>) -> Changed<K, V> {
+    match t {
+        Tree::Leaf => Changed { tree: rebuild(z, Tree::Leaf), changed: false },
+        Tree::Node(r, l, k, v, rt) => match x.cmp(k) {
+            Ordering::Less => del_at(l, x, Path::ToL { r, z, k, v, rt }),
+            Ordering::Greater => del_at(rt, x, Path::ToR { r, l, k, v, z }),
+            Ordering::Equal =>
+                Changed { tree: remove_at(r, l, rt, z), changed: true }
         }
     }
 }
 
 fn del<K : Ord, V>(t : Tree<K, V>, x : K) -> Changed<K, V> {
+    del_at(t, x, Path::Top)
+}
+
+struct [value] DelMin<K, V> { key : K, value : V, tree : Tree<K, V> }
+
+fn del_min_at<K, V>(t : Tree<K, V>, z : Path<K, V>) -> DelMin<K, V> {
     match t {
-        Tree::Leaf => Changed { tree: Tree::Leaf, changed: false },
-        Tree::Node(r, l, k, v, rt) => match x.cmp(k) {
-            Ordering::Less => {
-                let below = del(l, x);
-                let sub = below.tree;
-                let changed = below.changed;
-                Changed {
-                    tree: if changed {
-                        bal_left_del(r, sub, k, v, rt)
-                    } else {
-                        Tree::Node { r, sub, k, v, rt }
-                    },
-                    changed
-                }
-            },
-            Ordering::Greater => {
-                let below = del(rt, x);
-                let sub = below.tree;
-                let changed = below.changed;
-                Changed {
-                    tree: if changed {
-                        bal_right_del(r, l, k, v, sub)
-                    } else {
-                        Tree::Node { r, l, k, v, sub }
-                    },
-                    changed
-                }
-            },
-            Ordering::Equal =>
-                Changed { tree: remove_root(r, l, rt), changed: true }
-        }
+        Tree::Node(_, Tree::Leaf, k, v, rt) =>
+            DelMin { key: k, value: v, tree: fixup_del(z, rt) },
+        Tree::Node(r, l, k, v, rt) =>
+            del_min_at(l, Path::ToL { r, z, k, v, rt }),
+        Tree::Leaf => core::intrinsic::panic::panic()
     }
+}
+
+fn del_min<K, V>(t : Tree<K, V>) -> DelMin<K, V> {
+    del_min_at(t, Path::Top)
+}
+
+// The mirror of `del_min`: strip the rightmost entry and repair up the
+// right spine.
+fn del_max_at<K, V>(t : Tree<K, V>, z : Path<K, V>) -> DelMin<K, V> {
+    match t {
+        Tree::Node(_, l, k, v, Tree::Leaf) =>
+            DelMin { key: k, value: v, tree: fixup_del(z, l) },
+        Tree::Node(r, l, k, v, rt) =>
+            del_max_at(rt, Path::ToR { r, l, k, v, z }),
+        Tree::Leaf => core::intrinsic::panic::panic()
+    }
+}
+
+fn del_max<K, V>(t : Tree<K, V>) -> DelMin<K, V> {
+    del_max_at(t, Path::Top)
 }
 
 fn lookup<K : Ord, V>(t : Tree<K, V>, x : K) -> Option<V> {
@@ -752,9 +742,13 @@ impl<K : Ord, V> WavlMap<K, V> {
 
     /// Adds or replaces the entry for `key`. O(log n).
     pub fn insert(self : Self, key : K, value : V) -> Self {
-        let r = ins(self.root, key, value);
+        // Decompose before mutating: a live `self` across `ins` would keep
+        // the root shared, forcing a path copy per update.
+        let size = self.size;
+        let root = self.root;
+        let r = ins(root, key, value);
         WavlMap {
-            size: if r.changed { self.size + 1 } else { self.size },
+            size: if r.changed { size + 1 } else { size },
             root: r.tree
         }
     }
@@ -784,9 +778,11 @@ impl<K : Ord, V> WavlMap<K, V> {
 
     /// Removes the entry for `key` when present. O(log n).
     pub fn remove(self : Self, key : K) -> Self {
-        let r = del(self.root, key);
+        let size = self.size;
+        let root = self.root;
+        let r = del(root, key);
         WavlMap {
-            size: if r.changed { self.size - 1 } else { self.size },
+            size: if r.changed { size - 1 } else { size },
             root: r.tree
         }
     }

--- a/library/std/src/collections/pure/wavlset.rr
+++ b/library/std/src/collections/pure/wavlset.rr
@@ -734,18 +734,24 @@ impl<T : Ord> WavlSet<T> {
 
     /// Adds `value`, keeping the existing element on equality. O(log n).
     pub fn insert(self : Self, value : T) -> Self {
-        let r = ins(self.root, value);
+        // Decompose before mutating: a live `self` across `ins` would keep
+        // the root shared, forcing a path copy per update.
+        let size = self.size;
+        let root = self.root;
+        let r = ins(root, value);
         WavlSet {
-            size: if r.added { self.size + 1 } else { self.size },
+            size: if r.added { size + 1 } else { size },
             root: r.tree
         }
     }
 
     /// Removes `value` when present. O(log n).
     pub fn remove(self : Self, value : T) -> Self {
-        let r = del(self.root, value);
+        let size = self.size;
+        let root = self.root;
+        let r = del(root, value);
         WavlSet {
-            size: if r.found { self.size - 1 } else { self.size },
+            size: if r.found { size - 1 } else { size },
             root: r.tree
         }
     }


### PR DESCRIPTION
## Summary

Rebuilds `WavlMap`'s insert/remove core on a bottom-up zipper and makes the map/set update wrappers decompose `self` before mutating. Together these take the `ordered-map-linear` std-collections benchmark from **7.98G instructions / 5.64G cycles to 2.83G / 3.09G** (2.8× / 1.8×), which moves the Reussir cell from ~1.5× *slower* than Koka's best WAVL variant to **1.24× faster in cycles**. `ordered-map-shared` — previously anomalously slower than both the linear and heavily-shared tiers — drops from ~1.4–1.6s to ~1.0s.

## The two defects

**1. Per-level `Changed` threading defeats reuse.** The recursive formulation returns `Changed { tree, changed }` at every level. Lowering consumes that result by extracting the tree member (plus an `rc.inc`) while spilling the struct to release it (`ref.load(ref.project(ref.spilled ...))` plus an `rc.dec`). The inc/dec pair is not recognized as cancelable (see #568), so a decrement that observes a shared count at runtime survives into token reuse, where its always-null token out-competes the genuinely live shell token in donor selection: the hot path then **frees the reusable node and mallocs a fresh one at every level** (~9% of update time inside mimalloc's slow paths, +77% instructions vs a flag-free insert).

The zipper dodges this structurally: descent pushes node-sized frames (`ToL`/`ToR`), fixups promote/demote the amortized-O(1) violating prefix and stop, and `rebuild` is a tight match-frame/build-node loop with 1:1 reuse. The one `Changed` per *operation* is built where the outcome is decided and tail-calls carry it out — there is no per-level result for the analysis to lose. Delete's inorder-successor splice runs the same fixup over an inner spine zipper and resumes the outer walk through a single `ToR` frame, so rank drops propagate across the join with no result threading. Measured head-to-head, the zipper is also the fastest of the three formulations tried (recursive, flag-free-insert, zipper), and it beats the same-workload zipper red-black tree by 1.38× in cycles at equal instruction count.

**2. Wrappers kept `self` live across the mutation.** `insert`/`remove` (map and set) read `self.size` *after* passing `self.root` into `ins`/`del`, so the root entered the mutation with count 2 and every operation path-copied ~19 nodes, then recursively dropped the old spine (~19% of runtime in `drop_in_place<Tree>`). The wrappers now bind `size` and `root` first, matching what `pop_min`/`pop_max` and `hashmap.rr`'s `put_map` already do. This alone removed 4.6G instructions per benchmark run.

## Validation

- All six `std-collections` benchmark cells pass their representation-independent checksums, under both `reussir` and `reussir-nrac`, and with both the shipped and the alias-patched compiler.
- `tests/integration/std/wavl.rr`: all 12 inputs pass (including `balance`, which asserts the WAVL height bound, `map_api`'s pop paths, and the `churn` model cross-check).
- An additional drain property test (alternating `pop_min`/`pop_max` over an LCG-churned map, checking order, count, and checksum agreement with `fold_left`) passes.

## Notes

`wavlset` gets only the wrapper fix here; its recursive core still threads `Added`/`Found` result structs. #568 recovers most of that cost at the compiler level; a zipper port of the set is a natural follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
