### PR TITLE
[backend][tests] alias analysis sees a value record's field through its spill

### DIFF
--- a/lib/Analysis/AliasAnalysis.cpp
+++ b/lib/Analysis/AliasAnalysis.cpp
@@ -24,6 +24,8 @@
 #include <llvm/Support/TypeSize.h>
 #include <mlir/Analysis/AliasAnalysis.h>
 #include <mlir/IR/Value.h>
+#include <optional>
+#include <utility>
 
 using namespace mlir;
 
@@ -220,6 +222,38 @@ ReussirAliasAnalysisImpl::getProducerAsRef(TypedValue<RefType> value) {
   return nullptr;
 }
 
+// A by-value record's field read as an SSA extract (`record.extract %s[i]`)
+// and read back through the record's spill
+// (`ref.load(ref.project(ref.spilled %s, [i]))`) produce the same stored
+// pointer. The pair appears wherever a by-value struct result is consumed:
+// the member is extracted for further use while the struct itself is
+// spilled so its release can be decomposed field by field. The two reads
+// must compare MustAlias for the member's retain (issued on the extract)
+// to cancel against the release's decrement (issued on the spilled load) —
+// otherwise the surviving decrement observes a shared count at runtime,
+// never yields a reuse token, and poisons token-donor selection with a
+// statically-plausible but always-null candidate.
+static std::optional<std::pair<Value, uint64_t>> valueRecordField(Value value) {
+  if (auto extractOp = llvm::dyn_cast_if_present<ReussirRecordExtractOp>(
+          value.getDefiningOp()))
+    return std::make_pair(mlir::Value(extractOp.getRecord()),
+                          extractOp.getIndex().getZExtValue());
+  auto loadOp =
+      llvm::dyn_cast_if_present<ReussirRefLoadOp>(value.getDefiningOp());
+  if (!loadOp)
+    return std::nullopt;
+  auto projectOp = llvm::dyn_cast_if_present<ReussirRefProjectOp>(
+      loadOp.getRef().getDefiningOp());
+  if (!projectOp)
+    return std::nullopt;
+  auto spilledOp = llvm::dyn_cast_if_present<ReussirRefSpilledOp>(
+      projectOp.getRef().getDefiningOp());
+  if (!spilledOp)
+    return std::nullopt;
+  return std::make_pair(spilledOp.getValue(),
+                        projectOp.getIndex().getZExtValue());
+}
+
 AliasResult ReussirAliasAnalysisImpl::decideAlias(TypedValue<RcType> lhs,
                                                   TypedValue<RcType> rhs) {
   // If both side stems from a load operation, check if the reference being
@@ -236,6 +270,13 @@ AliasResult ReussirAliasAnalysisImpl::decideAlias(TypedValue<RcType> lhs,
   auto rhsNullable = getProducerAsNullable(rhs);
   if (lhsNullable && rhsNullable)
     return alias(lhsNullable, rhsNullable);
+  // Case 3: the same field of the same by-value record, read directly by
+  // extract on one side and through the record's spill on the other.
+  auto lhsField = valueRecordField(lhs);
+  auto rhsField = valueRecordField(rhs);
+  if (lhsField && rhsField && lhsField->first == rhsField->first &&
+      lhsField->second == rhsField->second)
+    return AliasResult::MustAlias;
   return AliasResult::MayAlias;
 }
 

--- a/tests/integration/conversion/inc_dec_cancellation_through_spilled_extract.mlir
+++ b/tests/integration/conversion/inc_dec_cancellation_through_spilled_extract.mlir
@@ -1,0 +1,66 @@
+// RUN: %reussir-opt %s --reussir-inc-dec-cancellation | %FileCheck %s
+
+// A by-value result struct is consumed by extracting its rc member for
+// further use while the struct itself is spilled so its release can be
+// decomposed field by field:
+//
+//   %m = record.extract %s[0] ; rc.inc(%m)            // retain the member
+//   %f = ref.load(ref.project(ref.spilled %s, [0]))   // the release's view
+//   rc.dec(%f)                                        // release the member
+//
+// `%m` and `%f` read the same stored pointer, so the pair is borrow
+// semantics in disguise and must cancel. Alias analysis proves the two
+// reads MustAlias (same record value, same field index); without that the
+// surviving decrement observes a shared count at runtime, never yields a
+// reuse token, and poisons token-donor selection with a candidate that is
+// null on every execution — an allocation plus a free of the genuinely
+// reusable block per call on result-struct shapes like std's
+// `Changed`/`Inserted`.
+
+!box = !reussir.record<compound "Box" {i64}>
+!pair = !reussir.record<compound "Pair" [value] {!box, i1}>
+!two = !reussir.record<compound "Two" [value] {!box, !box}>
+
+module {
+  // CHECK-LABEL: @cancel_extract_spill_roundtrip
+  func.func @cancel_extract_spill_roundtrip(%s: !pair) -> !reussir.rc<!box> {
+    // CHECK-NOT: reussir.rc.inc
+    // CHECK-NOT: reussir.rc.dec
+    %m = reussir.record.extract(%s : !pair)[0] : !reussir.rc<!box>
+    reussir.rc.inc (%m : !reussir.rc<!box>)
+    %spill = reussir.ref.spilled(%s : !pair) : !reussir.ref<!pair>
+    %slot = reussir.ref.project(%spill : !reussir.ref<!pair>) [0] : !reussir.ref<!reussir.rc<!box>>
+    %f = reussir.ref.load(%slot : !reussir.ref<!reussir.rc<!box>>) : !reussir.rc<!box>
+    reussir.rc.dec (%f : !reussir.rc<!box>)
+    return %m : !reussir.rc<!box>
+  }
+
+  // Distinct fields of the same spill hold distinct pointers: the retain of
+  // field 0 must not cancel against the release of field 1.
+  // CHECK-LABEL: @keep_distinct_fields
+  func.func @keep_distinct_fields(%s: !two) -> !reussir.rc<!box> {
+    // CHECK: reussir.rc.inc
+    // CHECK: reussir.rc.dec
+    %m = reussir.record.extract(%s : !two)[0] : !reussir.rc<!box>
+    reussir.rc.inc (%m : !reussir.rc<!box>)
+    %spill = reussir.ref.spilled(%s : !two) : !reussir.ref<!two>
+    %slot = reussir.ref.project(%spill : !reussir.ref<!two>) [1] : !reussir.ref<!reussir.rc<!box>>
+    %f = reussir.ref.load(%slot : !reussir.ref<!reussir.rc<!box>>) : !reussir.rc<!box>
+    reussir.rc.dec (%f : !reussir.rc<!box>)
+    return %m : !reussir.rc<!box>
+  }
+
+  // Spills of different record values stay unrelated even at equal indices.
+  // CHECK-LABEL: @keep_distinct_records
+  func.func @keep_distinct_records(%s: !pair, %t: !pair) -> !reussir.rc<!box> {
+    // CHECK: reussir.rc.inc
+    // CHECK: reussir.rc.dec
+    %m = reussir.record.extract(%s : !pair)[0] : !reussir.rc<!box>
+    reussir.rc.inc (%m : !reussir.rc<!box>)
+    %spill = reussir.ref.spilled(%t : !pair) : !reussir.ref<!pair>
+    %slot = reussir.ref.project(%spill : !reussir.ref<!pair>) [0] : !reussir.ref<!reussir.rc<!box>>
+    %f = reussir.ref.load(%slot : !reussir.ref<!reussir.rc<!box>>) : !reussir.rc<!box>
+    reussir.rc.dec (%f : !reussir.rc<!box>)
+    return %m : !reussir.rc<!box>
+  }
+}


### PR DESCRIPTION
## Summary

Companion to #567, which fixes the std `WavlMap` at the library level; this PR recovers the idiomatic result-struct style for everything else (`wavlset`, the HAMT, user code) at the compiler level. The two are independent — either lands cleanly without the other.

Teaches the alias analysis that a by-value record's field read as an SSA extract (`record.extract %s[i]`) and read back through the record's spill (`ref.load(ref.project(ref.spilled %s, [i]))`) are the same stored pointer, so they compare `MustAlias`.

The pair appears wherever a by-value result struct is consumed: the member is extracted for further use (with an `rc.inc`) while the struct itself is spilled so its release can be decomposed field by field (ending in an `rc.dec` of the reloaded member). Without the equivalence, `reussir-inc-dec-cancellation` cannot cancel the pair, and the surviving decrement is doubly harmful:

- it costs an rc round-trip per call, and
- after decrement expansion it becomes a token producer whose rc **provably has a live use** (the extracted member) — its nullable token is null on every execution, yet `reussir-token-reuse`'s donor selection can prefer it (DFS-order tiebreak) over the genuinely live destructuring token. The hot path then materializes a `token.free` of the reusable block next to a `token.ensure(null)` that mallocs a fresh one — an allocate/free pair per recursion level.

This is the dominant cost of the idiomatic `Changed`/`Inserted`/`Deleted` result-struct style used throughout `std::collections::pure`.

## Measured effect (std-collections benchmarks, library unchanged)

| benchmark | before | after |
|---|---|---|
| ordered-map workload on the recursive `Changed`-threading WAVL | 5.67G instr / 4.79G cycles, ~9% of time in mimalloc slow paths | **3.02G / 2.56G (−47%)**, allocator traffic gone from the profile |
| `hash-map-linear` (std HAMT, `Inserted`/`Deleted` per level) | 9.69G instr / 6.38G cycles | **7.81G / 6.23G** (−19% instructions) |

The patched compiler makes the result-struct shape faster than the manual flag-free workaround was on the shipped compiler, i.e. the idiomatic style stops carrying a penalty.

## Soundness

The rule fires only when both sides reduce to the *same* record SSA value and the *same* field index — the spill is a pure materialization of that value, so the two reads yield identical pointer bits. It is disjoint from the #290 hazard (a `ref.drop` standing between an inc and a dec of a *possibly contained* rc): that guard keys on the drop op itself and is untouched.

## Testing

- New lit test `inc_dec_cancellation_through_spilled_extract.mlir`: the roundtrip pair cancels; distinct fields of one spill and equal fields of distinct records do not.
- Existing cancellation/token suites pass (`inc_dec_cancellation*.mlir`, `reuse_stopped_by_call.mlir`, `free_token_at_end.mlir`).
- All six `std-collections` benchmark cells pass their checksums when built with the patched compiler, for both the current std and the zipper `WavlMap` rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
