### PR TITLE
[tests][ci] survive the lit 23 hard-deprecation of the external shell

### DIFF
--- a/.github/conda/windows-msvc.yml
+++ b/.github/conda/windows-msvc.yml
@@ -4,7 +4,7 @@ dependencies:
   - python=3.12
   - cmake
   - ninja
-  - lit
+  - lit <24
   # lit's --timeout (set via LIT_OPTS in the workflow) needs psutil to
   # reap wedged test processes.
   - psutil

--- a/.github/workflows/mlir-cpp-test-macos.yml
+++ b/.github/workflows/mlir-cpp-test-macos.yml
@@ -33,7 +33,7 @@ jobs:
           # (tests/integration/rene/wasi_*.rr); CMake finds it on PATH at
           # configure time, which is what turns the `wasmer` lit feature on.
           brew install cmake ninja llvm spdlog googletest python@3 wasmer
-          pip3 install lit --break-system-packages
+          pip3 install 'lit<24' --break-system-packages
 
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/mlir-cpp-test.yml
+++ b/.github/workflows/mlir-cpp-test.yml
@@ -64,7 +64,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y cmake ninja-build wget libgtest-dev libgmock-dev libspdlog-dev libgmp-dev
-          sudo pip install lit --break-system-packages
+          sudo pip install 'lit<24' --break-system-packages
 
       # The engine that runs what the WebAssembly suite builds. The official
       # installer drops the binary in ~/.wasmer/bin; putting that on PATH is

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y cmake ninja-build wget libgtest-dev libgmock-dev libspdlog-dev libgmp-dev
-          sudo pip install lit --break-system-packages
+          sudo pip install 'lit<24' --break-system-packages
 
       - name: Install LLVM ${{ matrix.llvm-version }}
         run: |
@@ -163,7 +163,7 @@ jobs:
         run: |
           brew update
           brew install cmake ninja llvm spdlog googletest python@3
-          pip3 install lit --break-system-packages
+          pip3 install 'lit<24' --break-system-packages
 
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/tests/integration/lit.cfg.py
+++ b/tests/integration/lit.cfg.py
@@ -3,7 +3,14 @@ import os
 import sys
 
 config.name = 'Reussir'
-config.test_format = lit.formats.ShTest(True)
+# lit 23 (LLVM 23) hard-errors on execute_external=True unless the migration
+# escape hatch force_execute_external is set; lit <= 22 does not know that
+# kwarg at all. Keep the external shell on both until the suites migrate to
+# lit's internal shell.
+try:
+    config.test_format = lit.formats.ShTest(True, force_execute_external=True)
+except TypeError:
+    config.test_format = lit.formats.ShTest(True)
 
 config.suffixes = ['.mlir', '.rr', '.repl', '.ll']
 # `Inputs/` directories hold companion files (transform scripts, C drivers)


### PR DESCRIPTION
## Summary

Every CI run since 2026-08-25 fails during lit discovery on all lit-running workflows (Windows MSVC, macOS Homebrew, MLIR MultiArch, Nightly Release): lit 23.1.0 turns `execute_external=True` into a `ValueError` at config load unless the migration escape hatch `force_execute_external=True` is set — and CI installs lit unpinned, so the 2026-08-25 PyPI release broke every runner.

Two commits:

1. **`lit.cfg.py` compat shim**: try `ShTest(True, force_execute_external=True)` first, fall back on `TypeError` for lit ≤ 22 (which does not accept the kwarg). Verified locally against lit 18.1.8; this PR's CI exercises the 23.1.0 path.
2. **Pin `lit<24` at all five install sites** (pip on linux/macos/nightly, the conda-forge spec for Windows): the escape hatch is documented to disappear in LLVM 24, so an unpinned install breaks the same way again on that release. The pin holds until the suites migrate to lit's internal shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FGAPjZfBhq5GN4PJQNBkHH

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/594"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790461283&installation_model_id=426051&pr_number=594&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F594&signature=3c642e903f95a1d81bc54a2f7a1f30823c929a4cd0780bdaad29bcc97512c6e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->