### PR TITLE
[backend][rt] instrument non-linear ffi/array usage at FFI boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,20 @@
   decisive element rather than folding the whole container, and `find`
   returns the least match rather than an unspecified one.
 
+### Compiler and runtime
+
+- `rrc --instrument-nonlinear-ffi` (and the matching
+  `instrument_nonlinear_ffi` profile knob in `rene`) instruments non-linear
+  ffi/array usage: the new `reussir-instrument-nonlinear-ffi` pass guards
+  every FFI-import call that consumes an rc'd `ffi_object`/`array` argument
+  with a reference-count check, and a count other than one calls the new
+  runtime entry point `__reussir_report_nonlinear_usage(file, line,
+  col)`, which reports the call's source location on stderr. A still-shared
+  value at the consuming boundary is the signature that the foreign side
+  degrades to copy-on-write instead of updating in place; the check is
+  purely diagnostic and runs after all rc optimization passes, so the
+  observed count is the final one.
+
 ## 0.1.0
 
 The first tagged release of Reussir: an MLIR-based compiler framework for

--- a/crates/rene/src/compile.rs
+++ b/crates/rene/src/compile.rs
@@ -424,6 +424,9 @@ pub(crate) fn profile_flags(
     if profile.reuse_across_call == Some(true) {
         args.push("--reuse-across-call".to_owned());
     }
+    if profile.instrument_nonlinear_ffi == Some(true) {
+        args.push("--instrument-nonlinear-ffi".to_owned());
+    }
     if profile.closure_wpd == Some(false) {
         args.push("--no-closure-wpd".to_owned());
     }

--- a/crates/rene/src/manifest.rs
+++ b/crates/rene/src/manifest.rs
@@ -161,6 +161,8 @@ pub struct Profile {
     pub target_features: Option<String>,
     /// `rrc --reuse-across-call` when true.
     pub reuse_across_call: Option<bool>,
+    /// `rrc --instrument-nonlinear-ffi` when true.
+    pub instrument_nonlinear_ffi: Option<bool>,
     /// `rrc --no-closure-wpd` when false (the knob is spelled positively
     /// here; unset leaves rrc's own default).
     pub closure_wpd: Option<bool>,
@@ -196,6 +198,7 @@ impl Profile {
             target_cpu,
             target_features,
             reuse_across_call,
+            instrument_nonlinear_ffi,
             closure_wpd,
             pack_record_members
         );

--- a/crates/reussir-backend-sys/build.rs
+++ b/crates/reussir-backend-sys/build.rs
@@ -35,6 +35,7 @@ const REUSSIR_ARCHIVES: &[&str] = &[
     "MLIRReussirTokenInstantiation",
     "MLIRReussirClosureOutlining",
     "MLIRReussirCompilePolymorphicFFI",
+    "MLIRReussirInstrumentNonlinearFFI",
     "MLIRReussirAttachNativeTarget",
     "MLIRReussirClosureBetaReduction",
     "MLIRReussirDefaultInliner",

--- a/crates/reussir-backend-sys/src/lib.rs
+++ b/crates/reussir-backend-sys/src/lib.rs
@@ -143,6 +143,7 @@ unsafe extern "C" {
     pub fn reussirCreateRcCreateFusionPass() -> MlirPass;
     pub fn reussirCreateTRMCRecursionAnalysisPass() -> MlirPass;
     pub fn reussirCreateCompilePolymorphicFFIPass(optimized: bool) -> MlirPass;
+    pub fn reussirCreateInstrumentNonlinearFFIPass() -> MlirPass;
     pub fn reussirCreateInvariantGroupAnalysisPass() -> MlirPass;
     pub fn reussirCreateBasicOpsLoweringPass(closure_wpd: bool) -> MlirPass;
     pub fn reussirCreateDebugInfoConversionPass() -> MlirPass;

--- a/crates/reussir-backend/src/pipeline.rs
+++ b/crates/reussir-backend/src/pipeline.rs
@@ -151,6 +151,14 @@ pub struct LoweringOptions {
     /// zero overhead: no transform pass is added and the pipeline is exactly
     /// the fixed pass list. `rrc` exposes this as `--transform-script`.
     pub transform_scripts: Vec<(Anchor, PathBuf)>,
+    /// Instrument non-linear ffi/array usage: before every FFI-import call
+    /// that consumes an rc'd `ffi_object`/`array` argument, check the
+    /// reference count and report the call's source location to the runtime
+    /// (`__reussir_report_nonlinear_usage`) when it is not one — the
+    /// signature that the foreign side degrades to copy-on-write instead of
+    /// updating in place. Purely diagnostic; `rrc` exposes it as
+    /// `--instrument-nonlinear-ffi`.
+    pub instrument_nonlinear_ffi: bool,
     /// Emit whole-program devirtualization artifacts for closures (a `!type`
     /// id per vtable, keyed by return type, plus a call-site type test at
     /// every indirect eval/clone/drop). The backend pipeline's SPECULATIVE
@@ -179,6 +187,9 @@ impl Default for LoweringOptions {
             // layout contract; only an explicit driver flag turns it off.
             pack_record_members: true,
             transform_scripts: Vec::new(),
+            // Off by default: instrumentation is an explicit diagnostic
+            // request.
+            instrument_nonlinear_ffi: false,
             // Off by default: embedders opt in explicitly; `rrc` turns it on
             // at `-O aggressive`/`-O size`.
             closure_wpd: false,
@@ -285,6 +296,7 @@ pub fn run_lowering_pipeline(
         enable_invariant_analysis = options.enable_invariant_analysis,
         nullary_variant_encoding = ?options.nullary_variant_encoding,
         pack_record_members = options.pack_record_members,
+        instrument_nonlinear_ffi = options.instrument_nonlinear_ffi,
         inline_transform,
     )
     .entered();
@@ -397,6 +409,12 @@ pub fn run_lowering_pipeline(
         func:   sys::reussirCreateRcCreateSinkPass();
         func:   sys::reussirCreateRcCreateFusionPass();
         module: sys::reussirCreateTRMCRecursionAnalysisPass();
+        // After every rc optimization pass (cancellation, token reuse,
+        // create sink/fusion), so the count each check observes is the
+        // final one, and before the scf dialect is lowered away.
+        if options.instrument_nonlinear_ffi => {
+            module: sys::reussirCreateInstrumentNonlinearFFIPass();
+        }
         module: sys::reussirCreateCompilePolymorphicFFIPass(false);
 
         // `kernel` anchor: the Reussir-level work is done (both

--- a/crates/reussir-compiler/src/driver/backend.rs
+++ b/crates/reussir-compiler/src/driver/backend.rs
@@ -142,6 +142,7 @@ pub(crate) fn backend_module(
     let options = LoweringOptions {
         opt,
         reuse_token_across_call: cli.reuse_across_call,
+        instrument_nonlinear_ffi: cli.instrument_nonlinear_ffi,
         emit_token_reuse_remarks: cli.token_reuse_remarks.is_some(),
         nullary_variant_encoding: cli.nullary_variant_encoding.resolve(machine.triple()),
         pack_record_members: !cli.no_pack_record_members,

--- a/crates/reussir-compiler/src/driver/cli.rs
+++ b/crates/reussir-compiler/src/driver/cli.rs
@@ -180,6 +180,14 @@ pub(crate) struct Cli {
     #[arg(long = "reuse-across-call")]
     pub(crate) reuse_across_call: bool,
 
+    /// Instrument non-linear ffi/array usage: before every FFI-import call
+    /// that consumes an rc'd ffi/array value, check its reference count and
+    /// report the call's source location on stderr when it is not 1 — the
+    /// signature that the foreign side copies-on-write instead of updating
+    /// in place. Purely diagnostic; program semantics are unchanged.
+    #[arg(long = "instrument-nonlinear-ffi")]
+    pub(crate) instrument_nonlinear_ffi: bool,
+
     /// Write every token-reuse decision to this JSON file. The report uses a
     /// shared location table (including source ranges and nested call-site
     /// locations) and groups identical generic instances instead of repeating

--- a/crates/reussir-rt/src/instrument.rs
+++ b/crates/reussir-rt/src/instrument.rs
@@ -1,0 +1,44 @@
+//! Diagnostic entry points for compiler-inserted instrumentation.
+//!
+//! `rrc --instrument-nonlinear-ffi` (and `rene`'s `instrument_nonlinear_ffi`
+//! profile knob) guard every FFI-import call that consumes an rc'd ffi/array
+//! value with a reference-count check; a count other than one calls
+//! [`__reussir_report_nonlinear_usage`] with the call's source location.
+//! Such a call is the signature of non-linear usage: the boundary consumes
+//! its arguments, so a still-shared box forces the foreign side to
+//! copy-on-write instead of updating in place.
+
+use core::ffi::{CStr, c_char};
+
+/// Reports a non-linear ffi/array consumption on stderr.
+///
+/// `file` is a NUL-terminated UTF-8 path (may be null or empty when the call
+/// site carries no location); `line` and `col` are 1-based, 0 when unknown.
+/// Purely diagnostic: it never aborts and has no effect on program state.
+///
+/// # Safety
+///
+/// `file` must be null or point to a NUL-terminated string that stays live
+/// for the duration of the call.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn __reussir_report_nonlinear_usage(
+    file: *const c_char,
+    line: u32,
+    col: u32,
+) {
+    let file = if file.is_null() {
+        String::new()
+    } else {
+        unsafe { CStr::from_ptr(file) }.to_string_lossy().into_owned()
+    };
+    let location = if file.is_empty() {
+        "<unknown location>".to_owned()
+    } else {
+        format!("{file}:{line}:{col}")
+    };
+    eprintln!(
+        "[reussir] non-linear ffi/array usage at {location}: value consumed \
+         by an FFI call while its reference count is not 1 (the foreign side \
+         will copy instead of updating in place)"
+    );
+}

--- a/crates/reussir-rt/src/lib.rs
+++ b/crates/reussir-rt/src/lib.rs
@@ -14,6 +14,7 @@ static GLOBAL: alloc::ReussirGlobalAlloc = alloc::ReussirGlobalAlloc;
 pub mod alloc;
 pub mod bridge;
 pub mod collections;
+pub mod instrument;
 pub mod nullable;
 pub mod option;
 pub mod panic;

--- a/crates/reussir-rt/src/symbols.rs
+++ b/crates/reussir-rt/src/symbols.rs
@@ -14,6 +14,7 @@ use crate::alloc::{
     __reussir_allocate, __reussir_allocate_small, __reussir_dealloc_unsized, __reussir_deallocate,
     __reussir_realloc_unsized, __reussir_reallocate,
 };
+use crate::instrument::__reussir_report_nonlinear_usage;
 use crate::panic::__reussir_panic;
 use crate::region::{
     __reussir_acquire_rigid_object, __reussir_cleanup_region, __reussir_freeze_flex_object,
@@ -56,6 +57,7 @@ pub fn exported_symbols() -> &'static [RuntimeSymbol] {
         __reussir_reallocate,
         __reussir_realloc_unsized,
         __reussir_panic,
+        __reussir_report_nonlinear_usage,
         __reussir_freeze_flex_object,
         __reussir_cleanup_region,
         __reussir_acquire_rigid_object,

--- a/docs/design/nonlinear-ffi-instrumentation.md
+++ b/docs/design/nonlinear-ffi-instrumentation.md
@@ -1,0 +1,77 @@
+# Non-linear FFI usage instrumentation
+
+The `reussir-instrument-nonlinear-ffi` pass guards every FFI-import call that
+consumes an rc'd `ffi_object` or `array` argument with a reference-count
+check. A count other than one at the boundary calls the runtime entry point
+`__reussir_report_nonlinear_usage(file, line, col)`, which prints the
+call's source location on stderr.
+
+Instrumentation is off by default. It is diagnostic output and never changes
+program semantics: a shared value still crosses the boundary, the foreign side
+still copies on write, and the result is identical.
+
+## Why the count matters at the boundary
+
+The FFI boundary follows the owned calling convention: every call consumes its
+rc arguments (`docs/design/polymorphic-ffi.md`, "Ownership: the boundary
+consumes"). When the caller still needs the value afterwards, the Perceus
+analysis retains it (`reussir.rc.inc`) before the call, so the count the
+callee observes is greater than one. For copy-on-write foreign structures —
+`reussir_rt::collections::vec::Vec` and everything else built on the foreign
+`Rc` header — that is exactly the case where an "in-place" update silently
+clones the whole payload. The instrumentation makes that cliff observable at
+its source location.
+
+## Entry points
+
+```sh
+reussir-opt input.mlir --reussir-instrument-nonlinear-ffi
+rrc input.rr -o demo.o --instrument-nonlinear-ffi
+```
+
+`rene` profiles spell it positively:
+
+```toml
+[profiles.dev]
+instrument_nonlinear_ffi = true
+```
+
+## What the pass emits
+
+FFI call sites are ordinary `func.call`s whose callee is the body-less native
+declaration a `reussir.trampoline import` names as its `target`. For each such
+call, and for each argument whose type is `!reussir.rc` of an `ffi_object` or
+`array` payload (region-managed capabilities are skipped — their boxes carry
+no ordinary count), the pass inserts before the call:
+
+```mlir
+%count  = reussir.rc.fetch (%arg : ...) : index
+%shared = arith.cmpi ne, %count, %c1
+%cold   = reussir.expect(%shared : i1, false) : i1
+scf.if %cold {
+  llvm.call @__reussir_report_nonlinear_usage(%file, %line, %col)
+}
+```
+
+The file name is a content-addressed (`Blake3Symbol.h`), NUL-terminated
+`llvm.mlir.global`; line and column come from the call's `FileLineColLoc`
+(resolved through fused/name/call-site locations, zero when absent). The
+report path is `reussir.expect`'ed cold.
+
+## Pipeline position
+
+The pass runs after `reussir-token-reuse` and the `rc-create-sink`/
+`rc-create-fusion` pair and before `reussir-compile-polymorphic-ffi` — after
+every pass that can change a reference count, so the observed count is the
+final one, and before `scf` is lowered away. Running it earlier would be
+wrong twice over: `inc-dec-cancellation` treats `reussir.rc.is_unique` as a
+barrier but not `reussir.rc.fetch`, so an early fetch could observe a count a
+cancelled pair later invalidates; and an early check would perturb the very
+optimizations whose residue it is meant to report.
+
+## Runtime
+
+`__reussir_report_nonlinear_usage` lives in `reussir-rt`
+(`src/instrument.rs`) and is registered in the JIT symbol table
+(`src/symbols.rs`). It never aborts; it writes one line per firing check to
+stderr.

--- a/include/Reussir-c/Passes.h
+++ b/include/Reussir-c/Passes.h
@@ -65,6 +65,11 @@ MlirPass reussirCreatePartialMovePass(void);
 MlirPass reussirCreateRcCreateFusionPass(void);
 MlirPass reussirCreateTRMCRecursionAnalysisPass(void);
 MlirPass reussirCreateCompilePolymorphicFFIPass(bool optimized);
+// Instruments FFI-import calls that consume rc'd ffi_object/array arguments:
+// a count != 1 at the call reports the source location to the runtime
+// (`__reussir_report_nonlinear_usage`). Add only when instrumentation is
+// requested; schedule after the rc optimization passes.
+MlirPass reussirCreateInstrumentNonlinearFFIPass(void);
 MlirPass reussirCreateInvariantGroupAnalysisPass(void);
 MlirPass reussirCreateBasicOpsLoweringPass(bool closureWpd);
 MlirPass reussirCreateDebugInfoConversionPass(void);

--- a/include/Reussir/Conversion/Passes.td
+++ b/include/Reussir/Conversion/Passes.td
@@ -257,6 +257,42 @@ def ReussirCompilePolymorphicFFIPass
 }
 
 //===----------------------------------------------------------------------===//
+// InstrumentNonlinearFFI
+//===----------------------------------------------------------------------===//
+def ReussirInstrumentNonlinearFFIPass
+    : Pass<"reussir-instrument-nonlinear-ffi", "::mlir::ModuleOp"> {
+  let summary = "report non-linearly used ffi/array values consumed by FFI "
+                "calls at runtime";
+  let description = [{
+    `reussir-instrument-nonlinear-ffi` instruments every call to an
+    FFI-imported function (the `target` of a `reussir.trampoline import`):
+    for each `!reussir.rc` argument whose payload is an `ffi_object` or an
+    `array`, it emits a guarded runtime report before the call:
+
+    ```mlir
+    %count = reussir.rc.fetch (%arg : ...) : index
+    %shared = arith.cmpi ne, %count, %c1
+    scf.if %shared {  // reussir.expect'ed cold
+      llvm.call @__reussir_report_nonlinear_usage(%file, %line, %col)
+    }
+    ```
+
+    The owned calling convention consumes every rc argument, so a reference
+    count above one at the boundary means the value is used non-linearly and
+    the foreign side degrades to copy-on-write instead of updating in place.
+    The runtime function reports the call's source location on stderr. The
+    check is purely diagnostic and never changes program semantics; schedule
+    it after the rc optimization passes so the observed count is the final
+    one.
+  }];
+  let dependentDialects = ["::reussir::ReussirDialect",
+                           "::mlir::arith::ArithDialect",
+                           "::mlir::func::FuncDialect",
+                           "::mlir::scf::SCFDialect",
+                           "::mlir::LLVM::LLVMDialect"];
+}
+
+//===----------------------------------------------------------------------===//
 // ConvertToLLVM
 //===----------------------------------------------------------------------===//
 def ReussirConvertToLLVMPass

--- a/lib/CAPI/Passes.cpp
+++ b/lib/CAPI/Passes.cpp
@@ -126,6 +126,9 @@ MlirPass reussirCreateCompilePolymorphicFFIPass(bool optimized) {
   options.optimized = optimized;
   return wrapOwned(reussir::createReussirCompilePolymorphicFFIPass(options));
 }
+MlirPass reussirCreateInstrumentNonlinearFFIPass(void) {
+  return wrapOwned(reussir::createReussirInstrumentNonlinearFFIPass());
+}
 MlirPass reussirCreateInvariantGroupAnalysisPass(void) {
   return wrapOwned(reussir::createReussirInvariantGroupAnalysisPass());
 }

--- a/lib/Conversion/CMakeLists.txt
+++ b/lib/Conversion/CMakeLists.txt
@@ -7,6 +7,7 @@ add_subdirectory(RcDecrementExpansion)
 add_subdirectory(TokenInstantiation)
 add_subdirectory(ClosureOutlining)
 add_subdirectory(CompilePolymorphicFFI)
+add_subdirectory(InstrumentNonlinearFFI)
 add_subdirectory(AttachNativeTarget)
 
 set(REUSSIR_CONVERSION_AGGREGATE_LIBS
@@ -19,6 +20,7 @@ set(REUSSIR_CONVERSION_AGGREGATE_LIBS
   MLIRReussirTokenInstantiation
   MLIRReussirClosureOutlining
   MLIRReussirCompilePolymorphicFFI
+  MLIRReussirInstrumentNonlinearFFI
   MLIRReussirAttachNativeTarget
 )
 

--- a/lib/Conversion/InstrumentNonlinearFFI/CMakeLists.txt
+++ b/lib/Conversion/InstrumentNonlinearFFI/CMakeLists.txt
@@ -1,0 +1,17 @@
+add_mlir_conversion_library(MLIRReussirInstrumentNonlinearFFI
+  InstrumentNonlinearFFI.cpp
+
+  DEPENDS
+  MLIRReussirConversionPassIncGen
+
+  LINK_COMPONENTS
+  Core
+
+  LINK_LIBS PUBLIC
+  MLIRReussir
+  MLIRArithDialect
+  MLIRFuncDialect
+  MLIRLLVMDialect
+  MLIRSCFDialect
+  MLIRTransforms
+)

--- a/lib/Conversion/InstrumentNonlinearFFI/InstrumentNonlinearFFI.cpp
+++ b/lib/Conversion/InstrumentNonlinearFFI/InstrumentNonlinearFFI.cpp
@@ -1,0 +1,190 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
+// the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file implements the Reussir non-linear FFI usage instrumentation:
+/// before every FFI-import call that consumes an rc'd `ffi_object` or `array`
+/// argument, insert a reference-count check that reports the call site to the
+/// runtime when the count is not one.
+///
+//===----------------------------------------------------------------------===//
+
+#include <string>
+
+#include <llvm/ADT/DenseSet.h>
+#include <llvm/ADT/SmallVector.h>
+#include <llvm/ADT/StringRef.h>
+#include <llvm/Support/Casting.h>
+#include <mlir/Dialect/Arith/IR/Arith.h>
+#include <mlir/Dialect/Func/IR/FuncOps.h>
+#include <mlir/Dialect/LLVMIR/LLVMDialect.h>
+#include <mlir/Dialect/SCF/IR/SCF.h>
+#include <mlir/IR/Builders.h>
+#include <mlir/IR/BuiltinOps.h>
+#include <mlir/IR/Location.h>
+#include <mlir/Pass/Pass.h>
+
+#include "Reussir/Conversion/Blake3Symbol.h"
+#include "Reussir/IR/ReussirDialect.h"
+#include "Reussir/IR/ReussirEnumAttrs.h"
+#include "Reussir/IR/ReussirOps.h"
+#include "Reussir/IR/ReussirTypes.h"
+
+namespace reussir {
+
+#define GEN_PASS_DEF_REUSSIRINSTRUMENTNONLINEARFFIPASS
+#include "Reussir/Conversion/Passes.h.inc"
+
+namespace {
+
+constexpr llvm::StringLiteral kReportFunctionName =
+    "__reussir_report_nonlinear_usage";
+
+// The source position a location resolves to, for the runtime report. Walks
+// through fused, named, and call-site locations to the first file location
+// with a valid line (same policy as the debug-info conversion).
+struct SourcePos {
+  llvm::StringRef file;
+  unsigned line = 0;
+  unsigned col = 0;
+};
+
+SourcePos extractSourcePos(mlir::Location loc) {
+  if (auto fileLoc = llvm::dyn_cast<mlir::FileLineColLoc>(loc))
+    return {fileLoc.getFilename().getValue(), fileLoc.getLine(),
+            fileLoc.getColumn()};
+  if (auto fusedLoc = llvm::dyn_cast<mlir::FusedLoc>(loc)) {
+    for (mlir::Location inner : fusedLoc.getLocations()) {
+      SourcePos pos = extractSourcePos(inner);
+      if (pos.line != 0)
+        return pos;
+    }
+  }
+  if (auto nameLoc = llvm::dyn_cast<mlir::NameLoc>(loc))
+    return extractSourcePos(nameLoc.getChildLoc());
+  if (auto callSiteLoc = llvm::dyn_cast<mlir::CallSiteLoc>(loc))
+    return extractSourcePos(callSiteLoc.getCallee());
+  return {};
+}
+
+mlir::LLVM::LLVMFuncOp getOrCreateReportFunction(mlir::ModuleOp module) {
+  if (auto existing =
+          module.lookupSymbol<mlir::LLVM::LLVMFuncOp>(kReportFunctionName))
+    return existing;
+  mlir::MLIRContext *ctx = module.getContext();
+  auto ptrType = mlir::LLVM::LLVMPointerType::get(ctx);
+  auto i32Type = mlir::IntegerType::get(ctx, 32);
+  auto fnType = mlir::LLVM::LLVMFunctionType::get(
+      mlir::LLVM::LLVMVoidType::get(ctx), {ptrType, i32Type, i32Type});
+  mlir::OpBuilder builder(ctx);
+  builder.setInsertionPointToStart(module.getBody());
+  auto func = mlir::LLVM::LLVMFuncOp::create(
+      builder, mlir::UnknownLoc::get(ctx), kReportFunctionName, fnType);
+  func.setLinkage(mlir::LLVM::Linkage::External);
+  return func;
+}
+
+// The address of a content-addressed, NUL-terminated global holding `file`,
+// so the name crosses the boundary as a single C string.
+mlir::Value materializeFileName(mlir::OpBuilder &builder, mlir::Location loc,
+                                mlir::ModuleOp module, llvm::StringRef file) {
+  std::string payload = file.str();
+  payload.push_back('\0');
+  std::string globalName =
+      mangledBlake3Symbol("REUSSIR_NONLINEAR_FILE", payload);
+  if (!module.lookupSymbol<mlir::LLVM::GlobalOp>(globalName)) {
+    auto i8Type = mlir::IntegerType::get(builder.getContext(), 8);
+    auto arrayType = mlir::LLVM::LLVMArrayType::get(i8Type, payload.size());
+    mlir::OpBuilder::InsertionGuard guard(builder);
+    builder.setInsertionPointToStart(module.getBody());
+    mlir::LLVM::GlobalOp::create(builder, loc, arrayType,
+                                 /*isConstant=*/true,
+                                 mlir::LLVM::Linkage::LinkonceODR, globalName,
+                                 builder.getStringAttr(payload));
+  }
+  auto ptrType = mlir::LLVM::LLVMPointerType::get(builder.getContext());
+  return mlir::LLVM::AddressOfOp::create(builder, loc, ptrType, globalName);
+}
+
+// Before `call`, checks `operand`'s reference count and reports the call's
+// source position to the runtime when the count is not one. The report path
+// is `reussir.expect`'ed cold.
+void instrumentOperand(mlir::ModuleOp module, mlir::func::CallOp call,
+                       mlir::Value operand) {
+  mlir::OpBuilder builder(call);
+  mlir::Location loc = call.getLoc();
+  mlir::Value count =
+      ReussirRcFetchOp::create(builder, loc, operand).getRefCount();
+  mlir::Value one = mlir::arith::ConstantIndexOp::create(builder, loc, 1);
+  mlir::Value shared = mlir::arith::CmpIOp::create(
+      builder, loc, mlir::arith::CmpIPredicate::ne, count, one);
+  mlir::Value cold =
+      ReussirExpectOp::create(builder, loc, shared, false).getLikely();
+  auto ifOp = mlir::scf::IfOp::create(builder, loc, mlir::TypeRange{}, cold,
+                                      /*addThenBlock=*/true,
+                                      /*addElseBlock=*/false);
+  builder.setInsertionPointToStart(ifOp.thenBlock());
+  SourcePos pos = extractSourcePos(loc);
+  mlir::LLVM::LLVMFuncOp reportFn = getOrCreateReportFunction(module);
+  mlir::Value filePtr = materializeFileName(builder, loc, module, pos.file);
+  auto i32Type = builder.getI32Type();
+  mlir::Value line = mlir::LLVM::ConstantOp::create(
+      builder, loc, i32Type, builder.getI32IntegerAttr(pos.line));
+  mlir::Value col = mlir::LLVM::ConstantOp::create(
+      builder, loc, i32Type, builder.getI32IntegerAttr(pos.col));
+  mlir::LLVM::CallOp::create(builder, loc, reportFn,
+                             mlir::ValueRange{filePtr, line, col});
+  mlir::scf::YieldOp::create(builder, loc);
+}
+
+//===----------------------------------------------------------------------===//
+// InstrumentNonlinearFFIPass
+//===----------------------------------------------------------------------===//
+
+struct InstrumentNonlinearFFIPass
+    : public impl::ReussirInstrumentNonlinearFFIPassBase<
+          InstrumentNonlinearFFIPass> {
+  using Base::Base;
+  void runOnOperation() override {
+    mlir::ModuleOp module = getOperation();
+
+    // FFI call sites are ordinary `func.call`s whose callee is the native
+    // declaration an import trampoline names as its target.
+    llvm::DenseSet<llvm::StringRef> importTargets;
+    module.walk([&](ReussirTrampolineOp op) {
+      if (op.getDirection() == TrampolineDirection::Import)
+        importTargets.insert(op.getTarget());
+    });
+    if (importTargets.empty())
+      return;
+
+    llvm::SmallVector<mlir::func::CallOp> calls;
+    module.walk([&](mlir::func::CallOp call) {
+      if (importTargets.contains(call.getCallee()))
+        calls.push_back(call);
+    });
+
+    for (mlir::func::CallOp call : calls) {
+      for (mlir::Value operand : call.getArgOperands()) {
+        // Region-managed boxes do not carry an ordinary reference count.
+        auto rcType = llvm::dyn_cast<RcType>(operand.getType());
+        if (!rcType || rcType.isRegional())
+          continue;
+        if (!llvm::isa<FFIObjectType, ArrayType>(rcType.getElementType()))
+          continue;
+        instrumentOperand(module, call, operand);
+      }
+    }
+  }
+};
+
+} // namespace
+
+} // namespace reussir

--- a/tests/integration/conversion/instrument_nonlinear_ffi.mlir
+++ b/tests/integration/conversion/instrument_nonlinear_ffi.mlir
@@ -1,0 +1,58 @@
+// RUN: %reussir-opt %s --reussir-instrument-nonlinear-ffi | %FileCheck %s
+
+// `reussir-instrument-nonlinear-ffi` guards every FFI-import call that
+// consumes an rc'd ffi_object/array argument with a reference-count check:
+// a count other than one reports the call's source location to
+// `__reussir_report_nonlinear_usage`. Scalar arguments and calls to
+// functions no import trampoline names stay untouched.
+
+!vec = !reussir.rc<!reussir.ffi_object<"::reussir_rt::collections::vec::Vec<f64>", @vec_drop>>
+!arr = !reussir.rc<!reussir.array<4 x f64>>
+
+module {
+  func.func private @vec_drop(!vec)
+  func.func private @vec_push(!vec, f64) -> !vec
+  func.func private @arr_sum(!arr) -> f64
+  func.func private @scalar_id(i64) -> i64
+  func.func private @native_use(!vec) -> !vec
+  reussir.trampoline import "C" @vec_push_ffi = @vec_push
+  reussir.trampoline import "C" @arr_sum_ffi = @arr_sum
+  reussir.trampoline import "C" @scalar_id_ffi = @scalar_id
+
+  func.func @use(%v: !vec, %x: f64, %a: !arr, %n: i64) -> f64 {
+    %r = func.call @vec_push(%v, %x) : (!vec, f64) -> !vec loc("demo.rr":10:9)
+    %s = func.call @arr_sum(%a) : (!arr) -> f64 loc("demo.rr":11:9)
+    %m = func.call @scalar_id(%n) : (i64) -> i64
+    %r2 = func.call @native_use(%r) : (!vec) -> !vec
+    return %s : f64
+  }
+}
+
+// The runtime declaration and the NUL-terminated file-name global:
+// CHECK-DAG: llvm.func @__reussir_report_nonlinear_usage(!llvm.ptr, i32, i32)
+// CHECK-DAG: llvm.mlir.global linkonce_odr constant @{{.*}}("demo.rr\00")
+
+// CHECK-LABEL: func.func @use
+
+// The ffi_object argument of the imported `vec_push`:
+// CHECK: %[[COUNT:.+]] = reussir.rc.fetch
+// CHECK: %[[SHARED:.+]] = arith.cmpi ne, %[[COUNT]]
+// CHECK: %[[COLD:.+]] = reussir.expect(%[[SHARED]]
+// CHECK: scf.if %[[COLD]]
+// CHECK: %[[FILE:.+]] = llvm.mlir.addressof
+// CHECK-DAG: %[[LINE:.+]] = llvm.mlir.constant(10 : i32)
+// CHECK-DAG: %[[COL:.+]] = llvm.mlir.constant(9 : i32)
+// CHECK: llvm.call @__reussir_report_nonlinear_usage(%[[FILE]], %[[LINE]], %[[COL]])
+// CHECK: call @vec_push
+
+// The array argument of the imported `arr_sum`:
+// CHECK: reussir.rc.fetch
+// CHECK: scf.if
+// CHECK: llvm.mlir.constant(11 : i32)
+// CHECK: llvm.call @__reussir_report_nonlinear_usage
+// CHECK: call @arr_sum
+
+// A scalar argument and a call without an import trampoline are untouched:
+// CHECK-NOT: reussir.rc.fetch
+// CHECK: call @scalar_id
+// CHECK-NEXT: call @native_use

--- a/tests/integration/frontend/instrument_nonlinear_ffi.rr
+++ b/tests/integration/frontend/instrument_nonlinear_ffi.rr
@@ -1,0 +1,39 @@
+// UNSUPPORTED: darwin
+// `--instrument-nonlinear-ffi` guards every FFI-import call that consumes an
+// rc'd ffi/array value with a reference-count check reporting to
+// `__reussir_report_nonlinear_usage`; without the flag nothing is
+// instrumented.
+
+// RUN: %rrc %s --emit mlir-llvm --instrument-nonlinear-ffi -o - | %FileCheck %s
+// RUN: %rrc %s --emit mlir-llvm -o - \
+// RUN:   | %FileCheck %s --check-prefix=OFF \
+// RUN:     --implicit-check-not=__reussir_report_nonlinear_usage
+
+extern "rust" [{
+    use reussir_rt::collections::vec::Vec as RVec;
+}];
+
+#[ffi(rust = "::reussir_rt::collections::vec::Vec")]
+pub struct Vec<T>;
+
+#[ffi(import)]
+pub fn new<T>() -> Vec<T> [{ RVec::new() }];
+
+#[ffi(import)]
+pub fn push<T>(v: Vec<T>, x: T) -> Vec<T> [{ RVec::push(v, x) }];
+
+#[ffi(import)]
+pub fn len<T>(v: Vec<T>) -> u64 [{ v.len() as u64 }];
+
+pub fn main() -> u64 {
+    let v = push(new<f64>(), 1.5);
+    len(v) + len(v)
+}
+
+extern "C" trampoline "reussir_main" = main;
+
+// CHECK: llvm.func @__reussir_report_nonlinear_usage(!llvm.ptr, i32, i32)
+// The consumed vec at `push` and at both `len` calls is guarded:
+// CHECK-COUNT-3: llvm.call @__reussir_report_nonlinear_usage
+
+// OFF: llvm.func @reussir_main

--- a/tests/integration/frontend/instrument_nonlinear_ffi_e2e.c
+++ b/tests/integration/frontend/instrument_nonlinear_ffi_e2e.c
@@ -1,0 +1,21 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the Reussir Project, dual licensed under the Apache License v2.0 or
+// the MIT License.
+// See https://github.com/reussir-lang/reussir/blob/main/LICENSE for license
+// information.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+//===----------------------------------------------------------------------===//
+// Driver for instrument_nonlinear_ffi_e2e.rr. `main` returns `f64`, which is
+// nontrivial at the trampoline boundary, so the export takes a leading
+// return pointer. The instrumentation must not change the result: both
+// `total` calls see the same vector, copy-on-write notwithstanding.
+
+extern void reussir_main(double *ret);
+
+int main(void) {
+  double result;
+  reussir_main(&result);
+  return result == 3.0 ? 0 : 1;
+}

--- a/tests/integration/frontend/instrument_nonlinear_ffi_e2e.rr
+++ b/tests/integration/frontend/instrument_nonlinear_ffi_e2e.rr
@@ -1,0 +1,41 @@
+// UNSUPPORTED: darwin
+// End-to-end `--instrument-nonlinear-ffi`: `v` is consumed by the first
+// `total` while still shared with the second (Perceus retains it before the
+// first call), so the runtime reports that call site — and only that one —
+// on stderr. The result is unchanged: the foreign side copies on write.
+
+// RUN: %rrc %s -o %t.o --relocation-mode pic --instrument-nonlinear-ffi
+// RUN: %cc %t.o %S/instrument_nonlinear_ffi_e2e.c -o %t.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
+// RUN: %t.exe 2>&1 | %FileCheck %s
+
+extern "rust" [{
+    use reussir_rt::collections::vec::Vec as RVec;
+}];
+
+#[ffi(rust = "::reussir_rt::collections::vec::Vec")]
+pub struct Vec<T>;
+
+#[ffi(import)]
+pub fn new<T>() -> Vec<T> [{ RVec::new() }];
+
+#[ffi(import)]
+pub fn push<T>(v: Vec<T>, x: T) -> Vec<T> [{ RVec::push(v, x) }];
+
+#[ffi(import)]
+pub fn total(v: Vec<f64>) -> f64 [{
+    let mut sum = 0.0;
+    for i in 0..v.len() {
+        sum += v.get(i).unwrap();
+    }
+    sum
+}];
+
+pub fn main() -> f64 {
+    let v = push(new<f64>(), 1.5);
+    total(v) + total(v)
+}
+
+extern "C" trampoline "reussir_main" = main;
+
+// CHECK: non-linear ffi/array usage at {{.*}}instrument_nonlinear_ffi_e2e.rr:{{[0-9]+}}:{{[0-9]+}}
+// CHECK-NOT: non-linear ffi/array usage

--- a/tool/reussir-opt/main.cpp
+++ b/tool/reussir-opt/main.cpp
@@ -92,6 +92,9 @@ int main(int argc, char **argv) {
     return reussir::createReussirCompilePolymorphicFFIPass();
   });
   mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {
+    return reussir::createReussirInstrumentNonlinearFFIPass();
+  });
+  mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {
     return reussir::createReussirClosureOutliningPass();
   });
   mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {


### PR DESCRIPTION
## Summary

Adds an opt-in diagnostic (`rrc --instrument-nonlinear-ffi`, `rene` profile knob `instrument_nonlinear_ffi`) that makes the copy-on-write cliff at the FFI boundary observable at its source location.

The new `reussir-instrument-nonlinear-ffi` module pass guards every FFI-import call (a `func.call` whose callee is the `target` of a `reussir.trampoline import`) that consumes an rc'd `ffi_object`/`array` argument:

```mlir
%count = reussir.rc.fetch (%arg) : index
%shared = arith.cmpi ne, %count, %c1       // reussir.expect'ed cold
scf.if %shared {
  llvm.call @__reussir_report_nonlinear_usage(%file, %line, %col)
}
```

The owned calling convention consumes every rc argument, so a count above one at the boundary means the value is still shared and the foreign side (e.g. `reussir_rt`'s `Vec`) copies instead of updating in place. The new runtime entry point (`reussir-rt/src/instrument.rs`, registered in the JIT symbol table) reports `file:line:col` on stderr and never aborts; program semantics are unchanged.

## Pipeline position

After every count-changing optimization (token reuse, inc/dec cancellation, rc-create sink/fusion) and before `compile-polymorphic-ffi`, while `scf` is still legal. Running earlier would be wrong: `inc-dec-cancellation` treats `rc.is_unique` as a barrier but not `rc.fetch`, so an early fetch could observe a count a cancelled pair later invalidates.

The file name is a content-addressed (`Blake3Symbol.h`) NUL-terminated global; line/col resolve through fused/name/call-site locations. Region-managed rc capabilities are skipped (no ordinary count). Off by default everywhere; design notes in `docs/design/nonlinear-ffi-instrumentation.md`.

## Tests

- `tests/integration/conversion/instrument_nonlinear_ffi.mlir` — pass level: ffi_object and array args guarded with the correct line/col constants; scalar args and calls without an import trampoline untouched.
- `tests/integration/frontend/instrument_nonlinear_ffi.rr` — `rrc --emit mlir-llvm`: three guarded call sites with the flag, zero references without it.
- `tests/integration/frontend/instrument_nonlinear_ffi_e2e.rr` + `.c` — `total(v) + total(v)` fires exactly one report (at the first call, where the Perceus retain makes the count 2) and the result is unchanged.

Full integration suite: 480 passed / 0 failed; ctest 32/32; cargo unit tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/575"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790006900&installation_model_id=426051&pr_number=575&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F575&signature=4721b49d80cd4d25f625a6ecaa24b6af22cbb4b322dd76537425a1ff3165c8e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->