### PR TITLE
[lsp] semantic-token kinds, legend, and UTF-16 line encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,6 +152,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-lsp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8b8fd1e175c5ee3108095da452e816519de618beccea23aa053c00cf5e344b9"
+dependencies = [
+ "futures",
+ "lsp-types",
+ "pin-project-lite",
+ "rustix 1.1.4",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+ "waitpid-any",
+]
+
+[[package]]
 name = "atomic"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -965,6 +985,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
 name = "document-features"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1166,6 +1197,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "ftree"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1176,6 +1216,30 @@ name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
 
 [[package]]
 name = "futures-core"
@@ -1218,6 +1282,7 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -1394,6 +1459,89 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
+
+[[package]]
+name = "icu_properties"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
+
+[[package]]
+name = "icu_provider"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "icy_sixel"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1408,6 +1556,27 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "image"
@@ -1699,6 +1868,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litemap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
+
+[[package]]
 name = "litrs"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1828,6 +2003,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
 dependencies = [
  "hashbrown 0.17.1",
+]
+
+[[package]]
+name = "lsp-types"
+version = "0.95.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e34d33a8e9b006cd3fc4fe69a921affa097bae4bb65f76271f4644f9a334365"
+dependencies = [
+ "bitflags 1.3.2",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "url",
 ]
 
 [[package]]
