### PR TITLE
[misc] emit structured token-reuse decision reports

### DIFF
--- a/crates/rene/src/compile.rs
+++ b/crates/rene/src/compile.rs
@@ -57,6 +57,8 @@ pub struct Options {
     pub upstream: std::collections::BTreeMap<String, String>,
     /// `rene build -j`: the bound on concurrent compile processes.
     pub jobs: Option<std::num::NonZeroUsize>,
+    /// Produce and cache one token-reuse JSON sidecar per selected product.
+    pub token_reuse_remarks: bool,
     /// Whether compiler diagnostics should retain ANSI styling while they
     /// are buffered away from the terminal.
     pub color: bool,
@@ -79,6 +81,9 @@ pub struct Product {
 pub struct ProductRecord {
     pub fingerprint: String,
     pub path: PathBuf,
+    /// Present only when the compile also produced this diagnostic sidecar.
+    #[serde(default)]
+    pub token_reuse_report: Option<PathBuf>,
 }
 
 /// Build the selected targets, reusing whatever the record proves current.
@@ -123,12 +128,21 @@ pub async fn build(
     for name in selected {
         let kind = manifest.targets[name].kind;
         let path = out_dir.join(artifact_file(name, kind, Some(&opts.target)));
+        let token_reuse_report = opts
+            .token_reuse_remarks
+            .then(|| plan::token_reuse_report_path(&path));
         let key = tables::product_key(&opts.profile_name, name);
-        let current = product_is_current(dir, &key, &fingerprint, &path)?;
+        let current = product_is_current(
+            dir,
+            &key,
+            &fingerprint,
+            &path,
+            token_reuse_report.as_deref(),
+        )?;
         if current {
             tracing::debug!(target = name, "up to date");
         }
-        plan.push((name, kind, path, key, current));
+        plan.push((name, kind, path, token_reuse_report, key, current));
     }
     // The root's commands come from the same synthesis the dump prints
     // (and the dependency pipeline runs): what `inspect --commands` shows
@@ -143,6 +157,7 @@ pub async fn build(
                 target: &opts.target,
                 linker: opts.linker.as_deref(),
                 build_dir: dir.root(),
+                token_reuse_remarks: opts.token_reuse_remarks,
             },
             Some(rt),
         )
@@ -150,7 +165,7 @@ pub async fn build(
         .filter_map(|command| Some((command.target.clone()?, command)))
         .collect();
     let mut invocations = Vec::new();
-    for (name, kind, path, _, current) in &plan {
+    for (name, kind, path, _, _, current) in &plan {
         if *current {
             continue;
         }
@@ -193,11 +208,12 @@ pub async fn build(
         return Err(error);
     }
     let mut products = Vec::with_capacity(plan.len());
-    for (name, _, path, key, current) in plan {
+    for (name, _, path, token_reuse_report, key, current) in plan {
         if !current {
             let record = ProductRecord {
                 fingerprint: fingerprint.clone(),
                 path: path.clone(),
+                token_reuse_report,
             };
             let record = serde_json::to_string(&record).map_err(|e| e.to_string())?;
             dir.set_status(&[(key.as_str(), record.as_str())])
@@ -469,6 +485,7 @@ pub(crate) fn product_is_current(
     key: &str,
     fingerprint: &str,
     path: &Path,
+    token_reuse_report: Option<&Path>,
 ) -> Result<bool, String> {
     let Some(record) = dir.status(key).map_err(|e| e.to_string())? else {
         return Ok(false);
@@ -477,7 +494,13 @@ pub(crate) fn product_is_current(
         // An older rene may have written a different shape; just rebuild.
         return Ok(false);
     };
-    Ok(record.fingerprint == fingerprint && record.path == path && path.is_file())
+    let report_is_current = token_reuse_report.is_none_or(|report| {
+        record.token_reuse_report.as_deref() == Some(report) && report.is_file()
+    });
+    Ok(record.fingerprint == fingerprint
+        && record.path == path
+        && path.is_file()
+        && report_is_current)
 }
 
 /// The artifact's file name for `name`, per the target platform — the

--- a/crates/rene/src/exec.rs
+++ b/crates/rene/src/exec.rs
@@ -42,6 +42,8 @@ pub struct Options<'a> {
     /// `rene build -j`: the process admission bound (held by the [`Pool`]).
     pub jobs: Option<NonZeroUsize>,
     pub build_dir: &'a Path,
+    /// Produce and track token-reuse JSON sidecars for dependency archives.
+    pub token_reuse_remarks: bool,
     /// Whether buffered rrc diagnostics retain ANSI styling.
     pub color: bool,
 }
@@ -143,6 +145,7 @@ async fn build_node(
         target: opts.target,
         linker: opts.linker,
         build_dir: opts.build_dir,
+        token_reuse_remarks: opts.token_reuse_remarks,
     };
     // At this point the node's upstream artifacts are final, so the local
     // check is exact: current means nothing to do at all.
@@ -173,6 +176,7 @@ async fn build_node(
         target: opts.target,
         linker: opts.linker,
         build_dir: opts.build_dir,
+        token_reuse_remarks: opts.token_reuse_remarks,
     };
     for command in plan::node_commands(graph, name, &plan_opts, Some(rt)) {
         bar.set_message(format!("{name}: {}", command.emit));

--- a/crates/rene/src/fresh.rs
+++ b/crates/rene/src/fresh.rs
@@ -115,6 +115,9 @@ pub struct DepRecord {
     /// The interface and archive this build produced.
     pub rri: PathBuf,
     pub archive: PathBuf,
+    /// The optional diagnostic sidecar produced with the archive.
+    #[serde(default)]
+    pub token_reuse_report: Option<PathBuf>,
 }
 
 /// What the check runs against.
@@ -129,6 +132,8 @@ pub struct Context<'a> {
     /// part of the root products' fingerprints.
     pub linker: Option<&'a Path>,
     pub build_dir: &'a Path,
+    /// Require token-reuse sidecars to be present and tied to the last build.
+    pub token_reuse_remarks: bool,
 }
 
 /// The recorded runtime bake, if any — the toolchain identity freshness
@@ -234,6 +239,12 @@ fn dep_state(
             return Ok(State::ArtifactMissing(artifact.display().to_string()));
         }
     }
+    if ctx.token_reuse_remarks {
+        let expected = plan::token_reuse_report_path(&record.archive);
+        if record.token_reuse_report.as_deref() != Some(expected.as_path()) || !expected.is_file() {
+            return Ok(State::ArtifactMissing(expected.display().to_string()));
+        }
+    }
     for dep in &graph.nodes[name].dependencies {
         // Direct edges suffice locally: transitive drift reaches this node
         // through its dependency's own record (and the propagation pass).
@@ -284,6 +295,7 @@ fn root_state(
             linker: ctx.linker.map(Path::to_path_buf),
             upstream,
             jobs: None,
+            token_reuse_remarks: ctx.token_reuse_remarks,
             // Output policy is deliberately absent from the fingerprint.
             color: false,
         },
@@ -292,7 +304,16 @@ fn root_state(
     for (target, decl) in &node.loaded.manifest.targets {
         let key = tables::product_key(ctx.profile_name, target);
         let path = out_dir.join(compile::artifact_file(target, decl.kind, Some(ctx.target)));
-        if !compile::product_is_current(dir, &key, &fingerprint, &path)? {
+        let token_reuse_report = ctx
+            .token_reuse_remarks
+            .then(|| plan::token_reuse_report_path(&path));
+        if !compile::product_is_current(
+            dir,
+            &key,
+            &fingerprint,
+            &path,
+            token_reuse_report.as_deref(),
+        )? {
             return Ok(State::TargetStale(target.clone()));
         }
     }
@@ -325,6 +346,9 @@ pub fn record_dep(
             .collect(),
         rri: deps_dir.join(format!("{name}.rri")),
         archive: plan::archive_path(&deps_dir, name, ctx.target),
+        token_reuse_report: ctx.token_reuse_remarks.then(|| {
+            plan::token_reuse_report_path(&plan::archive_path(&deps_dir, name, ctx.target))
+        }),
     };
     let record = serde_json::to_string(&record).map_err(|e| e.to_string())?;
     let sources = serde_json::to_string(sources).map_err(|e| e.to_string())?;
@@ -476,6 +500,7 @@ mod tests {
             target: TEST_TARGET,
             linker: None,
             build_dir: &f.build_dir,
+            token_reuse_remarks: false,
         }
     }
 

--- a/crates/rene/src/main.rs
+++ b/crates/rene/src/main.rs
@@ -173,6 +173,13 @@ struct BuildArgs {
     /// available parallelism).
     #[arg(short = 'j', long = "jobs")]
     jobs: Option<std::num::NonZeroUsize>,
+
+    /// Ask each artifact-producing rrc invocation to write its token-reuse
+    /// decisions as JSON, for the host or any cross target. Reports are cached
+    /// next to their artifacts as `<artifact>.token-reuse.json` (including
+    /// dependency archives).
+    #[arg(long)]
+    token_reuse_remarks: bool,
 }
 
 /// Delete the build directory, unless another rene is using it.
@@ -229,6 +236,11 @@ struct InspectArgs {
     /// must judge against the same value.
     #[arg(long)]
     linker: Option<PathBuf>,
+
+    /// Render token-reuse JSON side outputs in the command plan and include
+    /// them in freshness checks, matching `rene build --token-reuse-remarks`.
+    #[arg(long)]
+    token_reuse_remarks: bool,
 }
 
 fn main() -> ExitCode {
@@ -425,6 +437,7 @@ async fn build(args: &BuildArgs, color: bool) -> Result<(), String> {
             linker: args.linker.as_deref(),
             jobs: args.jobs,
             build_dir: &root,
+            token_reuse_remarks: args.token_reuse_remarks,
             color,
         },
         &pool,
@@ -461,6 +474,7 @@ async fn build(args: &BuildArgs, color: bool) -> Result<(), String> {
                 &target,
             ),
             jobs: args.jobs,
+            token_reuse_remarks: args.token_reuse_remarks,
             color,
         },
         &graph,
@@ -584,6 +598,7 @@ async fn inspect(args: &InspectArgs, color: bool) -> Result<(), String> {
                     target: &target,
                     linker: args.linker.as_deref(),
                     build_dir: &root,
+                    token_reuse_remarks: args.token_reuse_remarks,
                 },
             )?;
             report["plan"] = plan::render(
@@ -594,6 +609,7 @@ async fn inspect(args: &InspectArgs, color: bool) -> Result<(), String> {
                     target: &target,
                     linker: args.linker.as_deref(),
                     build_dir: &root,
+                    token_reuse_remarks: args.token_reuse_remarks,
                 },
                 bake.as_ref(),
                 Some(&states),

--- a/crates/rene/src/plan.rs
+++ b/crates/rene/src/plan.rs
@@ -33,6 +33,8 @@ pub struct Options<'a> {
     /// `rene build --linker`, overriding the profile's.
     pub linker: Option<&'a Path>,
     pub build_dir: &'a Path,
+    /// Add an rrc JSON report side output to every artifact-producing compile.
+    pub token_reuse_remarks: bool,
 }
 
 /// The placeholder argv entries for bake-decided paths.
@@ -87,6 +89,7 @@ pub(crate) fn node_commands(
                     decl.kind,
                     opts.linker,
                 ));
+                add_token_reuse_report(&mut args, &out, opts.token_reuse_remarks);
                 args.extend(polyffi_args(bake));
                 args.extend(externs.iter().cloned());
                 if decl.kind.is_linked() {
@@ -119,6 +122,7 @@ pub(crate) fn node_commands(
             TargetKind::Staticlib,
             opts.linker,
         ));
+        add_token_reuse_report(&mut staticlib, &archive, opts.token_reuse_remarks);
         staticlib.extend(polyffi_args(bake));
         staticlib.extend(externs.iter().cloned());
         vec![
@@ -135,6 +139,23 @@ pub(crate) fn node_commands(
                 args: staticlib,
             },
         ]
+    }
+}
+
+/// The deterministic sidecar path rene assigns to an artifact's token-reuse
+/// report (`demo` -> `demo.token-reuse.json`, `libx.a` ->
+/// `libx.a.token-reuse.json`). Keeping the original suffix prevents target
+/// kinds with the same stem from colliding.
+pub(crate) fn token_reuse_report_path(artifact: &Path) -> PathBuf {
+    let mut name = artifact.file_name().unwrap_or_default().to_os_string();
+    name.push(".token-reuse.json");
+    artifact.with_file_name(name)
+}
+
+fn add_token_reuse_report(args: &mut Vec<String>, artifact: &Path, enabled: bool) {
+    if enabled {
+        args.push("--token-reuse-remarks".to_owned());
+        args.push(token_reuse_report_path(artifact).display().to_string());
     }
 }
 

--- a/crates/rene/tests/cli.rs
+++ b/crates/rene/tests/cli.rs
@@ -83,6 +83,7 @@ fn build_help_distinguishes_products_from_the_machine_target() {
     assert!(help.contains("--bin <NAME>"), "{help}");
     assert!(help.contains("--lib <NAME>"), "{help}");
     assert!(help.contains("--target <TRIPLE>"), "{help}");
+    assert!(help.contains("--token-reuse-remarks"), "{help}");
 }
 
 #[test]
@@ -240,11 +241,12 @@ impl Fakes {
         // fabricates the `-o` artifact.
         let rrc = script(
             "fake-rrc",
-            r#"root=""; input=""; out=""; package=""; color=auto; prev=""; scan=no
+            r#"root=""; input=""; out=""; report=""; package=""; color=auto; prev=""; scan=no
 for arg in "$@"; do
   [ "$prev" = "--package-root" ] && root="$arg"
   [ "$prev" = "--package-name" ] && package="$arg"
   [ "$prev" = "-o" ] && out="$arg"
+  [ "$prev" = "--token-reuse-remarks" ] && report="$arg"
   [ "$prev" = "--color" ] && color="$arg"
   [ "$arg" = "--scan-deps" ] && scan=yes
   case "$arg" in *.rr) input="$arg";; esac
@@ -283,6 +285,10 @@ if [ "$scan" = no ]; then
     exit 1
   fi
   echo compiled > "$out"
+  if [ -n "$report" ]; then
+    mkdir -p "$(dirname "$report")"
+    printf '{"schema":"reussir.token-reuse.v1","locations":[],"decisions":[]}\n' > "$report"
+  fi
   exit 0
 fi
 log="$(dirname "$0")/rrc-runs"
@@ -1376,6 +1382,41 @@ fn build_runs_the_dependency_pipeline() {
             .all(|line| !line.contains("--package-name app")),
         "the root re-ran despite identical upstream bytes: {after:#?}"
     );
+
+    // Reports are side outputs of artifact-producing compiles, never the interface
+    // compile. Enabling them after a normal build refreshes each affected
+    // record exactly once and uses collision-free paths beside the products.
+    let out = fakes.rene(&["build", "--token-reuse-remarks"], &manifest, &root);
+    assert!(out.status.success(), "stderr: {}", stderr(&out));
+    let with_remarks = fakes.package_compiles();
+    assert_eq!(with_remarks.len(), 8, "{with_remarks:#?}");
+    assert!(
+        !with_remarks[5].contains("--token-reuse-remarks"),
+        "interface unexpectedly requested remarks: {with_remarks:#?}"
+    );
+    let dep_report = deps_dir.join("libutil.a.token-reuse.json");
+    let root_report = root.join("dev/demo.token-reuse.json");
+    assert!(
+        with_remarks[6].contains(&format!("--token-reuse-remarks {}", dep_report.display())),
+        "{with_remarks:#?}"
+    );
+    assert!(
+        with_remarks[7].contains(&format!("--token-reuse-remarks {}", root_report.display())),
+        "{with_remarks:#?}"
+    );
+    assert!(dep_report.is_file() && root_report.is_file());
+
+    let out = fakes.rene(&["build", "--token-reuse-remarks"], &manifest, &root);
+    assert!(out.status.success(), "stderr: {}", stderr(&out));
+    assert_eq!(fakes.package_compiles().len(), 8, "fresh reports rebuilt");
+
+    // Deleting one tracked sidecar recompiles only its own product.
+    std::fs::remove_file(&root_report).unwrap();
+    let out = fakes.rene(&["build", "--token-reuse-remarks"], &manifest, &root);
+    assert!(out.status.success(), "stderr: {}", stderr(&out));
+    let repaired = fakes.package_compiles();
+    assert_eq!(repaired.len(), 9, "{repaired:#?}");
+    assert!(repaired[8].contains("--package-name app"), "{repaired:#?}");
 }
 
 /// `rene new` end to end: the flags land in the scaffold, the manifest the

--- a/crates/reussir-backend-sys/src/lib.rs
+++ b/crates/reussir-backend-sys/src/lib.rs
@@ -150,7 +150,7 @@ unsafe extern "C" {
         expand_decrement: bool,
         outline_record: bool,
     ) -> MlirPass;
-    pub fn reussirCreateTokenReusePass(reuse_across_call: bool) -> MlirPass;
+    pub fn reussirCreateTokenReusePass(reuse_across_call: bool, emit_remarks: bool) -> MlirPass;
 
     //==-- Upstream passes used by the pipeline --==//
 
@@ -185,6 +185,14 @@ unsafe extern "C" {
     pub fn reussirCreateReconcileUnrealizedCastsPass() -> MlirPass;
 
     //==-- Standalone helpers --==//
+
+    /// Installs the token-reuse JSON remark streamer on `context`. The report
+    /// is finalized when the context is destroyed. Returns false when the
+    /// output cannot be opened or the context already owns a remark engine.
+    pub fn reussirContextEnableTokenReuseRemarks(
+        context: MlirContext,
+        output_path: MlirStringRef,
+    ) -> bool;
 
     /// Monomorphizes and compiles polymorphic FFI operations in the module.
     /// Returns true on success. `rust_path` and the `lib_dirs` array (of

--- a/crates/reussir-backend/src/pipeline.rs
+++ b/crates/reussir-backend/src/pipeline.rs
@@ -133,6 +133,9 @@ pub struct LoweringOptions {
     pub opt: OptLevel,
     /// Allow the token-reuse pass to reuse tokens across function calls.
     pub reuse_token_across_call: bool,
+    /// Emit structured decisions from the token-reuse pass. A driver enabling
+    /// this must install a remark streamer on the MLIR context.
+    pub emit_token_reuse_remarks: bool,
     /// How nullary variants of shared rc-boxed enums are encoded. `rrc`
     /// exposes this as `--nullary-variant-encoding`; embedders (REPL/JIT,
     /// tests) default to [`NullaryVariantEncoding::Boxed`].
@@ -164,6 +167,7 @@ impl Default for LoweringOptions {
         Self {
             opt: OptLevel::Default,
             reuse_token_across_call: false,
+            emit_token_reuse_remarks: false,
             // Boxed by default: only target-aware drivers (rrc) pick an
             // immediate encoding, so embedders (REPL/JIT, tests) keep the
             // boxed layout untouched.
@@ -277,6 +281,7 @@ pub fn run_lowering_pipeline(
         "reussir_lowering",
         opt = ?options.opt,
         reuse_token_across_call = options.reuse_token_across_call,
+        emit_token_reuse_remarks = options.emit_token_reuse_remarks,
         enable_invariant_analysis = options.enable_invariant_analysis,
         nullary_variant_encoding = ?options.nullary_variant_encoding,
         pack_record_members = options.pack_record_members,
@@ -384,7 +389,10 @@ pub fn run_lowering_pipeline(
         // Second acquire/drop expansion phase: expand decrements and outline
         // record drops.
         module: sys::reussirCreateAcquireDropExpansionPass(true, true);
-        func:   sys::reussirCreateTokenReusePass(options.reuse_token_across_call);
+        func:   sys::reussirCreateTokenReusePass(
+            options.reuse_token_across_call,
+            options.emit_token_reuse_remarks,
+        );
         module: sys::reussirCreateConvertToSTDPass();
         func:   sys::reussirCreateRcCreateSinkPass();
         func:   sys::reussirCreateRcCreateFusionPass();

--- a/crates/reussir-codegen/src/lower/expr.rs
+++ b/crates/reussir-codegen/src/lower/expr.rs
@@ -316,15 +316,23 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
     }
 
     /// Resolve a MIR span (an offset into the current function's file) to a
-    /// `FileLineColLoc`, or `unknown` without a source cache or span — or when
+    /// `FileLineColRange`, or `unknown` without a source cache or span — or when
     /// the file's content could not be obtained (a re-ingested dump whose
     /// source is virtual or missing), since offsets then resolve to nothing.
     pub(super) fn location(&self, span: Option<Span>) -> Location<'c> {
         match (self.source, span) {
             (Some(cache), Some(span)) if cache.is_available(self.cur_file.get()) => {
                 let file = self.cur_file.get();
-                let (line, col) = cache.line_col(file, span.start as usize);
-                Location::new(self.context, cache.name(file), line, col)
+                let (start_line, start_col) = cache.line_col(file, span.start as usize);
+                let (end_line, end_col) = cache.line_col(file, span.end as usize);
+                Location::file_line_col_range(
+                    self.context,
+                    cache.name(file),
+                    start_line,
+                    start_col,
+                    end_line,
+                    end_col,
+                )
             }
             _ => Location::unknown(self.context),
         }

--- a/crates/reussir-codegen/src/lower/mod.rs
+++ b/crates/reussir-codegen/src/lower/mod.rs
@@ -311,9 +311,9 @@ impl CodegenUnit {
 ///
 /// `tcx` is the type arena the program was monomorphized in; the ownership
 /// analysis that places reference-count ops is run per function against it.
-/// `source`, when given, labels each lowered op with a `FileLineColLoc` resolved
-/// from the MIR's byte spans (and carries the file name into the module's debug
-/// attributes); without it, ops get `unknown` locations.
+/// `source`, when given, labels each lowered op with a `FileLineColRange`
+/// resolved from the MIR's byte spans (and carries the file name into the
+/// module's debug attributes); without it, ops get `unknown` locations.
 ///
 /// `names`, when given *together with* `source`, additionally emits DWARF debug
 /// info: it resolves the interned source names of functions, parameters, and
@@ -809,7 +809,10 @@ transform [{
                 .as_operation()
                 .to_string_with_flags(OperationPrintingFlags::new().enable_debug_info(true, false))
                 .expect("print with locations");
-            assert!(printed.contains("loc(\"add.rr\":1:"), "{printed}");
+            assert!(
+                printed.contains("loc(\"add.rr\":1:") && printed.contains(" to "),
+                "{printed}"
+            );
         });
     }
 

--- a/crates/reussir-compiler/src/driver.rs
+++ b/crates/reussir-compiler/src/driver.rs
@@ -144,6 +144,12 @@ fn run(cli: &Cli) -> Result<bool, String> {
         return Err("no output file given; pass -o".into());
     };
     let target = resolve_target(cli)?;
+    if cli.token_reuse_remarks.is_some() && target <= Stage::Mlir {
+        return Err(format!(
+            "--token-reuse-remarks requires the lowering pipeline, but `{target}` stops before \
+             token reuse; emit `mlir-llvm` or a later stage"
+        ));
+    }
     // The interface header names the package it describes; only package mode
     // has that name authoritatively (a plain file or dump does not).
     if target == Stage::Rri && package.is_none() {
@@ -271,6 +277,13 @@ fn run(cli: &Cli) -> Result<bool, String> {
         return Err("no input file (or --package-root/--package-name) given".into());
     };
     let input_stage = resolve_input_stage(cli, input)?;
+    if cli.token_reuse_remarks.is_some() && input_stage == Stage::LlvmIr {
+        return Err(
+            "--token-reuse-remarks cannot be used with LLVM IR input, which enters after the \
+             token-reuse pass"
+                .into(),
+        );
+    }
     if target < input_stage {
         return Err(format!(
             "cannot emit `{target}` from a `{input_stage}` input: the pipeline only runs forward"

--- a/crates/reussir-compiler/src/driver/backend.rs
+++ b/crates/reussir-compiler/src/driver/backend.rs
@@ -8,6 +8,7 @@ use std::path::{Path, PathBuf};
 use reussir_backend::llvm::LlvmLowering;
 use reussir_backend::melior::ir::Module;
 use reussir_backend::pipeline::{self, LoweringOptions, OptLevel};
+use reussir_backend_sys as sys;
 
 use crate::{RelocMode, TargetMachine, TargetSpec, emit_to_file};
 
@@ -38,6 +39,25 @@ pub(crate) fn backend(
         Produced::Units(units, exports) => (units, true, exports),
         Produced::Module(module, exports) => (vec![module], false, exports),
     };
+
+    // One context-wide streamer aggregates remarks from every function pass
+    // and codegen unit, then finalizes the deterministic JSON report when the
+    // context drops at the end of this compilation.
+    if let Some(path) = &cli.token_reuse_remarks {
+        let path = path.to_string_lossy();
+        let path_ref = sys::mlir_sys::MlirStringRef {
+            data: path.as_ptr().cast(),
+            length: path.len(),
+        };
+        // SAFETY: `context` and `path` are live for the call; the C API copies
+        // the path while constructing its owned output stream.
+        if !unsafe { sys::reussirContextEnableTokenReuseRemarks(context.to_raw(), path_ref) } {
+            return Err(format!(
+                "failed to initialize token-reuse remark output `{}`",
+                path
+            ));
+        }
+    }
 
     // A static library and the linked targets are the ones whose units do not
     // each become a user-visible file: every unit is emitted into a scratch
@@ -122,6 +142,7 @@ pub(crate) fn backend_module(
     let options = LoweringOptions {
         opt,
         reuse_token_across_call: cli.reuse_across_call,
+        emit_token_reuse_remarks: cli.token_reuse_remarks.is_some(),
         nullary_variant_encoding: cli.nullary_variant_encoding.resolve(machine.triple()),
         pack_record_members: !cli.no_pack_record_members,
         closure_wpd,

--- a/crates/reussir-compiler/src/driver/cli.rs
+++ b/crates/reussir-compiler/src/driver/cli.rs
@@ -180,6 +180,13 @@ pub(crate) struct Cli {
     #[arg(long = "reuse-across-call")]
     pub(crate) reuse_across_call: bool,
 
+    /// Write every token-reuse decision to this JSON file. The report uses a
+    /// shared location table (including source ranges and nested call-site
+    /// locations) and groups identical generic instances instead of repeating
+    /// their source/sink locations. Requires an output past the `mlir` stage.
+    #[arg(long = "token-reuse-remarks", value_name = "FILE")]
+    pub(crate) token_reuse_remarks: Option<PathBuf>,
+
     /// Disable whole-program devirtualization of closures. WPD tags every
     /// closure vtable with its return-type family id, asserts it at the
     /// indirect eval/clone/drop call sites, and lets the backend's

--- a/crates/reussir-compiler/tests/driver.rs
+++ b/crates/reussir-compiler/tests/driver.rs
@@ -177,6 +177,118 @@ fn dumps_mlir_llvm_and_llvm_ir_from_source() {
 }
 
 #[test]
+fn token_reuse_report_deduplicates_generic_instances_for_a_wasm_target() {
+    let dir = scratch("reuse-remarks-wasm");
+    let src = dir.path().join("generic.rr");
+    std::fs::write(
+        &src,
+        r#"pub enum Box<T> {
+    Wrap(T)
+}
+
+fn update<T>(boxed: Box<T>, value: T) -> Box<T> {
+    match boxed {
+        Box::Wrap(_) => {
+            let next = value;
+            Box::Wrap { next }
+        }
+    }
+}
+
+pub fn update_i64(boxed: Box<i64>, value: i64) -> Box<i64> {
+    update(boxed, value)
+}
+
+pub fn update_i32(boxed: Box<i32>, value: i32) -> Box<i32> {
+    update(boxed, value)
+}
+"#,
+    )
+    .expect("write generic source");
+    let out = dir.path().join("generic.mlir-llvm");
+    let report_path = dir.path().join("reuse.json");
+    let output = rrc(&[
+        &src,
+        Path::new("-o"),
+        &out,
+        Path::new("--emit"),
+        Path::new("mlir-llvm"),
+        Path::new("-O"),
+        Path::new("none"),
+        Path::new("--target-triple"),
+        Path::new("wasm32-unknown-unknown"),
+        Path::new("--codegen-units"),
+        Path::new("2"),
+        Path::new("--token-reuse-remarks"),
+        &report_path,
+    ]);
+    assert!(
+        output.status.success(),
+        "rrc reuse report failed:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let report_text = read(&report_path);
+    let report: serde_json::Value = serde_json::from_str(&report_text)
+        .unwrap_or_else(|e| panic!("bad reuse JSON ({e}):\n{report_text}"));
+    assert_eq!(report["schema"], "reussir.token-reuse.v1");
+    assert_eq!(
+        report["coordinates"],
+        serde_json::json!({
+            "line_base": 1,
+            "column_base": 1,
+            "column_unit": "utf-8-byte",
+            "end": "exclusive",
+        })
+    );
+    assert_eq!(
+        report["files"],
+        serde_json::json!([src.to_string_lossy().as_ref()])
+    );
+    assert_eq!(
+        report["locations"],
+        serde_json::json!([
+            {
+                "kind": "file",
+                "file": 0,
+                "start": { "line": 7, "column": 25 },
+                "end": { "line": 10, "column": 10 },
+            },
+            {
+                "kind": "file",
+                "file": 0,
+                "start": { "line": 9, "column": 13 },
+                "end": { "line": 9, "column": 31 },
+            },
+        ])
+    );
+
+    let decisions = report["decisions"]
+        .as_array()
+        .expect("decisions is an array");
+    assert_eq!(decisions.len(), 1, "report:\n{report_text}");
+    let decision = &decisions[0];
+    assert_eq!(decision["kind"], "reuse");
+    assert_eq!(decision["source"], 0);
+    assert_eq!(decision["sink"], 1);
+    assert_eq!(decision["strategy"], "ensure");
+    assert_eq!(decision["score"], 2);
+    assert_eq!(decision["available_tokens"], 1);
+    assert_eq!(decision["compatible_tokens"], 1);
+    assert_eq!(decision["occurrences"], 2);
+    let instances = decision["instances"]
+        .as_array()
+        .expect("instances is an array");
+    assert_eq!(instances.len(), 2);
+    assert!(
+        instances.iter().all(|instance| instance
+            .as_str()
+            .is_some_and(|name| name.contains("update"))),
+        "instances: {instances:#?}"
+    );
+}
+
+#[test]
 fn compiles_source_to_object() {
     let (dir, src) = source("obj");
     let obj = dir.path().join("prog.o");

--- a/docs/design/token-reuse-remarks.md
+++ b/docs/design/token-reuse-remarks.md
@@ -143,9 +143,11 @@ scheduling and multiple codegen units do not perturb the JSON bytes.
 
 ## Cost model
 
-The disabled path performs only the pass-option branch. Compatibility counting,
-remark construction, string conversion, location interning, locking, and JSON
-state do not run unless reporting is enabled.
+The pass dispatches once per function to separate reporting-enabled and
+reporting-disabled template instantiations. The disabled candidate loop has no
+reporting branch or compatibility counter. Remark construction, string
+conversion, location interning, locking, and JSON state do not run unless
+reporting is enabled.
 
 In the enabled streamer, closed state uses compact enums (`DecisionKind`,
 `ReuseStrategy`, `AllocationReason`, and `LocationKind`) and numeric location

--- a/docs/design/token-reuse-remarks.md
+++ b/docs/design/token-reuse-remarks.md
@@ -1,0 +1,155 @@
+# Token-reuse decision reports
+
+The one-shot `TokenReuse` pass can report every fresh-allocation versus reuse
+decision as structured JSON. The report is intended for source-aware tools: a
+web playground can highlight the construction (the sink), jump to the dead
+object that donated its storage (the source), and explain why the pass did or
+did not reuse it.
+
+Reporting is off by default. It is diagnostic output and never changes the
+reuse result.
+
+## Entry points
+
+At the pass level, `reussir-token-reuse{emit-remarks=1}` emits standard MLIR
+`Passed` and `Missed` remarks in category `TokenReuse`, subcategory `OneShot`.
+This keeps the optimization available to MLIR tooling and custom remark
+streamers. For example:
+
+```sh
+reussir-opt input.mlir \
+  --reussir-token-reuse=emit-remarks=1 \
+  --remarks-filter=TokenReuse \
+  --remark-format=emitRemark
+```
+
+`rrc` installs Reussir's JSON streamer and enables the pass with:
+
+```sh
+rrc input.rr --emit mlir-llvm -o output.mlir \
+  --token-reuse-remarks reuse.json
+```
+
+The requested output must run the lowering pipeline: `mlir-llvm`, LLVM IR,
+assembly, an object, a library, or an executable. A plain `mlir` dump stops
+before token reuse and is rejected instead of producing an empty, misleading
+report. The report is target-independent; an explicit `--target-triple`,
+including a WebAssembly target, follows the same path.
+
+`rene` forwards the option to every artifact-producing compilation:
+
+```sh
+rene build --token-reuse-remarks
+rene build --target wasm32-wasip1 --token-reuse-remarks
+```
+
+Each report is a cached sidecar beside its artifact. The name retains the
+artifact's complete file name so target kinds cannot collide:
+
+```text
+dev/demo.token-reuse.json
+dev/demo.wasm.token-reuse.json
+dev/deps/libutil.a.token-reuse.json
+```
+
+Dependency-interface (`.rri`) compilations do not run token reuse and do not
+receive a report. Deleting a sidecar invalidates only the product that owns it.
+`rene inspect --commands --token-reuse-remarks` exposes the exact paths without
+building.
+
+## Schema v1
+
+Every document has the schema tag `reussir.token-reuse.v1`:
+
+```json
+{
+  "schema": "reussir.token-reuse.v1",
+  "coordinates": {
+    "line_base": 1,
+    "column_base": 1,
+    "column_unit": "utf-8-byte",
+    "end": "exclusive"
+  },
+  "files": ["src/list.rr"],
+  "locations": [
+    {
+      "kind": "file",
+      "file": 0,
+      "start": {"line": 8, "column": 25},
+      "end": {"line": 11, "column": 10}
+    },
+    {
+      "kind": "file",
+      "file": 0,
+      "start": {"line": 10, "column": 13},
+      "end": {"line": 10, "column": 31}
+    }
+  ],
+  "decisions": [
+    {
+      "kind": "reuse",
+      "sink": 1,
+      "source": 0,
+      "strategy": "ensure",
+      "score": 2,
+      "available_tokens": 1,
+      "compatible_tokens": 1,
+      "instances": ["_RIC6updatelE", "_RIC6updatexE"],
+      "occurrences": 2
+    }
+  ]
+}
+```
+
+Coordinates match MLIR's source locations: lines and columns start at one,
+columns count UTF-8 bytes, and a range's end is exclusive. `files` is a shared
+string table; a file location's numeric `file` field indexes it.
+
+Locations form another shared table. A decision's `source` and `sink` are
+numeric indexes into that table. Supported nodes preserve MLIR's nested
+location structure:
+
+- `file`: a source range and file-table index;
+- `name`: a name and `child` location;
+- `callsite`: `callee` and `caller` locations;
+- `fused`: a `locations` array;
+- `unknown`;
+- `opaque`: a lossless printed fallback for an unrecognized location kind.
+
+For a reuse decision, `source` is the location of the token-producing dead
+object and `sink` is the accepting construction. `strategy` is `ensure` for an
+exact compatible token or `realloc` for a resizable donor. `score` is the
+selection heuristic's score.
+
+For an allocation decision, `source`, `strategy`, and `score` are absent.
+`reason` is either `no-available-token` or `no-compatible-token`. Both decision
+kinds record how many tokens were available and how many passed compatibility
+scoring, so a UI can distinguish an empty reuse set from rejected candidates.
+
+## Deduplication and determinism
+
+Locations are structurally interned. A one-child `FusedLoc` that only carries
+per-instantiation debug metadata is normalized to its child, preventing generic
+monomorphizations from duplicating otherwise identical source ranges. Other
+nested location structure remains visible.
+
+Decisions with the same kind, source/sink, strategy or reason, score, and
+candidate counts are grouped. Their function symbols appear once each in the
+sorted `instances` array, while `occurrences` retains the total number of
+remarks. This is lossless enough for a frontend to expand the grouping if it
+wants per-instance annotations. Files, canonical locations, decisions, and
+instances are sorted before serialization, so MLIR's parallel function-pass
+scheduling and multiple codegen units do not perturb the JSON bytes.
+
+## Cost model
+
+The disabled path performs only the pass-option branch. Compatibility counting,
+remark construction, string conversion, location interning, locking, and JSON
+state do not run unless reporting is enabled.
+
+In the enabled streamer, closed state uses compact enums (`DecisionKind`,
+`ReuseStrategy`, `AllocationReason`, and `LocationKind`) and numeric location
+IDs. Strings are retained only for irreducible payloads—file paths, names,
+opaque locations, and instance symbols—and for canonical location keys needed
+by structural deduplication and deterministic ordering. A mutex protects the
+single context-wide report while MLIR runs function passes in parallel.

--- a/include/Reussir-c/Passes.h
+++ b/include/Reussir-c/Passes.h
@@ -73,8 +73,9 @@ MlirPass reussirCreateDebugInfoConversionPass(void);
 // pipeline runs it once with both disabled and once with both enabled.
 MlirPass reussirCreateAcquireDropExpansionPass(bool expandDecrement,
                                                bool outlineRecord);
-// Token reuse can optionally reuse tokens across function calls.
-MlirPass reussirCreateTokenReusePass(bool reuseAcrossCall);
+// Token reuse can optionally reuse tokens across function calls and emit one
+// structured optimization remark for every allocation/reuse decision.
+MlirPass reussirCreateTokenReusePass(bool reuseAcrossCall, bool emitRemarks);
 
 //===----------------------------------------------------------------------===//
 // Upstream passes used by the pipeline
@@ -109,6 +110,13 @@ MlirPass reussirCreateReconcileUnrealizedCastsPass(void);
 //===----------------------------------------------------------------------===//
 // Standalone helpers
 //===----------------------------------------------------------------------===//
+
+// Installs a context-wide token-reuse remark streamer that writes a
+// deterministic, location-deduplicated JSON report to `outputPath` when the
+// context is destroyed. Returns false when the path cannot be opened or a
+// remark engine is already installed on the context.
+bool reussirContextEnableTokenReuseRemarks(MlirContext context,
+                                           MlirStringRef outputPath);
 
 // Monomorphizes and compiles polymorphic FFI operations in the module. Returns
 // true on success. `rustPath` and the `libDirs` array (of `nLibDirs` entries)

--- a/include/Reussir/Transformation/Passes.td
+++ b/include/Reussir/Transformation/Passes.td
@@ -182,6 +182,10 @@ def ReussirTokenReusePass
                         /*default=*/"false",
                         "allow token reuse across function calls (may increase "
                         "peak heap usage)">,
+                 Option<"emitRemarks", "emit-remarks", "bool",
+                        /*default=*/"false",
+                        "emit structured remarks for every allocation/reuse "
+                        "decision">,
   ];
 
   let dependentDialects = ["::reussir::ReussirDialect"];

--- a/lib/CAPI/CMakeLists.txt
+++ b/lib/CAPI/CMakeLists.txt
@@ -7,15 +7,16 @@
 # MLIR/LLVM that mlir-sys pulls in. Requires the distro's static MLIR/LLVM
 # development packages (including libpolly-<ver>-dev for the static Polly
 # archives llvm-config references).
-add_library(ReussirCAPI STATIC Dialects.cpp Passes.cpp Types.cpp Attrs.cpp Jit.cpp
-                               Artifact.cpp)
+add_library(ReussirCAPI STATIC Dialects.cpp Passes.cpp ReuseRemarks.cpp Types.cpp
+                               Attrs.cpp Jit.cpp Artifact.cpp)
 
 # Jit.cpp runs the custom Reussir LLVM passes and (when available) TPDE. Linking
 # these as usage requirements gives ReussirCAPI their headers/defines and orders
 # the build; the archives themselves are pulled onto the final Rust link line by
 # reussir-backend-sys (see its build.rs).
 target_link_libraries(ReussirCAPI PRIVATE ReussirLLVMAllocationSimplicationPass
-                                          ReussirLLVMLinearRecurrencePass)
+                                          ReussirLLVMLinearRecurrencePass
+                                          MLIRIR LLVMSupport)
 if(REUSSIR_HAS_TPDE)
   target_compile_definitions(ReussirCAPI PRIVATE REUSSIR_HAS_TPDE)
   target_link_libraries(ReussirCAPI PRIVATE tpde_llvm)

--- a/lib/CAPI/CMakeLists.txt
+++ b/lib/CAPI/CMakeLists.txt
@@ -15,8 +15,7 @@ add_library(ReussirCAPI STATIC Dialects.cpp Passes.cpp ReuseRemarks.cpp Types.cp
 # the build; the archives themselves are pulled onto the final Rust link line by
 # reussir-backend-sys (see its build.rs).
 target_link_libraries(ReussirCAPI PRIVATE ReussirLLVMAllocationSimplicationPass
-                                          ReussirLLVMLinearRecurrencePass
-                                          MLIRIR LLVMSupport)
+                                          ReussirLLVMLinearRecurrencePass)
 if(REUSSIR_HAS_TPDE)
   target_compile_definitions(ReussirCAPI PRIVATE REUSSIR_HAS_TPDE)
   target_link_libraries(ReussirCAPI PRIVATE tpde_llvm)

--- a/lib/CAPI/Passes.cpp
+++ b/lib/CAPI/Passes.cpp
@@ -144,9 +144,10 @@ MlirPass reussirCreateAcquireDropExpansionPass(bool expandDecrement,
   options.outlineRecord = outlineRecord;
   return wrapOwned(reussir::createReussirAcquireDropExpansionPass(options));
 }
-MlirPass reussirCreateTokenReusePass(bool reuseAcrossCall) {
+MlirPass reussirCreateTokenReusePass(bool reuseAcrossCall, bool emitRemarks) {
   reussir::ReussirTokenReusePassOptions options;
   options.reuseAcrossCall = reuseAcrossCall;
+  options.emitRemarks = emitRemarks;
   return wrapOwned(reussir::createReussirTokenReusePass(options));
 }
 

--- a/lib/CAPI/ReuseRemarks.cpp
+++ b/lib/CAPI/ReuseRemarks.cpp
@@ -33,6 +33,11 @@
 #include <llvm/Support/FileSystem.h>
 #include <llvm/Support/JSON.h>
 #include <llvm/Support/raw_ostream.h>
+
+// Complete mlir::DialectVersion before MLIR C API headers reach
+// BytecodeWriter.h; MSVC's STL rejects destroying unique_ptr<T> when T is only
+// forward declared.
+#include <mlir/Bytecode/BytecodeImplementation.h>
 #include <mlir/CAPI/IR.h>
 #include <mlir/CAPI/Support.h>
 #include <mlir/IR/Location.h>
@@ -166,7 +171,7 @@ public:
     if (remark.getCategoryName() != "TokenReuse")
       return;
 
-    std::lock_guard lock(mutex);
+    std::lock_guard<std::mutex> lock(mutex);
     DecisionKey incoming;
     if (remark.getRemarkName() == "TokenReused")
       incoming.kind = DecisionKind::Reuse;
@@ -208,7 +213,7 @@ public:
   }
 
   void finalize() override {
-    std::lock_guard lock(mutex);
+    std::lock_guard<std::mutex> lock(mutex);
     if (finalized)
       return;
     finalized = true;

--- a/lib/CAPI/ReuseRemarks.cpp
+++ b/lib/CAPI/ReuseRemarks.cpp
@@ -1,0 +1,472 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
+// the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file implements the JSON streamer used by rrc for token-reuse remarks.
+///
+//===----------------------------------------------------------------------===//
+
+#include "Reussir-c/Passes.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <set>
+#include <string>
+#include <system_error>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include <llvm/ADT/SmallVector.h>
+#include <llvm/ADT/StringRef.h>
+#include <llvm/Support/FileSystem.h>
+#include <llvm/Support/JSON.h>
+#include <llvm/Support/raw_ostream.h>
+#include <mlir/CAPI/IR.h>
+#include <mlir/CAPI/Support.h>
+#include <mlir/IR/Location.h>
+#include <mlir/IR/Remarks.h>
+
+namespace {
+
+using LocationId = uint32_t;
+
+enum class LocationKind : uint8_t {
+  File,
+  Name,
+  CallSite,
+  Fused,
+  Unknown,
+  Opaque,
+};
+
+enum class DecisionKind : uint8_t { Reuse, Allocate };
+enum class ReuseStrategy : uint8_t { None, Ensure, Realloc };
+enum class AllocationReason : uint8_t {
+  None,
+  NoAvailableToken,
+  NoCompatibleToken,
+};
+
+struct LocationNode {
+  LocationKind kind = LocationKind::Unknown;
+  // File path, NameLoc name, or the printed form of an opaque location. These
+  // are the only location payloads that cannot be represented by numeric IDs.
+  std::string text;
+  uint64_t startLine = 0;
+  uint64_t startColumn = 0;
+  uint64_t endLine = 0;
+  uint64_t endColumn = 0;
+  llvm::SmallVector<LocationId, 2> children;
+};
+
+struct DecisionKey {
+  DecisionKind kind = DecisionKind::Allocate;
+  LocationId sink = 0;
+  std::optional<LocationId> source;
+  ReuseStrategy strategy = ReuseStrategy::None;
+  AllocationReason reason = AllocationReason::None;
+  int64_t score = 0;
+  uint64_t availableTokens = 0;
+  uint64_t compatibleTokens = 0;
+
+  bool operator<(const DecisionKey &other) const {
+    return std::tie(kind, sink, source, strategy, reason, score,
+                    availableTokens, compatibleTokens) <
+           std::tie(other.kind, other.sink, other.source, other.strategy,
+                    other.reason, other.score, other.availableTokens,
+                    other.compatibleTokens);
+  }
+};
+
+struct Decision {
+  std::set<std::string> instances;
+  uint64_t occurrences = 0;
+};
+
+struct InternedLocation {
+  LocationId id;
+  // References a std::map key, whose address remains stable across insertion.
+  llvm::StringRef canonicalKey;
+};
+
+void appendKeyPart(std::string &key, llvm::StringRef part) {
+  key += std::to_string(part.size());
+  key.push_back(':');
+  key.append(part.data(), part.size());
+}
+
+std::optional<int64_t> parseSignedMetric(llvm::StringRef value) {
+  int64_t parsed = 0;
+  if (value.getAsInteger(10, parsed))
+    return std::nullopt;
+  return parsed;
+}
+
+std::optional<uint64_t> parseUnsignedMetric(llvm::StringRef value) {
+  uint64_t parsed = 0;
+  if (value.getAsInteger(10, parsed))
+    return std::nullopt;
+  return parsed;
+}
+
+llvm::StringRef decisionKindName(DecisionKind kind) {
+  switch (kind) {
+  case DecisionKind::Reuse:
+    return "reuse";
+  case DecisionKind::Allocate:
+    return "allocate";
+  }
+  return "";
+}
+
+llvm::StringRef strategyName(ReuseStrategy strategy) {
+  switch (strategy) {
+  case ReuseStrategy::Ensure:
+    return "ensure";
+  case ReuseStrategy::Realloc:
+    return "realloc";
+  case ReuseStrategy::None:
+    return "";
+  }
+  return "";
+}
+
+llvm::StringRef reasonName(AllocationReason reason) {
+  switch (reason) {
+  case AllocationReason::NoAvailableToken:
+    return "no-available-token";
+  case AllocationReason::NoCompatibleToken:
+    return "no-compatible-token";
+  case AllocationReason::None:
+    return "";
+  }
+  return "";
+}
+
+class TokenReuseJsonStreamer final
+    : public mlir::remark::detail::MLIRRemarkStreamerBase {
+public:
+  explicit TokenReuseJsonStreamer(std::unique_ptr<llvm::raw_fd_ostream> output)
+      : output(std::move(output)) {}
+
+  void streamOptimizationRemark(
+      const mlir::remark::detail::Remark &remark) override {
+    if (remark.getCategoryName() != "TokenReuse")
+      return;
+
+    std::lock_guard lock(mutex);
+    DecisionKey incoming;
+    if (remark.getRemarkName() == "TokenReused")
+      incoming.kind = DecisionKind::Reuse;
+    else if (remark.getRemarkName() == "TokenNotReused")
+      incoming.kind = DecisionKind::Allocate;
+    else
+      return;
+
+    incoming.sink = internLocation(remark.getLocation()).id;
+    for (const auto &arg : remark.getArgs()) {
+      if (arg.key == "Source" && arg.hasAttribute()) {
+        if (auto loc = llvm::dyn_cast<mlir::LocationAttr>(arg.getAttribute()))
+          incoming.source = internLocation(mlir::Location(loc)).id;
+      } else if (arg.key == "Strategy") {
+        if (arg.val == "ensure")
+          incoming.strategy = ReuseStrategy::Ensure;
+        else if (arg.val == "realloc")
+          incoming.strategy = ReuseStrategy::Realloc;
+      } else if (arg.key == "Reason") {
+        if (arg.val == "no-available-token")
+          incoming.reason = AllocationReason::NoAvailableToken;
+        else if (arg.val == "no-compatible-token")
+          incoming.reason = AllocationReason::NoCompatibleToken;
+      } else if (arg.key == "Score") {
+        if (auto value = parseSignedMetric(arg.val))
+          incoming.score = *value;
+      } else if (arg.key == "AvailableTokens") {
+        if (auto value = parseUnsignedMetric(arg.val))
+          incoming.availableTokens = *value;
+      } else if (arg.key == "CompatibleTokens") {
+        if (auto value = parseUnsignedMetric(arg.val))
+          incoming.compatibleTokens = *value;
+      }
+    }
+
+    Decision &decision = decisions.try_emplace(incoming).first->second;
+    ++decision.occurrences;
+    decision.instances.emplace(remark.getFunction());
+  }
+
+  void finalize() override {
+    std::lock_guard lock(mutex);
+    if (finalized)
+      return;
+    finalized = true;
+    writeReport();
+  }
+
+private:
+  InternedLocation internLocation(mlir::Location loc) {
+    LocationNode node;
+    std::string key;
+
+    if (auto file = llvm::dyn_cast<mlir::FileLineColRange>(loc)) {
+      node.kind = LocationKind::File;
+      node.text = file.getFilename().getValue().str();
+      node.startLine = file.getStartLine();
+      node.startColumn = file.getStartColumn();
+      node.endLine = file.getEndLine();
+      node.endColumn = file.getEndColumn();
+      key.push_back(static_cast<char>(LocationKind::File));
+      appendKeyPart(key, node.text);
+      for (uint64_t coordinate :
+           {node.startLine, node.startColumn, node.endLine, node.endColumn}) {
+        key.push_back('#');
+        key += std::to_string(coordinate);
+      }
+    } else if (auto name = llvm::dyn_cast<mlir::NameLoc>(loc)) {
+      node.kind = LocationKind::Name;
+      node.text = name.getName().getValue().str();
+      InternedLocation child = internLocation(name.getChildLoc());
+      node.children.push_back(child.id);
+      key.push_back(static_cast<char>(LocationKind::Name));
+      appendKeyPart(key, node.text);
+      appendKeyPart(key, child.canonicalKey);
+    } else if (auto callSite = llvm::dyn_cast<mlir::CallSiteLoc>(loc)) {
+      node.kind = LocationKind::CallSite;
+      InternedLocation callee = internLocation(callSite.getCallee());
+      InternedLocation caller = internLocation(callSite.getCaller());
+      node.children.push_back(callee.id);
+      node.children.push_back(caller.id);
+      key.push_back(static_cast<char>(LocationKind::CallSite));
+      appendKeyPart(key, callee.canonicalKey);
+      appendKeyPart(key, caller.canonicalKey);
+    } else if (auto fused = llvm::dyn_cast<mlir::FusedLoc>(loc)) {
+      llvm::SmallVector<InternedLocation, 2> children;
+      for (mlir::Location child : fused.getLocations()) {
+        children.push_back(internLocation(child));
+        node.children.push_back(children.back().id);
+      }
+      // Debug metadata commonly wraps one source location in a FusedLoc.
+      // Treat that wrapper as the source location itself so `-g` does not
+      // defeat deduplication or split generic instances into separate sites.
+      if (children.size() == 1)
+        return children.front();
+      node.kind = LocationKind::Fused;
+      key.push_back(static_cast<char>(LocationKind::Fused));
+      for (const InternedLocation &child : children)
+        appendKeyPart(key, child.canonicalKey);
+    } else if (llvm::isa<mlir::UnknownLoc>(loc)) {
+      node.kind = LocationKind::Unknown;
+      key.push_back(static_cast<char>(LocationKind::Unknown));
+    } else {
+      node.kind = LocationKind::Opaque;
+      llvm::raw_string_ostream text(node.text);
+      loc.print(text);
+      text.flush();
+      key.push_back(static_cast<char>(LocationKind::Opaque));
+      appendKeyPart(key, node.text);
+    }
+
+    auto [it, inserted] = locationIds.try_emplace(std::move(key), 0);
+    if (inserted) {
+      it->second = static_cast<LocationId>(locations.size());
+      locations.push_back(std::move(node));
+    }
+    return {it->second, llvm::StringRef(it->first)};
+  }
+
+  void writeReport() {
+    std::set<std::string> files;
+    for (const LocationNode &location : locations)
+      if (location.kind == LocationKind::File)
+        files.insert(location.text);
+
+    std::map<std::string, uint64_t> fileIds;
+    uint64_t nextId = 0;
+    for (const std::string &file : files)
+      fileIds.emplace(file, nextId++);
+
+    // Internal IDs are optimized for insertion. Remap them using the sorted
+    // canonical keys so parallel pass scheduling cannot perturb JSON output.
+    std::vector<uint64_t> outputLocationIds(locations.size());
+    nextId = 0;
+    for (const auto &[_, internalId] : locationIds)
+      outputLocationIds[internalId] = nextId++;
+
+    struct OrderedDecision {
+      const DecisionKey *key;
+      const Decision *decision;
+    };
+    std::vector<OrderedDecision> orderedDecisions;
+    orderedDecisions.reserve(decisions.size());
+    for (const auto &[key, decision] : decisions)
+      orderedDecisions.push_back({&key, &decision});
+    auto outputSourceId = [&](const DecisionKey &key) {
+      return key.source
+                 ? std::optional<uint64_t>(outputLocationIds[*key.source])
+                 : std::nullopt;
+    };
+    std::sort(
+        orderedDecisions.begin(), orderedDecisions.end(),
+        [&](const OrderedDecision &left, const OrderedDecision &right) {
+          const DecisionKey &lhs = *left.key;
+          const DecisionKey &rhs = *right.key;
+          return std::make_tuple(lhs.kind, outputLocationIds[lhs.sink],
+                                 outputSourceId(lhs), lhs.strategy, lhs.reason,
+                                 lhs.score, lhs.availableTokens,
+                                 lhs.compatibleTokens) <
+                 std::make_tuple(rhs.kind, outputLocationIds[rhs.sink],
+                                 outputSourceId(rhs), rhs.strategy, rhs.reason,
+                                 rhs.score, rhs.availableTokens,
+                                 rhs.compatibleTokens);
+        });
+
+    llvm::json::OStream json(*output, 2);
+    json.object([&] {
+      json.attribute("schema", "reussir.token-reuse.v1");
+      json.attributeObject("coordinates", [&] {
+        json.attribute("line_base", int64_t{1});
+        json.attribute("column_base", int64_t{1});
+        json.attribute("column_unit", "utf-8-byte");
+        json.attribute("end", "exclusive");
+      });
+      json.attributeArray("files", [&] {
+        for (const std::string &file : files)
+          json.value(file);
+      });
+      json.attributeArray("locations", [&] {
+        for (const auto &[_, internalId] : locationIds) {
+          const LocationNode &location = locations[internalId];
+          json.object([&] {
+            switch (location.kind) {
+            case LocationKind::File:
+              json.attribute("kind", "file");
+              json.attribute("file",
+                             static_cast<int64_t>(fileIds.at(location.text)));
+              json.attributeObject("start", [&] {
+                json.attribute("line",
+                               static_cast<int64_t>(location.startLine));
+                json.attribute("column",
+                               static_cast<int64_t>(location.startColumn));
+              });
+              json.attributeObject("end", [&] {
+                json.attribute("line", static_cast<int64_t>(location.endLine));
+                json.attribute("column",
+                               static_cast<int64_t>(location.endColumn));
+              });
+              break;
+            case LocationKind::Name:
+              json.attribute("kind", "name");
+              json.attribute("name", location.text);
+              json.attribute("child",
+                             static_cast<int64_t>(
+                                 outputLocationIds[location.children[0]]));
+              break;
+            case LocationKind::CallSite:
+              json.attribute("kind", "callsite");
+              json.attribute("callee",
+                             static_cast<int64_t>(
+                                 outputLocationIds[location.children[0]]));
+              json.attribute("caller",
+                             static_cast<int64_t>(
+                                 outputLocationIds[location.children[1]]));
+              break;
+            case LocationKind::Fused:
+              json.attribute("kind", "fused");
+              json.attributeArray("locations", [&] {
+                for (LocationId child : location.children)
+                  json.value(static_cast<int64_t>(outputLocationIds[child]));
+              });
+              break;
+            case LocationKind::Unknown:
+              json.attribute("kind", "unknown");
+              break;
+            case LocationKind::Opaque:
+              json.attribute("kind", "opaque");
+              json.attribute("text", location.text);
+              break;
+            }
+          });
+        }
+      });
+      json.attributeArray("decisions", [&] {
+        for (const OrderedDecision &ordered : orderedDecisions) {
+          const DecisionKey &key = *ordered.key;
+          const Decision &decision = *ordered.decision;
+          json.object([&] {
+            json.attribute("kind", decisionKindName(key.kind));
+            json.attribute("sink",
+                           static_cast<int64_t>(outputLocationIds[key.sink]));
+            if (key.source)
+              json.attribute("source", static_cast<int64_t>(
+                                           outputLocationIds[*key.source]));
+            if (key.strategy != ReuseStrategy::None)
+              json.attribute("strategy", strategyName(key.strategy));
+            if (key.reason != AllocationReason::None)
+              json.attribute("reason", reasonName(key.reason));
+            if (key.kind == DecisionKind::Reuse)
+              json.attribute("score", key.score);
+            json.attribute("available_tokens",
+                           static_cast<int64_t>(key.availableTokens));
+            json.attribute("compatible_tokens",
+                           static_cast<int64_t>(key.compatibleTokens));
+            json.attributeArray("instances", [&] {
+              for (const std::string &instance : decision.instances)
+                json.value(instance);
+            });
+            json.attribute("occurrences",
+                           static_cast<int64_t>(decision.occurrences));
+          });
+        }
+      });
+    });
+    *output << '\n';
+    output->flush();
+  }
+
+  std::unique_ptr<llvm::raw_fd_ostream> output;
+  std::mutex mutex;
+  // The canonical string is required for structural location deduplication and
+  // deterministic ordering. Decisions themselves use compact numeric IDs.
+  std::map<std::string, LocationId> locationIds;
+  std::vector<LocationNode> locations;
+  std::map<DecisionKey, Decision> decisions;
+  bool finalized = false;
+};
+
+} // namespace
+
+bool reussirContextEnableTokenReuseRemarks(MlirContext context,
+                                           MlirStringRef outputPath) {
+  mlir::MLIRContext *ctx = unwrap(context);
+  if (ctx->getRemarkEngine())
+    return false;
+
+  std::error_code error;
+  auto output = std::make_unique<llvm::raw_fd_ostream>(
+      unwrap(outputPath), error, llvm::sys::fs::OF_Text);
+  if (error)
+    return false;
+
+  mlir::remark::RemarkCategories categories;
+  // MLIR only constructs a per-kind filter when that kind is populated; using
+  // `all` alone does not activate passed or missed remarks. Limit both kinds
+  // directly so unrelated pass remarks never reach this enabled-only path.
+  categories.passed = "TokenReuse";
+  categories.missed = "TokenReuse";
+  auto streamer = std::make_unique<TokenReuseJsonStreamer>(std::move(output));
+  auto policy = std::make_unique<mlir::remark::RemarkEmittingPolicyAll>();
+  return mlir::succeeded(mlir::remark::enableOptimizationRemarks(
+      *ctx, std::move(streamer), std::move(policy), categories));
+}

--- a/lib/Transformation/TokenReuse/CMakeLists.txt
+++ b/lib/Transformation/TokenReuse/CMakeLists.txt
@@ -9,5 +9,6 @@ add_mlir_library(MLIRReussirTokenReuse
 
   LINK_LIBS PUBLIC
   MLIRReussir
+  MLIRIR
   MLIRPass
 )

--- a/lib/Transformation/TokenReuse/TokenReuse.cpp
+++ b/lib/Transformation/TokenReuse/TokenReuse.cpp
@@ -324,6 +324,35 @@ mlir::TypedValue<RcType> expandedDecProducerRc(mlir::scf::IfOp scfIf,
   return nullptr;
 }
 
+/// Score one available token for an acceptor, or return -1 when the value is
+/// not a compatible token producer. Keeping this independent of remark
+/// bookkeeping lets the default analysis loop stay exactly the same shape
+/// when reporting is disabled.
+int scoreToken(mlir::Value token, TokenAcceptor acceptor,
+               EquivalenceAnalysis &equivalence) {
+  if (auto producer = dyn_cast_or_null<TokenProducer>(token.getDefiningOp())) {
+    ReussirRcDecOp producerAsDec =
+        dyn_cast<ReussirRcDecOp>(producer.getOperation());
+    mlir::TypedValue<RcType> producerRc =
+        producerAsDec ? producerAsDec.getRcPtr() : nullptr;
+    return heuristic(producer.getTokenType(), producerRc, acceptor,
+                     equivalence);
+  }
+
+  auto scfIf = dyn_cast_or_null<mlir::scf::IfOp>(token.getDefiningOp());
+  if (!scfIf || !scfIf->hasAttr(kExpandedDecrementAttr))
+    return -1;
+  auto nullableType = dyn_cast<NullableType>(token.getType());
+  if (!nullableType)
+    return -1;
+  auto producedType = dyn_cast<TokenType>(nullableType.getPtrTy());
+  if (!producedType)
+    return -1;
+  mlir::TypedValue<RcType> producerRc = expandedDecProducerRc(
+      scfIf, llvm::cast<mlir::OpResult>(token).getResultNumber());
+  return heuristic(producedType, producerRc, acceptor, equivalence);
+}
+
 bool escapeTrappedTokensSweep(mlir::func::FuncOp func) {
   llvm::SmallVector<mlir::scf::IfOp> worklist;
   func.walk<mlir::WalkOrder::PostOrder>([&](mlir::scf::IfOp op) {
@@ -448,6 +477,7 @@ struct TokenReusePass : public impl::ReussirTokenReusePassBase<TokenReusePass> {
         << mlir::remark::metric("CompatibleTokens", compatibleTokens);
   }
 
+  template <bool EmitRemarks>
   ValueSet oneShotTokenReuse(
       mlir::Region &region, ValueSet availableTokens,
       llvm::SmallVectorImpl<Reuse> &reuses, llvm::SmallVectorImpl<Free> &frees,
@@ -463,10 +493,6 @@ struct TokenReusePass : public impl::ReussirTokenReusePassBase<TokenReusePass> {
       return {};
     }
 
-    // Keep the disabled path free of remark bookkeeping. In particular, the
-    // compatibility count would otherwise add work to this pass's hot loop.
-    const bool shouldEmitRemarks = emitRemarks;
-
     for (auto &op : region.front()) {
       if (isa<mlir::LoopLikeOpInterface>(op) ||
           (isa<mlir::CallOpInterface>(op) &&
@@ -480,15 +506,15 @@ struct TokenReusePass : public impl::ReussirTokenReusePassBase<TokenReusePass> {
             frees.push_back({token, &op});
           availableTokens = {};
           for (auto &nestedRegion : op.getRegions())
-            oneShotTokenReuse(nestedRegion, {}, reuses, frees, equivalence,
-                              domInfo, dfsOrder);
+            oneShotTokenReuse<EmitRemarks>(nestedRegion, {}, reuses, frees,
+                                           equivalence, domInfo, dfsOrder);
         }
       } else if (auto branchOp = dyn_cast<mlir::RegionBranchOpInterface>(op)) {
         llvm::SmallVector<ValueSet> branchResults;
         for (auto &nestedRegion : op.getRegions())
-          branchResults.push_back(
-              oneShotTokenReuse(nestedRegion, availableTokens, reuses, frees,
-                                equivalence, domInfo, dfsOrder));
+          branchResults.push_back(oneShotTokenReuse<EmitRemarks>(
+              nestedRegion, availableTokens, reuses, frees, equivalence,
+              domInfo, dfsOrder));
         // A RegionBranch op with no regions has nothing to intersect;
         // availableTokens flows through unchanged.
         if (!branchResults.empty()) {
@@ -536,70 +562,40 @@ struct TokenReusePass : public impl::ReussirTokenReusePassBase<TokenReusePass> {
         auto allocOp = llvm::dyn_cast_if_present<ReussirTokenAllocOp>(
             acceptor.getToken().getDefiningOp());
         if (allocOp && allocOp.getToken().hasOneUse()) {
-          size_t compatibleTokenCount = 0;
           int bestScore = -1;
           mlir::Value bestToken{};
           bool bestRealloc = false;
+          [[maybe_unused]] size_t compatibleTokenCount;
+          if constexpr (EmitRemarks)
+            compatibleTokenCount = 0;
 
           for (auto tokenVal : availableTokens) {
-            if (auto producer =
-                    dyn_cast_or_null<TokenProducer>(tokenVal.getDefiningOp())) {
-              ReussirRcDecOp producerAsDec =
-                  dyn_cast<ReussirRcDecOp>(producer.getOperation());
-              mlir::TypedValue<RcType> producerRc =
-                  producerAsDec ? producerAsDec.getRcPtr() : nullptr;
-              int score = heuristic(producer.getTokenType(), producerRc,
-                                    acceptor, equivalence);
-              if (shouldEmitRemarks && score >= 0)
-                ++compatibleTokenCount;
-              if (score >= 0 && (score > bestScore ||
-                                 (score == bestScore && bestToken &&
-                                  tokenOrderKey(dfsOrder, tokenVal) >
-                                      tokenOrderKey(dfsOrder, bestToken)))) {
-                bestScore = score;
-                bestToken = tokenVal;
-                bestRealloc = (score < kReallocEnsureCutoff);
-              }
+            int score = scoreToken(tokenVal, acceptor, equivalence);
+            if constexpr (EmitRemarks)
+              compatibleTokenCount += score >= 0;
+            if (score >= 0 && (score > bestScore ||
+                               (score == bestScore && bestToken &&
+                                tokenOrderKey(dfsOrder, tokenVal) >
+                                    tokenOrderKey(dfsOrder, bestToken)))) {
+              bestScore = score;
+              bestToken = tokenVal;
+              bestRealloc = (score < kReallocEnsureCutoff);
             }
-            if (auto scfIf = dyn_cast_or_null<mlir::scf::IfOp>(
-                    tokenVal.getDefiningOp())) {
-              if (scfIf->hasAttr(kExpandedDecrementAttr)) {
-                auto nullableType = dyn_cast<NullableType>(tokenVal.getType());
-                if (!nullableType)
-                  continue;
-                auto producedType =
-                    dyn_cast<TokenType>(nullableType.getPtrTy());
-                if (!producedType)
-                  continue;
-                mlir::TypedValue<RcType> producerRc = expandedDecProducerRc(
-                    scfIf,
-                    llvm::cast<mlir::OpResult>(tokenVal).getResultNumber());
-                int score =
-                    heuristic(producedType, producerRc, acceptor, equivalence);
-                if (shouldEmitRemarks && score >= 0)
-                  ++compatibleTokenCount;
-                if (score >= 0 && (score > bestScore ||
-                                   (score == bestScore && bestToken &&
-                                    tokenOrderKey(dfsOrder, tokenVal) >
-                                        tokenOrderKey(dfsOrder, bestToken)))) {
-                  bestScore = score;
-                  bestToken = tokenVal;
-                  bestRealloc = (score < kReallocEnsureCutoff);
-                }
-              }
-            }
+          }
+
+          if constexpr (EmitRemarks) {
+            if (bestToken)
+              emitReusedRemark(acceptor, bestToken, bestRealloc, bestScore,
+                               availableTokens.size(), compatibleTokenCount);
+            else
+              emitNotReusedRemark(acceptor, availableTokens.size(),
+                                  compatibleTokenCount);
           }
 
           if (bestToken) {
             mlir::Value selectedToken = bestToken;
-            if (shouldEmitRemarks)
-              emitReusedRemark(acceptor, selectedToken, bestRealloc, bestScore,
-                               availableTokens.size(), compatibleTokenCount);
             availableTokens = availableTokens.erase(bestToken);
             reuses.push_back({selectedToken, bestRealloc, acceptor});
-          } else if (shouldEmitRemarks) {
-            emitNotReusedRemark(acceptor, availableTokens.size(),
-                                compatibleTokenCount);
           }
         }
         // ReussirClosureCreateOp is a kind of acceptor.
@@ -645,10 +641,17 @@ struct TokenReusePass : public impl::ReussirTokenReusePassBase<TokenReusePass> {
     getOperation()->walk<mlir::WalkOrder::PreOrder>(
         [&](mlir::Operation *op) { dfsOrder[op] = counter++; });
 
-    for (auto &region : getOperation()->getRegions()) {
-      oneShotTokenReuse(region, {}, reuses, frees, equivalence, domInfo,
-                        dfsOrder);
-    }
+    // Dispatch once per function. The disabled instantiation contains no
+    // compatibility counter, remark construction, or reporting branches in
+    // the candidate-selection loop.
+    if (emitRemarks)
+      for (auto &region : getOperation()->getRegions())
+        oneShotTokenReuse<true>(region, {}, reuses, frees, equivalence, domInfo,
+                                dfsOrder);
+    else
+      for (auto &region : getOperation()->getRegions())
+        oneShotTokenReuse<false>(region, {}, reuses, frees, equivalence,
+                                 domInfo, dfsOrder);
 
     mlir::IRRewriter rewriter(getOperation());
 

--- a/lib/Transformation/TokenReuse/TokenReuse.cpp
+++ b/lib/Transformation/TokenReuse/TokenReuse.cpp
@@ -38,6 +38,7 @@
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/Dominance.h>
 #include <mlir/IR/PatternMatch.h>
+#include <mlir/IR/Remarks.h>
 #include <mlir/IR/Value.h>
 #include <mlir/IR/ValueRange.h>
 #include <mlir/Pass/Pass.h>
@@ -412,6 +413,41 @@ struct Free {
 };
 struct TokenReusePass : public impl::ReussirTokenReusePassBase<TokenReusePass> {
   using Base::Base;
+
+  mlir::remark::RemarkOpts remarkOpts(llvm::StringRef name) {
+    return mlir::remark::RemarkOpts::name(name)
+        .category("TokenReuse")
+        .subCategory("OneShot")
+        .function(getOperation().getSymName());
+  }
+
+  void emitReusedRemark(TokenAcceptor acceptor, mlir::Value source,
+                        bool realloc, int score, size_t availableTokens,
+                        size_t compatibleTokens) {
+    auto remark =
+        mlir::remark::passed(acceptor->getLoc(), remarkOpts("TokenReused"));
+    if (!remark)
+      return;
+    // Preserve the LocationAttr alongside its printed form so a custom
+    // streamer can serialize its full structure instead of reparsing text.
+    remark << mlir::remark::detail::Remark::Arg(
+                  "Source", static_cast<mlir::LocationAttr>(source.getLoc()))
+           << mlir::remark::metric("Strategy", realloc ? "realloc" : "ensure")
+           << mlir::remark::metric("Score", score)
+           << mlir::remark::metric("AvailableTokens", availableTokens)
+           << mlir::remark::metric("CompatibleTokens", compatibleTokens);
+  }
+
+  void emitNotReusedRemark(TokenAcceptor acceptor, size_t availableTokens,
+                           size_t compatibleTokens) {
+    llvm::StringRef reason =
+        availableTokens == 0 ? "no-available-token" : "no-compatible-token";
+    mlir::remark::missed(acceptor->getLoc(), remarkOpts("TokenNotReused"))
+        << mlir::remark::metric("Reason", reason)
+        << mlir::remark::metric("AvailableTokens", availableTokens)
+        << mlir::remark::metric("CompatibleTokens", compatibleTokens);
+  }
+
   ValueSet oneShotTokenReuse(
       mlir::Region &region, ValueSet availableTokens,
       llvm::SmallVectorImpl<Reuse> &reuses, llvm::SmallVectorImpl<Free> &frees,
@@ -426,6 +462,10 @@ struct TokenReusePass : public impl::ReussirTokenReusePassBase<TokenReusePass> {
       signalPassFailure();
       return {};
     }
+
+    // Keep the disabled path free of remark bookkeeping. In particular, the
+    // compatibility count would otherwise add work to this pass's hot loop.
+    const bool shouldEmitRemarks = emitRemarks;
 
     for (auto &op : region.front()) {
       if (isa<mlir::LoopLikeOpInterface>(op) ||
@@ -496,6 +536,7 @@ struct TokenReusePass : public impl::ReussirTokenReusePassBase<TokenReusePass> {
         auto allocOp = llvm::dyn_cast_if_present<ReussirTokenAllocOp>(
             acceptor.getToken().getDefiningOp());
         if (allocOp && allocOp.getToken().hasOneUse()) {
+          size_t compatibleTokenCount = 0;
           int bestScore = -1;
           mlir::Value bestToken{};
           bool bestRealloc = false;
@@ -509,6 +550,8 @@ struct TokenReusePass : public impl::ReussirTokenReusePassBase<TokenReusePass> {
                   producerAsDec ? producerAsDec.getRcPtr() : nullptr;
               int score = heuristic(producer.getTokenType(), producerRc,
                                     acceptor, equivalence);
+              if (shouldEmitRemarks && score >= 0)
+                ++compatibleTokenCount;
               if (score >= 0 && (score > bestScore ||
                                  (score == bestScore && bestToken &&
                                   tokenOrderKey(dfsOrder, tokenVal) >
@@ -533,6 +576,8 @@ struct TokenReusePass : public impl::ReussirTokenReusePassBase<TokenReusePass> {
                     llvm::cast<mlir::OpResult>(tokenVal).getResultNumber());
                 int score =
                     heuristic(producedType, producerRc, acceptor, equivalence);
+                if (shouldEmitRemarks && score >= 0)
+                  ++compatibleTokenCount;
                 if (score >= 0 && (score > bestScore ||
                                    (score == bestScore && bestToken &&
                                     tokenOrderKey(dfsOrder, tokenVal) >
@@ -547,8 +592,14 @@ struct TokenReusePass : public impl::ReussirTokenReusePassBase<TokenReusePass> {
 
           if (bestToken) {
             mlir::Value selectedToken = bestToken;
+            if (shouldEmitRemarks)
+              emitReusedRemark(acceptor, selectedToken, bestRealloc, bestScore,
+                               availableTokens.size(), compatibleTokenCount);
             availableTokens = availableTokens.erase(bestToken);
             reuses.push_back({selectedToken, bestRealloc, acceptor});
+          } else if (shouldEmitRemarks) {
+            emitNotReusedRemark(acceptor, availableTokens.size(),
+                                compatibleTokenCount);
           }
         }
         // ReussirClosureCreateOp is a kind of acceptor.

--- a/tests/integration/conversion/straight_line_reuse.mlir
+++ b/tests/integration/conversion/straight_line_reuse.mlir
@@ -1,4 +1,10 @@
 // RUN: %reussir-opt %s -reussir-token-reuse | %FileCheck %s
+// RUN: %reussir-opt %s --reussir-token-reuse=emit-remarks=1 --remarks-filter=TokenReuse --remark-format=emitRemark -o %t.remarks.mlir 2>&1 | %FileCheck %s --check-prefix=REMARK
+
+// REMARK: remark: [Passed] TokenReused | Category:TokenReuse:OneShot | Function=reuse | AvailableTokens=1, CompatibleTokens=1, Score=2, Source=loc("{{.*}}straight_line_reuse.mlir":{{[0-9]+}}:14), Strategy=ensure
+// REMARK: remark: [Missed] TokenNotReused | Category:TokenReuse:OneShot | Function=no_cross_bin_realloc | AvailableTokens=1, CompatibleTokens=0, Reason=no-compatible-token
+// REMARK: remark: [Passed] TokenReused | Category:TokenReuse:OneShot | Function=same_bin_realloc | AvailableTokens=1, CompatibleTokens=1, Score=1, Source=loc("{{.*}}straight_line_reuse.mlir":{{[0-9]+}}:14), Strategy=realloc
+// REMARK: remark: [Missed] TokenNotReused | Category:TokenReuse:OneShot | Function=no_available | AvailableTokens=0, CompatibleTokens=0, Reason=no-available-token
 
 !rc64 = !reussir.rc<i64>
 !rc64x2 = !reussir.rc<!reussir.record<compound "test" {i64, i64}>>
@@ -55,5 +61,12 @@ module @test attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<f80, dense<
         %tk = reussir.token.alloc : !reussir.token<align: 8, size: 80>
         %6 = reussir.rc.create value(%5 : !reussir.record<compound "test9" {i64, i64, i64, i64, i64, i64, i64, i64, i64}>) token(%tk : !reussir.token<align: 8, size: 80>) : !rc64x9
         return %6 : !rc64x9
+    }
+
+    func.func @no_available() -> !rc64 {
+        %value = arith.constant 0 : i64
+        %tk = reussir.token.alloc : !reussir.token<align: 8, size: 16>
+        %result = reussir.rc.create value(%value : i64) token(%tk : !reussir.token<align: 8, size: 16>) : !rc64
+        return %result : !rc64
     }
 }

--- a/tests/integration/frontend/token_reuse_remarks.rr
+++ b/tests/integration/frontend/token_reuse_remarks.rr
@@ -1,0 +1,62 @@
+// RUN: %rrc %s --emit mlir-llvm -O none --target-triple wasm32-unknown-unknown --codegen-units 2 -o %t.mlir-llvm --token-reuse-remarks %t.json
+// RUN: %FileCheck %s --check-prefix=JSON < %t.json
+// RUN: %not %rrc %s --emit mlir -o %t.early.mlir --token-reuse-remarks %t.early.json 2>&1 | %FileCheck %s --check-prefix=EARLY
+
+pub enum Box<T> {
+    Wrap(T)
+}
+
+fn update<T>(boxed: Box<T>, value: T) -> Box<T> {
+    match boxed {
+        Box::Wrap(_) => {
+            let next = value;
+            Box::Wrap { next }
+        }
+    }
+}
+
+pub fn update_i64(boxed: Box<i64>, value: i64) -> Box<i64> {
+    update(boxed, value)
+}
+
+pub fn update_i32(boxed: Box<i32>, value: i32) -> Box<i32> {
+    update(boxed, value)
+}
+
+// JSON: "schema": "reussir.token-reuse.v1"
+// JSON: "coordinates": {
+// JSON: "line_base": 1
+// JSON: "column_base": 1
+// JSON: "column_unit": "utf-8-byte"
+// JSON: "end": "exclusive"
+// JSON: "files": [
+// JSON-NEXT: "{{.*}}token_reuse_remarks.rr"
+// JSON: "locations": [
+// JSON: "kind": "file"
+// JSON: "start": {
+// JSON-NEXT: "line": 11
+// JSON-NEXT: "column": 25
+// JSON: "end": {
+// JSON-NEXT: "line": 14
+// JSON-NEXT: "column": 10
+// JSON: "kind": "file"
+// JSON: "start": {
+// JSON-NEXT: "line": 13
+// JSON-NEXT: "column": 13
+// JSON: "end": {
+// JSON-NEXT: "line": 13
+// JSON-NEXT: "column": 31
+// JSON: "decisions": [
+// JSON: "kind": "reuse"
+// JSON-NEXT: "sink": 1
+// JSON-NEXT: "source": 0
+// JSON-NEXT: "strategy": "ensure"
+// JSON-NEXT: "score": 2
+// JSON-NEXT: "available_tokens": 1
+// JSON-NEXT: "compatible_tokens": 1
+// JSON-NEXT: "instances": [
+// JSON-NEXT: "_RIC6update{{.*}}E"
+// JSON-NEXT: "_RIC6update{{.*}}E"
+// JSON: "occurrences": 2
+
+// EARLY: --token-reuse-remarks requires the lowering pipeline

--- a/tests/integration/rene/build.rr
+++ b/tests/integration/rene/build.rr
@@ -32,6 +32,20 @@
 
 // FRESH: up to date
 
+// Token-reuse reports are cached sidecars named after the compiled product.
+// Turning them on after the ordinary build recompiles once to materialize the
+// report; the JSON is directly consumable, and the shared plan shows the exact
+// rrc boundary.
+// RUN: %rene build --manifest-path %S/build/rene.ncl --build-dir %t.bdir --token-reuse-remarks %rrc_linker | %FileCheck %s --check-prefix=LISTING
+// RUN: %FileCheck %s --check-prefix=REMARK < %t.bdir/dev/demo%exe_ext.token-reuse.json
+// RUN: %rene inspect --manifest-path %S/build/rene.ncl --build-dir %t.bdir --frozen --commands --token-reuse-remarks | %FileCheck %s --check-prefix=REMARK-PLAN
+
+// REMARK: "schema": "reussir.token-reuse.v1"
+// REMARK: "locations":
+// REMARK: "decisions":
+// REMARK-PLAN: "--token-reuse-remarks",
+// REMARK-PLAN-NEXT: "{{.*}}demo{{.*}}.token-reuse.json",
+
 // A profile builds into its own directory with its own knobs (`release`
 // here also refines the built-in with the manifest's `codegen_units = 2`,
 // exercising the multi-unit link under rene).
@@ -59,9 +73,10 @@
 // A cross-target plan needs no target toolchain to render: the public
 // contract already names the WASI target at rrc's boundary and gives the
 // executable its WebAssembly suffix.
-// RUN: %rene inspect --manifest-path %S/build/rene.ncl --build-dir %t.bdir --frozen --commands --target wasm32-wasip1 | %FileCheck %s --check-prefix=WASM
+// RUN: %rene inspect --manifest-path %S/build/rene.ncl --build-dir %t.bdir --frozen --commands --target wasm32-wasip1 --token-reuse-remarks | %FileCheck %s --check-prefix=WASM
 
 // WASM: "{{.*[/\\]+}}dev{{[/\\]+}}demo.wasm"
+// WASM: "{{.*[/\\]+}}dev{{[/\\]+}}demo.wasm.token-reuse.json"
 // WASM: "--target-triple",
 // WASM-NEXT: "wasm32-wasip1",
 // WASM: "target": "wasm32-wasip1"

--- a/tests/integration/rene/build.rr
+++ b/tests/integration/rene/build.rr
@@ -44,7 +44,7 @@
 // REMARK: "locations":
 // REMARK: "decisions":
 // REMARK-PLAN: "--token-reuse-remarks",
-// REMARK-PLAN-NEXT: "{{.*}}demo{{.*}}.token-reuse.json",
+// REMARK-PLAN: "{{.*}}demo{{.*}}.token-reuse.json",
 
 // A profile builds into its own directory with its own knobs (`release`
 // here also refines the built-in with the manifest's `codegen_units = 2`,
@@ -76,9 +76,9 @@
 // RUN: %rene inspect --manifest-path %S/build/rene.ncl --build-dir %t.bdir --frozen --commands --target wasm32-wasip1 --token-reuse-remarks | %FileCheck %s --check-prefix=WASM
 
 // WASM: "{{.*[/\\]+}}dev{{[/\\]+}}demo.wasm"
-// WASM: "{{.*[/\\]+}}dev{{[/\\]+}}demo.wasm.token-reuse.json"
 // WASM: "--target-triple",
 // WASM-NEXT: "wasm32-wasip1",
+// WASM: "{{.*[/\\]+}}dev{{[/\\]+}}demo.wasm.token-reuse.json"
 // WASM: "target": "wasm32-wasip1"
 
 // An undeclared profile or binary target is refused by name.

--- a/tests/unittest/CMakeLists.txt
+++ b/tests/unittest/CMakeLists.txt
@@ -16,6 +16,7 @@ target_sources(
 target_link_libraries(reussir-ut
   PRIVATE
     ReussirRustCompiler
+    ReussirCAPI
     MLIRReussir
     GTest::gtest
     GTest::gtest_main

--- a/tests/unittest/cases/reuse_remarks.cpp
+++ b/tests/unittest/cases/reuse_remarks.cpp
@@ -17,6 +17,11 @@
 #include <llvm/Support/FileUtilities.h>
 #include <llvm/Support/JSON.h>
 #include <llvm/Support/MemoryBuffer.h>
+
+// Complete mlir::DialectVersion before MLIR C API headers reach
+// BytecodeWriter.h; MSVC's STL rejects destroying unique_ptr<T> when T is only
+// forward declared.
+#include <mlir/Bytecode/BytecodeImplementation.h>
 #include <mlir/CAPI/IR.h>
 #include <mlir/CAPI/Support.h>
 #include <mlir/IR/BuiltinAttributes.h>

--- a/tests/unittest/cases/reuse_remarks.cpp
+++ b/tests/unittest/cases/reuse_remarks.cpp
@@ -1,0 +1,118 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
+// the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+//===----------------------------------------------------------------------===//
+
+#include "Reussir-c/Passes.h"
+
+#include <gtest/gtest.h>
+
+#include <llvm/ADT/SmallString.h>
+#include <llvm/Support/FileSystem.h>
+#include <llvm/Support/FileUtilities.h>
+#include <llvm/Support/JSON.h>
+#include <llvm/Support/MemoryBuffer.h>
+#include <mlir/CAPI/IR.h>
+#include <mlir/CAPI/Support.h>
+#include <mlir/IR/BuiltinAttributes.h>
+#include <mlir/IR/MLIRContext.h>
+#include <mlir/IR/Remarks.h>
+
+namespace {
+
+TEST(TokenReuseRemarks, DeduplicatesLocationsAndGenericInstances) {
+  llvm::SmallString<128> path;
+  ASSERT_FALSE(
+      llvm::sys::fs::createTemporaryFile("reussir-reuse", "json", path));
+  llvm::FileRemover remove(path);
+
+  {
+    mlir::MLIRContext context;
+    MlirStringRef outputPath{path.data(), path.size()};
+    ASSERT_TRUE(
+        reussirContextEnableTokenReuseRemarks(wrap(&context), outputPath));
+
+    mlir::Location source =
+        mlir::FileLineColRange::get(&context, "generic.rr", 2, 3, 2, 9);
+    mlir::Location reuseSink =
+        mlir::FileLineColRange::get(&context, "generic.rr", 8, 5, 8, 19);
+    mlir::Location allocateSink =
+        mlir::FileLineColRange::get(&context, "generic.rr", 12, 7, 12, 15);
+
+    // Monomorphized functions commonly have distinct debug metadata wrapped
+    // around the same source location. The JSON streamer deliberately strips
+    // one-child fused wrappers so both instances share one decision/location.
+    for (llvm::StringRef instance : {"generic<i32>", "generic<i64>"}) {
+      mlir::Attribute metadata = mlir::StringAttr::get(&context, instance);
+      mlir::Location wrappedSource =
+          mlir::FusedLoc::get(&context, {source}, metadata);
+      mlir::Location wrappedSink =
+          mlir::FusedLoc::get(&context, {reuseSink}, metadata);
+      auto remark = mlir::remark::passed(
+          wrappedSink, mlir::remark::RemarkOpts::name("TokenReused")
+                           .category("TokenReuse")
+                           .subCategory("OneShot")
+                           .function(instance));
+      ASSERT_TRUE(remark);
+      remark << mlir::remark::detail::Remark::Arg(
+                    "Source", static_cast<mlir::LocationAttr>(wrappedSource))
+             << mlir::remark::metric("Strategy", "ensure")
+             << mlir::remark::metric("Score", 2)
+             << mlir::remark::metric("AvailableTokens", 1)
+             << mlir::remark::metric("CompatibleTokens", 1);
+    }
+
+    mlir::remark::missed(allocateSink,
+                         mlir::remark::RemarkOpts::name("TokenNotReused")
+                             .category("TokenReuse")
+                             .subCategory("OneShot")
+                             .function("allocate"))
+        << mlir::remark::metric("Reason", "no-available-token")
+        << mlir::remark::metric("AvailableTokens", 0)
+        << mlir::remark::metric("CompatibleTokens", 0);
+  }
+
+  auto buffer = llvm::MemoryBuffer::getFile(path);
+  ASSERT_TRUE(static_cast<bool>(buffer)) << buffer.getError().message();
+  auto parsed = llvm::json::parse((*buffer)->getBuffer());
+  ASSERT_TRUE(static_cast<bool>(parsed)) << llvm::toString(parsed.takeError());
+  const llvm::json::Object *report = parsed->getAsObject();
+  ASSERT_NE(report, nullptr);
+  EXPECT_EQ(report->getString("schema"), "reussir.token-reuse.v1");
+
+  const llvm::json::Array *files = report->getArray("files");
+  ASSERT_NE(files, nullptr);
+  ASSERT_EQ(files->size(), 1u);
+  EXPECT_EQ((*files)[0].getAsString(), "generic.rr");
+
+  const llvm::json::Array *locations = report->getArray("locations");
+  ASSERT_NE(locations, nullptr);
+  EXPECT_EQ(locations->size(), 3u);
+
+  const llvm::json::Array *decisions = report->getArray("decisions");
+  ASSERT_NE(decisions, nullptr);
+  ASSERT_EQ(decisions->size(), 2u);
+  const llvm::json::Object *reuse = (*decisions)[0].getAsObject();
+  ASSERT_NE(reuse, nullptr);
+  EXPECT_EQ(reuse->getString("kind"), "reuse");
+  EXPECT_NE(reuse->getInteger("source"), reuse->getInteger("sink"));
+  EXPECT_EQ(reuse->getInteger("occurrences"), 2);
+  const llvm::json::Array *instances = reuse->getArray("instances");
+  ASSERT_NE(instances, nullptr);
+  ASSERT_EQ(instances->size(), 2u);
+  EXPECT_EQ((*instances)[0].getAsString(), "generic<i32>");
+  EXPECT_EQ((*instances)[1].getAsString(), "generic<i64>");
+
+  const llvm::json::Object *allocate = (*decisions)[1].getAsObject();
+  ASSERT_NE(allocate, nullptr);
+  EXPECT_EQ(allocate->getString("kind"), "allocate");
+  EXPECT_EQ(allocate->getString("reason"), "no-available-token");
+  EXPECT_FALSE(allocate->get("source"));
+}
+
+} // namespace


### PR DESCRIPTION
## Summary

- add opt-in Passed/Missed MLIR remarks for every one-shot token allocation/reuse decision
- stream deterministic reussir.token-reuse.v1 JSON with structural source locations, shared location IDs, and grouped generic instances
- wire --token-reuse-remarks through rrc and rene, including target-independent per-artifact sidecars and freshness tracking
- preserve the disabled hot path and use enum-backed decision/location state with numeric IDs

## Tests

- C++ unit suite: 32 passed
- reussir-compiler / rrc suite: passed
- reussir-codegen suite: passed
- rene suite: 75 passed, 1 ignored
- focused lit tests for MLIR remarks and rrc JSON: passed
- full lit suite: in progress before marking ready

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/571"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789496133&installation_model_id=426051&pr_number=571&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F571&signature=69ea9427405ecf2b5754ecb0f6dbb6939da8b6e1d26ae5b68cdc84d67dff4194"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->