### PR TITLE
[lsp] Tree-sitter highlighting for embedded MLIR and Rust blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3403,6 +3403,10 @@ version = "0.1.0"
 dependencies = [
  "async-lsp",
  "reussir-syntax",
+ "tracing",
+ "tree-sitter-highlight",
+ "tree-sitter-mlir",
+ "tree-sitter-rust",
 ]
 
 [[package]]
@@ -3669,6 +3673,7 @@ version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -3884,6 +3889,12 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
 
 [[package]]
 name = "string_cache"
@@ -4450,6 +4461,58 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "tree-sitter"
+version = "0.26.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17ebdd3a5a7e28a1890b876fdbd0c3c0fe0a6336cffaa104f11b9f720c9daa29"
+dependencies = [
+ "cc",
+ "regex",
+ "regex-syntax",
+ "serde_json",
+ "streaming-iterator",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-highlight"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd7a0c48d503cf4e0a57a2453424eaef2fce4b4269f13e3579e52f0d0c9e5cc8"
+dependencies = [
+ "regex",
+ "streaming-iterator",
+ "thiserror 2.0.18",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-language"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "tree-sitter-mlir"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fae01f2991b7b63e2a047f83ed6033c3bdac203b389753975996d37d7020da3"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-rust"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439e577dbe07423ec2582ac62c7531120dbfccfa6e5f92406f93dd271a120e45"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,6 +127,11 @@ tracing-subscriber = "0.3"
 # contents are synchronized as whole snapshots; semantic highlighting work is
 # dispatched to Tokio's blocking pool.
 async-lsp = { version = "=0.2.4", default-features = false, features = ["client-monitor", "stdio", "tokio", "tracing"] }
+# Embedded Rust poly-FFI bodies and MLIR transform schedules are deliberately
+# syntax-highlighted without invoking either language's semantic frontend.
+tree-sitter-highlight = "=0.26.11"
+tree-sitter-rust = "=0.24.2"
+tree-sitter-mlir = "=0.1.7"
 # Platform data directories for the REPL's persisted history
 # (XDG_DATA_HOME/~/.local/share on Linux, %LOCALAPPDATA% on Windows,
 # ~/Library/Application Support on macOS).

--- a/crates/reussir-lsp/Cargo.toml
+++ b/crates/reussir-lsp/Cargo.toml
@@ -12,3 +12,7 @@ path = "src/main.rs"
 [dependencies]
 async-lsp.workspace = true
 reussir-syntax = { path = "../reussir-syntax" }
+tracing.workspace = true
+tree-sitter-highlight.workspace = true
+tree-sitter-rust.workspace = true
+tree-sitter-mlir.workspace = true

--- a/crates/reussir-lsp/src/embedded.rs
+++ b/crates/reussir-lsp/src/embedded.rs
@@ -1,0 +1,232 @@
+//! Tree-sitter highlighting for syntax embedded in Reussir raw blocks.
+//!
+//! This module is intentionally syntactic. It does not invoke rustc, MLIR, or
+//! either language's name/type resolution.
+
+use std::sync::OnceLock;
+
+use tree_sitter_highlight::{HighlightConfiguration, HighlightEvent, Highlighter};
+
+use crate::semantic::{RawSemanticToken, SemanticKind};
+
+const CAPTURE_NAMES: &[&str] = &[
+    "attribute",
+    "boolean",
+    "comment",
+    "constant",
+    "constant.builtin",
+    "constructor",
+    "function",
+    "function.builtin",
+    "function.macro",
+    "function.method",
+    "keyword",
+    "label",
+    "number",
+    "operator",
+    "property",
+    "string",
+    "string.escape",
+    "string.special.symbol",
+    "tag",
+    "type",
+    "type.builtin",
+    "variable",
+    "variable.builtin",
+    "variable.member",
+    "variable.parameter",
+];
+
+static RUST_CONFIG: OnceLock<Option<HighlightConfiguration>> = OnceLock::new();
+static MLIR_CONFIG: OnceLock<Option<HighlightConfiguration>> = OnceLock::new();
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum EmbeddedLanguage {
+    RustSource,
+    RustBody,
+    Mlir,
+}
+
+pub(crate) fn highlight(
+    source: &str,
+    source_offset: usize,
+    language: EmbeddedLanguage,
+) -> Vec<RawSemanticToken> {
+    let (owned_source, kept_start, kept_end) = match language {
+        EmbeddedLanguage::RustBody => {
+            const PREFIX: &str = "fn __reussir_embedded() {\n";
+            const SUFFIX: &str = "\n}";
+            let masked = mask_polyffi_placeholders(source);
+            let mut wrapped = String::with_capacity(PREFIX.len() + masked.len() + SUFFIX.len());
+            wrapped.push_str(PREFIX);
+            wrapped.push_str(&masked);
+            wrapped.push_str(SUFFIX);
+            let end = PREFIX.len() + masked.len();
+            (wrapped, PREFIX.len(), end)
+        }
+        EmbeddedLanguage::RustSource => {
+            let masked = mask_polyffi_placeholders(source);
+            let end = masked.len();
+            (masked, 0, end)
+        }
+        EmbeddedLanguage::Mlir => (source.to_owned(), 0, source.len()),
+    };
+
+    let Some(config) = configuration(language) else {
+        tracing::warn!(
+            ?language,
+            "embedded Tree-sitter configuration is unavailable"
+        );
+        return Vec::new();
+    };
+    let mut highlighter = Highlighter::new();
+    let Ok(events) = highlighter.highlight(config, owned_source.as_bytes(), None, |_| None) else {
+        tracing::warn!(
+            ?language,
+            "Tree-sitter could not start highlighting embedded block"
+        );
+        return Vec::new();
+    };
+
+    let mut stack = Vec::new();
+    let mut output = Vec::new();
+    for event in events {
+        let Ok(event) = event else {
+            tracing::warn!(
+                ?language,
+                "Tree-sitter stopped while highlighting embedded block"
+            );
+            return Vec::new();
+        };
+        match event {
+            HighlightEvent::HighlightStart(highlight) => stack.push(highlight.0),
+            HighlightEvent::HighlightEnd => {
+                stack.pop();
+            }
+            HighlightEvent::Source { start, end } => {
+                let Some(&capture) = stack.last() else {
+                    continue;
+                };
+                let start = start.max(kept_start);
+                let end = end.min(kept_end);
+                if start >= end {
+                    continue;
+                }
+                if let Some((kind, modifiers)) = capture_style(capture) {
+                    output.push(RawSemanticToken {
+                        start: source_offset + start - kept_start,
+                        end: source_offset + end - kept_start,
+                        kind,
+                        modifiers,
+                    });
+                }
+            }
+        }
+    }
+    output
+}
+
+fn configuration(language: EmbeddedLanguage) -> Option<&'static HighlightConfiguration> {
+    match language {
+        EmbeddedLanguage::RustSource | EmbeddedLanguage::RustBody => RUST_CONFIG
+            .get_or_init(|| {
+                let mut config = HighlightConfiguration::new(
+                    tree_sitter_rust::LANGUAGE.into(),
+                    "rust",
+                    tree_sitter_rust::HIGHLIGHTS_QUERY,
+                    tree_sitter_rust::INJECTIONS_QUERY,
+                    "",
+                )
+                .ok()?;
+                config.configure(CAPTURE_NAMES);
+                Some(config)
+            })
+            .as_ref(),
+        EmbeddedLanguage::Mlir => MLIR_CONFIG
+            .get_or_init(|| {
+                let mut config = HighlightConfiguration::new(
+                    tree_sitter_mlir::LANGUAGE.into(),
+                    "mlir",
+                    tree_sitter_mlir::HIGHLIGHTS_QUERY,
+                    tree_sitter_mlir::INJECTIONS_QUERY,
+                    tree_sitter_mlir::LOCALS_QUERY,
+                )
+                .ok()?;
+                config.configure(CAPTURE_NAMES);
+                Some(config)
+            })
+            .as_ref(),
+    }
+}
+
+fn capture_style(capture: usize) -> Option<(SemanticKind, u32)> {
+    let name = *CAPTURE_NAMES.get(capture)?;
+    let declaration = 0;
+    let readonly = crate::semantic::modifier::READONLY;
+    let default_library = crate::semantic::modifier::DEFAULT_LIBRARY;
+    Some(match name {
+        "attribute" => (SemanticKind::Decorator, declaration),
+        "boolean" => (SemanticKind::Keyword, declaration),
+        "comment" => (SemanticKind::Comment, declaration),
+        "constant" => (SemanticKind::Variable, readonly),
+        "constant.builtin" => (SemanticKind::Variable, readonly | default_library),
+        "constructor" => (SemanticKind::Function, declaration),
+        "function" => (SemanticKind::Function, declaration),
+        "function.builtin" => (SemanticKind::Function, default_library),
+        "function.macro" => (SemanticKind::Macro, declaration),
+        "function.method" => (SemanticKind::Method, declaration),
+        "keyword" => (SemanticKind::Keyword, declaration),
+        "label" | "tag" => (SemanticKind::Variable, declaration),
+        "number" => (SemanticKind::Number, declaration),
+        "operator" => (SemanticKind::Operator, declaration),
+        "property" | "variable.member" => (SemanticKind::Property, declaration),
+        "string" | "string.escape" | "string.special.symbol" => (SemanticKind::String, declaration),
+        "type" => (SemanticKind::Type, declaration),
+        "type.builtin" => (SemanticKind::Type, default_library),
+        "variable" => (SemanticKind::Variable, declaration),
+        "variable.builtin" => (SemanticKind::Variable, default_library),
+        "variable.parameter" => (SemanticKind::Parameter, declaration),
+        _ => return None,
+    })
+}
+
+/// Replace `[:T:]`-style poly-FFI placeholders with valid ASCII Rust
+/// identifiers of exactly the same byte width. The highlighted ranges can
+/// therefore be applied directly to the original Reussir document.
+fn mask_polyffi_placeholders(source: &str) -> String {
+    let mut bytes = source.as_bytes().to_vec();
+    let mut cursor = 0;
+    while cursor + 3 < bytes.len() {
+        if bytes[cursor] != b'[' || bytes[cursor + 1] != b':' {
+            cursor += 1;
+            continue;
+        }
+        let Some(relative_end) = bytes[cursor + 2..]
+            .windows(2)
+            .position(|window| window == b":]")
+        else {
+            break;
+        };
+        let end = cursor + 2 + relative_end + 2;
+        bytes[cursor..end].fill(b'_');
+        bytes[cursor] = b'p';
+        cursor = end;
+    }
+    // Every non-placeholder byte came from valid UTF-8, and placeholders are
+    // replaced byte-for-byte with ASCII.
+    String::from_utf8(bytes).expect("placeholder masking preserves UTF-8")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn placeholder_mask_preserves_byte_offsets() {
+        let input = "Vec::<[:T:]>::new() + [:世界:]";
+        let masked = mask_polyffi_placeholders(input);
+        assert_eq!(masked.len(), input.len());
+        assert_eq!(&masked[..7], "Vec::<p");
+        assert!(masked.is_ascii());
+    }
+}

--- a/crates/reussir-lsp/src/main.rs
+++ b/crates/reussir-lsp/src/main.rs
@@ -1,5 +1,7 @@
 // The async-lsp main loop lands with the server routing; until then the
-// binary only anchors the crate so the encoding module and its tests build.
+// binary only anchors the crate so the highlighting modules and tests build.
+#[allow(dead_code)]
+mod embedded;
 #[allow(dead_code)]
 mod semantic;
 

--- a/crates/reussir-lsp/src/semantic.rs
+++ b/crates/reussir-lsp/src/semantic.rs
@@ -4,6 +4,8 @@ use async_lsp::lsp_types::{SemanticToken, SemanticTokenModifier, SemanticTokenTy
 use reussir_syntax::kind::{ResolvedNode, ResolvedToken, SyntaxKind};
 use reussir_syntax::parse;
 
+use crate::embedded::{self, EmbeddedLanguage};
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(u32)]
 pub(crate) enum SemanticKind {
@@ -105,23 +107,44 @@ struct AbsoluteSemanticToken {
 
 pub(crate) fn semantic_tokens(source: &str) -> Vec<SemanticToken> {
     let parsed = parse(source);
-    let raw = parsed
+    let mut raw = Vec::new();
+    for token in parsed
         .root
         .descendants_with_tokens()
         .filter_map(|element| element.into_token())
-        .filter_map(|token| {
-            classify_reussir(token).map(|(kind, modifiers)| {
-                let range = token.text_range();
-                RawSemanticToken {
-                    start: u32::from(range.start()) as usize,
-                    end: u32::from(range.end()) as usize,
-                    kind,
-                    modifiers,
-                }
-            })
-        })
-        .collect();
+    {
+        if token.kind() == SyntaxKind::RawMlirLiteral {
+            raw.extend(highlight_embedded(token));
+        } else if let Some((kind, modifiers)) = classify_reussir(token) {
+            let range = token.text_range();
+            raw.push(RawSemanticToken {
+                start: u32::from(range.start()) as usize,
+                end: u32::from(range.end()) as usize,
+                kind,
+                modifiers,
+            });
+        }
+    }
     encode(source, raw)
+}
+
+fn highlight_embedded(token: &ResolvedToken) -> Vec<RawSemanticToken> {
+    let text = token.text();
+    let Some(body) = text
+        .strip_prefix("[{")
+        .and_then(|text| text.strip_suffix("}]"))
+    else {
+        return Vec::new();
+    };
+    let token_start = u32::from(token.text_range().start()) as usize;
+    let body_start = token_start + 2;
+    let language = match token.parent().kind() {
+        SyntaxKind::TransformStmt => EmbeddedLanguage::Mlir,
+        SyntaxKind::ExternSourceStmt => EmbeddedLanguage::RustSource,
+        SyntaxKind::FnStmt => EmbeddedLanguage::RustBody,
+        _ => return Vec::new(),
+    };
+    embedded::highlight(body, body_start, language)
 }
 
 fn classify_reussir(token: &ResolvedToken) -> Option<(SemanticKind, u32)> {
@@ -667,6 +690,52 @@ fn use_it(p: Point<i64>) -> i64 { m::sqrt(p.get()) }"#;
                 "missing {text:?} as {kind:?}: {tokens:#?}"
             );
         }
+    }
+
+    #[test]
+    fn highlights_embedded_mlir_and_rust_without_raw_overlap() {
+        let source = r#"transform [{ %x = arith.constant 1 : i64 }];
+extern "rust" [{ use crate::Thing; }];
+#[ffi(import)] fn make<T>() -> T [{ println!("{}", 1); Vec::<[:T:]>::new() }];"#;
+        let tokens = decoded(source);
+        assert!(
+            tokens
+                .iter()
+                .any(|(text, kind, _, _)| text == "arith.constant"
+                    && *kind == SemanticKind::Function)
+        );
+        assert!(
+            tokens
+                .iter()
+                .any(|(text, kind, _, _)| text == "use" && *kind == SemanticKind::Keyword)
+        );
+        assert!(
+            tokens
+                .iter()
+                .any(|(text, kind, _, _)| text == "new" && *kind == SemanticKind::Function),
+            "{tokens:#?}"
+        );
+        assert!(
+            tokens
+                .iter()
+                .any(|(text, kind, _, _)| text == "println!" && *kind == SemanticKind::Macro)
+        );
+        assert!(
+            tokens
+                .iter()
+                .any(|(text, kind, _, _)| text == "[:T:]" && *kind == SemanticKind::Type)
+        );
+        assert!(!tokens.iter().any(|(text, _, _, _)| text.starts_with("[{")));
+    }
+
+    #[test]
+    fn malformed_embedded_block_does_not_hide_outer_reussir() {
+        let tokens = decoded("transform [{ %x = <not mlir }]; fn okay() -> i64 { 1 }");
+        assert!(
+            tokens
+                .iter()
+                .any(|(text, kind, _, _)| text == "okay" && *kind == SemanticKind::Function)
+        );
     }
 
     #[test]


### PR DESCRIPTION
Raw [{ ... }] literals inside transform statements, extern "rust" sources,
and poly-FFI fn bodies get syntax-only Tree-sitter highlighting; nothing
invokes rustc, MLIR, or name/type resolution. Rust bodies are wrapped in a
synthetic fn and [:T:] placeholders are masked byte-for-byte so highlight
ranges map straight back onto the Reussir document.
**Stack** (splits #580 into ≤400-LOC units, lockfiles excluded — merge bottom-up):
1. #583 — [lsp] semantic-token kinds, legend, and UTF-16 line encoding
2. #584 — [lsp] classify Reussir tokens from the lossless cstree
3. #585 — [lsp] Tree-sitter highlighting for embedded MLIR and Rust blocks
4. #586 — [lsp] async-lsp stdio server and the reussir-lsp binary
5. #587 — [vscode] wasm codec: LSP request builders and Content-Length framing
6. #588 — [vscode] wasm codec: streaming decode, response routing, and wasm ABI
7. #589 — [vscode] extension scaffold and the TypeScript wasm binding
8. #590 — [vscode] extension host: server lifecycle and semantic-token provider
9. #591 — [vscode] protocol smoke test, VSIX packaging, and CMake targets
10. #592 — [lsp][vscode] CI workflow, nightly packaging, docs, and lit coverage

Includes the fixes for the review findings on #580: lone-CR line handling, legend drift guard, linear UTF-16 conversion, 'modifier' token mapping, EPIPE/signal liveness, crash recovery with restart, and pending-request cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7oSRt4CxcRt9EEMtfP6Wr