@@ -2386,6 +2574,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pest"
 version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2594,6 +2788,15 @@ dependencies = [
  "linux-raw-sys 0.11.0",
  "syscalls",
  "winapi",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -3195,6 +3398,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "reussir-lsp"
+version = "0.1.0"
+dependencies = [
+ "async-lsp",
+]
+
+[[package]]
 name = "reussir-repl"
 version = "0.1.0"
 dependencies = [
@@ -3463,6 +3673,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -3744,6 +3965,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "synchrony"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3753,6 +3985,17 @@ dependencies = [
  "futures-util",
  "local-event",
  "loom",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3983,6 +4226,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
+name = "tinystr"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3996,6 +4249,19 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
+dependencies = [
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "toml"
@@ -4111,6 +4377,18 @@ name = "toml_writer"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -4269,6 +4547,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4320,6 +4617,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
 dependencies = [
  "utf8parse",
+]
+
+[[package]]
+name = "waitpid-any"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18aa3ce681e189f125c4c1e1388c03285e2fd434ef52c7203084012ac29c5e4a"
+dependencies = [
+ "rustix 1.1.4",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4717,6 +5024,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
+name = "writeable"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
+
+[[package]]
 name = "wyz"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4748,6 +5061,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4765,6 +5101,60 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "3"
 members = [
     "crates/reussir-rt",
     "crates/reussir-syntax",
+    "crates/reussir-lsp",
     "crates/reussir-core",
     "crates/reussir-backend-sys",
     "crates/reussir-backend",
@@ -20,6 +21,7 @@ members = [
 default-members = [
     "crates/reussir-rt",
     "crates/reussir-syntax",
+    "crates/reussir-lsp",
     "crates/reussir-core",
     "crates/rene",
     "crates/reussir-trait-dsl",
@@ -121,6 +123,10 @@ stacker = "0.1.21"
 tracing = "0.1"
 # Log-level plumbing for the REPL binary's `-l` flag.
 tracing-subscriber = "0.3"
+# The language server uses async-lsp's Tower service stack over stdio. Document
+# contents are synchronized as whole snapshots; semantic highlighting work is
+# dispatched to Tokio's blocking pool.
+async-lsp = { version = "=0.2.4", default-features = false, features = ["client-monitor", "stdio", "tokio", "tracing"] }
 # Platform data directories for the REPL's persisted history
 # (XDG_DATA_HOME/~/.local/share on Linux, %LOCALAPPDATA% on Windows,
 # ~/Library/Application Support on macOS).

--- a/crates/reussir-lsp/Cargo.toml
+++ b/crates/reussir-lsp/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "reussir-lsp"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Semantic-token language server for Reussir"
+
+[[bin]]
+name = "reussir-lsp"
+path = "src/main.rs"
+
+[dependencies]
+async-lsp.workspace = true

--- a/crates/reussir-lsp/src/main.rs
+++ b/crates/reussir-lsp/src/main.rs
@@ -1,0 +1,9 @@
+// The async-lsp main loop lands with the server routing; until then the
+// binary only anchors the crate so the encoding module and its tests build.
+#[allow(dead_code)]
+mod semantic;
+
+fn main() {
+    eprintln!("reussir-lsp: the LSP main loop is not wired up yet");
+    std::process::exit(2);
+}

--- a/crates/reussir-lsp/src/semantic.rs
+++ b/crates/reussir-lsp/src/semantic.rs
@@ -1,0 +1,335 @@
+//! LSP semantic-token encoding for Reussir.
+
+use async_lsp::lsp_types::{SemanticToken, SemanticTokenModifier, SemanticTokenType};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(u32)]
+pub(crate) enum SemanticKind {
+    Namespace,
+    Type,
+    Struct,
+    Enum,
+    Interface,
+    TypeParameter,
+    Parameter,
+    Variable,
+    Property,
+    EnumMember,
+    Function,
+    Method,
+    Macro,
+    Keyword,
+    Modifier,
+    Comment,
+    String,
+    Number,
+    Operator,
+    Decorator,
+}
+
+/// One row per `SemanticKind`, in discriminant order. The advertised legend
+/// and the test decoder both derive from this table, and a test asserts each
+/// row's position matches its discriminant, so the three cannot drift apart.
+pub(crate) const TOKEN_LEGEND: &[(SemanticKind, SemanticTokenType)] = &[
+    (SemanticKind::Namespace, SemanticTokenType::NAMESPACE),
+    (SemanticKind::Type, SemanticTokenType::TYPE),
+    (SemanticKind::Struct, SemanticTokenType::STRUCT),
+    (SemanticKind::Enum, SemanticTokenType::ENUM),
+    (SemanticKind::Interface, SemanticTokenType::INTERFACE),
+    (SemanticKind::TypeParameter, SemanticTokenType::TYPE_PARAMETER),
+    (SemanticKind::Parameter, SemanticTokenType::PARAMETER),
+    (SemanticKind::Variable, SemanticTokenType::VARIABLE),
+    (SemanticKind::Property, SemanticTokenType::PROPERTY),
+    (SemanticKind::EnumMember, SemanticTokenType::ENUM_MEMBER),
+    (SemanticKind::Function, SemanticTokenType::FUNCTION),
+    (SemanticKind::Method, SemanticTokenType::METHOD),
+    (SemanticKind::Macro, SemanticTokenType::MACRO),
+    (SemanticKind::Keyword, SemanticTokenType::KEYWORD),
+    (SemanticKind::Modifier, SemanticTokenType::MODIFIER),
+    (SemanticKind::Comment, SemanticTokenType::COMMENT),
+    (SemanticKind::String, SemanticTokenType::STRING),
+    (SemanticKind::Number, SemanticTokenType::NUMBER),
+    (SemanticKind::Operator, SemanticTokenType::OPERATOR),
+    (SemanticKind::Decorator, SemanticTokenType::DECORATOR),
+];
+
+/// One row per modifier bit, in bit order; validated the same way as
+/// [`TOKEN_LEGEND`].
+pub(crate) const MODIFIER_LEGEND: &[(u32, SemanticTokenModifier)] = &[
+    (modifier::DECLARATION, SemanticTokenModifier::DECLARATION),
+    (modifier::READONLY, SemanticTokenModifier::READONLY),
+    (modifier::DEFAULT_LIBRARY, SemanticTokenModifier::DEFAULT_LIBRARY),
+];
+
+pub(crate) fn legend_token_types() -> Vec<SemanticTokenType> {
+    TOKEN_LEGEND.iter().map(|(_, ty)| ty.clone()).collect()
+}
+
+pub(crate) fn legend_token_modifiers() -> Vec<SemanticTokenModifier> {
+    MODIFIER_LEGEND
+        .iter()
+        .map(|(_, modifier)| modifier.clone())
+        .collect()
+}
+
+pub(crate) mod modifier {
+    pub(crate) const DECLARATION: u32 = 1 << 0;
+    pub(crate) const READONLY: u32 = 1 << 1;
+    pub(crate) const DEFAULT_LIBRARY: u32 = 1 << 2;
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct RawSemanticToken {
+    pub(crate) start: usize,
+    pub(crate) end: usize,
+    pub(crate) kind: SemanticKind,
+    pub(crate) modifiers: u32,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct AbsoluteSemanticToken {
+    line: u32,
+    start: u32,
+    length: u32,
+    kind: SemanticKind,
+    modifiers: u32,
+}
+
+fn encode(source: &str, mut raw: Vec<RawSemanticToken>) -> Vec<SemanticToken> {
+    let lines = LineIndex::new(source);
+    // Sorting lets one forward-only UTF-16 cursor serve every token, keeping
+    // column conversion linear instead of re-encoding each line prefix.
+    raw.sort_unstable_by_key(|token| (token.start, token.end));
+    let mut cursor = Utf16Cursor::default();
+    let mut absolute = Vec::new();
+    for token in raw {
+        absolute.extend(lines.split(source, token, &mut cursor));
+    }
+    absolute.sort_by_key(|token| (token.line, token.start, token.length, token.kind));
+
+    let mut normalized: Vec<AbsoluteSemanticToken> = Vec::with_capacity(absolute.len());
+    for mut token in absolute {
+        if token.length == 0 {
+            continue;
+        }
+        if let Some(previous) = normalized
+            .last_mut()
+            .filter(|previous| previous.line == token.line)
+        {
+            let previous_end = previous.start + previous.length;
+            if token.start < previous_end {
+                let overlap = previous_end - token.start;
+                if overlap >= token.length {
+                    continue;
+                }
+                token.start += overlap;
+                token.length -= overlap;
+            }
+            if previous.start + previous.length == token.start
+                && previous.kind == token.kind
+                && previous.modifiers == token.modifiers
+            {
+                previous.length += token.length;
+                continue;
+            }
+        }
+        normalized.push(token);
+    }
+
+    let mut previous_line = 0;
+    let mut previous_start = 0;
+    normalized
+        .into_iter()
+        .map(|token| {
+            let delta_line = token.line - previous_line;
+            let delta_start = if delta_line == 0 {
+                token.start - previous_start
+            } else {
+                token.start
+            };
+            previous_line = token.line;
+            previous_start = token.start;
+            SemanticToken {
+                delta_line,
+                delta_start,
+                length: token.length,
+                token_type: token.kind as u32,
+                token_modifiers_bitset: token.modifiers,
+            }
+        })
+        .collect()
+}
+
+#[derive(Debug)]
+struct LineInfo {
+    start: usize,
+    content_end: usize,
+    next_start: usize,
+}
+
+#[derive(Debug)]
+struct LineIndex {
+    lines: Vec<LineInfo>,
+}
+
+/// Forward-only byte-offset → UTF-16-column state shared across tokens.
+/// A lookup behind the previous position falls back to the line start, so it
+/// stays correct for arbitrary inputs and linear for sorted ones.
+#[derive(Debug, Default)]
+struct Utf16Cursor {
+    line: usize,
+    byte: usize,
+    utf16: u32,
+}
+
+impl LineIndex {
+    fn new(source: &str) -> Self {
+        // The LSP position contract (and VS Code's document model) treats
+        // `\n`, `\r\n`, and a lone `\r` as line terminators.
+        let bytes = source.as_bytes();
+        let mut lines = Vec::new();
+        let mut start = 0;
+        let mut index = 0;
+        while index < bytes.len() {
+            let next_start = match bytes[index] {
+                b'\n' => index + 1,
+                b'\r' if bytes.get(index + 1) == Some(&b'\n') => index + 2,
+                b'\r' => index + 1,
+                _ => {
+                    index += 1;
+                    continue;
+                }
+            };
+            lines.push(LineInfo {
+                start,
+                content_end: index,
+                next_start,
+            });
+            index = next_start;
+            start = next_start;
+        }
+        lines.push(LineInfo {
+            start,
+            content_end: source.len(),
+            next_start: source.len(),
+        });
+        Self { lines }
+    }
+
+    fn split(
+        &self,
+        source: &str,
+        token: RawSemanticToken,
+        columns: &mut Utf16Cursor,
+    ) -> Vec<AbsoluteSemanticToken> {
+        let mut output = Vec::new();
+        let mut cursor = token.start.min(source.len());
+        let end = token.end.min(source.len());
+        while cursor < end {
+            let line_index = self
+                .lines
+                .partition_point(|line| line.start <= cursor)
+                .saturating_sub(1);
+            let line = &self.lines[line_index];
+            let segment_end = end.min(line.content_end);
+            if cursor < segment_end {
+                let start = self.utf16_column(source, columns, line_index, cursor);
+                let length = self.utf16_column(source, columns, line_index, segment_end) - start;
+                output.push(AbsoluteSemanticToken {
+                    line: line_index as u32,
+                    start,
+                    length,
+                    kind: token.kind,
+                    modifiers: token.modifiers,
+                });
+            }
+            if end <= line.content_end || line.next_start <= cursor {
+                break;
+            }
+            cursor = line.next_start;
+        }
+        output
+    }
+
+    fn utf16_column(
+        &self,
+        source: &str,
+        columns: &mut Utf16Cursor,
+        line_index: usize,
+        byte: usize,
+    ) -> u32 {
+        if line_index != columns.line || byte < columns.byte {
+            columns.line = line_index;
+            columns.byte = self.lines[line_index].start;
+            columns.utf16 = 0;
+        }
+        columns.utf16 += source[columns.byte..byte].encode_utf16().count() as u32;
+        columns.byte = byte;
+        columns.utf16
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    impl TryFrom<u32> for SemanticKind {
+        type Error = ();
+
+        fn try_from(value: u32) -> Result<Self, Self::Error> {
+            TOKEN_LEGEND
+                .get(value as usize)
+                .map(|(kind, _)| *kind)
+                .ok_or(())
+        }
+    }
+
+    #[test]
+    fn legend_rows_match_their_discriminants() {
+        for (index, (kind, _)) in TOKEN_LEGEND.iter().enumerate() {
+            assert_eq!(*kind as usize, index, "row {index} is out of order");
+        }
+        for (index, (bit, _)) in MODIFIER_LEGEND.iter().enumerate() {
+            assert_eq!(*bit, 1 << index, "modifier row {index} is out of order");
+        }
+    }
+
+    #[test]
+    fn uses_utf16_positions_and_splits_multiline_comments() {
+        let source = "fn 😀() { /* α\r\nβ */ let x = 1 }";
+        let raw = vec![RawSemanticToken {
+            start: source.find("/*").unwrap(),
+            end: source.find("*/").unwrap() + 2,
+            kind: SemanticKind::Comment,
+            modifiers: 0,
+        }];
+        let encoded = encode(source, raw);
+        assert_eq!(encoded.len(), 2);
+        assert_eq!((encoded[0].delta_line, encoded[0].delta_start), (0, 10));
+        assert_eq!((encoded[1].delta_line, encoded[1].delta_start), (1, 0));
+    }
+
+    #[test]
+    fn lone_carriage_return_terminates_a_line() {
+        let source = "let a = 1\rlet b = 2";
+        let start = source.rfind("let").unwrap();
+        let raw = vec![RawSemanticToken {
+            start,
+            end: start + 3,
+            kind: SemanticKind::Keyword,
+            modifiers: 0,
+        }];
+        let encoded = encode(source, raw);
+        assert_eq!(encoded.len(), 1);
+        assert_eq!((encoded[0].delta_line, encoded[0].delta_start), (1, 0));
+    }
+
+    #[test]
+    fn line_index_handles_mixed_line_endings() {
+        let index = LineIndex::new("a\r\nb\rc\nd");
+        let starts: Vec<usize> = index.lines.iter().map(|line| line.start).collect();
+        let content_ends: Vec<usize> = index.lines.iter().map(|line| line.content_end).collect();
+        assert_eq!(starts, [0, 3, 5, 7]);
+        assert_eq!(content_ends, [1, 4, 6, 8]);
+    }
+}


### PR DESCRIPTION
First slice of the Reussir language server: the token-kind enum, a single
TOKEN_LEGEND/MODIFIER_LEGEND table that both the advertised legend and the
test decoder derive from (a test pins each row to its discriminant), and the
byte-range → LSP delta encoding. The line index treats \n, \r\n, and lone \r
as line terminators per the LSP position contract, and UTF-16 column
conversion uses a forward-only cursor over sorted tokens so encoding stays
linear. The binary is a stub until the async-lsp main loop lands.
**Stack** (splits #580 into ≤400-LOC units, lockfiles excluded — merge bottom-up):
1. #583 — [lsp] semantic-token kinds, legend, and UTF-16 line encoding
2. #584 — [lsp] classify Reussir tokens from the lossless cstree
3. #585 — [lsp] Tree-sitter highlighting for embedded MLIR and Rust blocks
4. #586 — [lsp] async-lsp stdio server and the reussir-lsp binary
5. #587 — [vscode] wasm codec: LSP request builders and Content-Length framing
6. #588 — [vscode] wasm codec: streaming decode, response routing, and wasm ABI
7. #589 — [vscode] extension scaffold and the TypeScript wasm binding
8. #590 — [vscode] extension host: server lifecycle and semantic-token provider
9. #591 — [vscode] protocol smoke test, VSIX packaging, and CMake targets
10. #592 — [lsp][vscode] CI workflow, nightly packaging, docs, and lit coverage

Includes the fixes for the review findings on #580: lone-CR line handling, legend drift guard, linear UTF-16 conversion, 'modifier' token mapping, EPIPE/signal liveness, crash recovery with restart, and pending-request cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7oSRt4CxcRt9EEMtfP6Wr