### PR TITLE
[ci] probe: macOS llvm@22 pin

### DIFF
--- a/.github/workflows/mlir-cpp-test-macos.yml
+++ b/.github/workflows/mlir-cpp-test-macos.yml
@@ -32,8 +32,10 @@ jobs:
           # wasmer runs the WebAssembly suites' modules
           # (tests/integration/rene/wasi_*.rr); CMake finds it on PATH at
           # configure time, which is what turns the `wasmer` lit feature on.
-          brew install cmake ninja llvm spdlog googletest python@3 wasmer
-          pip3 install 'lit<24' --break-system-packages
+          # llvm@22 (keg-only) pins the toolchain: FindLLVM.cmake requires
+          # LLVM 22.x and the unversioned formula moved on to 23.
+          brew install cmake ninja llvm@22 spdlog googletest python@3 wasmer
+          pip3 install lit --break-system-packages
 
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -48,7 +50,7 @@ jobs:
 
       - name: Setup environment paths
         run: |
-          LLVM_PREFIX=$(brew --prefix llvm)
+          LLVM_PREFIX=$(brew --prefix llvm@22)
           echo "LLVM_PREFIX=${LLVM_PREFIX}" >> $GITHUB_ENV
           echo "${LLVM_PREFIX}/bin" >> $GITHUB_PATH
           echo "DYLD_LIBRARY_PATH=${LLVM_PREFIX}/lib:$DYLD_LIBRARY_PATH" >> $GITHUB_ENV

--- a/.github/workflows/mlir-cpp-test-macos.yml
+++ b/.github/workflows/mlir-cpp-test-macos.yml
@@ -53,6 +53,10 @@ jobs:
           LLVM_PREFIX=$(brew --prefix llvm@22)
           echo "LLVM_PREFIX=${LLVM_PREFIX}" >> $GITHUB_ENV
           echo "${LLVM_PREFIX}/bin" >> $GITHUB_PATH
+          # llvm@22 is keg-only: its lib dir no longer implies the shared
+          # Homebrew lib dir on the linker path, so -lzstd/-lxml2 from
+          # llvm-sys/tblgen-sys stop resolving without this.
+          echo "LIBRARY_PATH=$(brew --prefix)/lib" >> $GITHUB_ENV
           echo "DYLD_LIBRARY_PATH=${LLVM_PREFIX}/lib:$DYLD_LIBRARY_PATH" >> $GITHUB_ENV
           echo "LLVM_SYMBOLIZER_PATH=${LLVM_PREFIX}/bin/llvm-symbolizer" >> $GITHUB_ENV
 


### PR DESCRIPTION
CI probe: verifies the llvm@22 Homebrew pin triggers and passes independently of PR #595 (whose pull_request workflows stopped triggering). Will be closed or merged into the main PR flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EpQbdaWoHeGduNHRQzSH8V

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/596"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790574362&installation_model_id=426051&pr_number=596&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F596&signature=23cc67a25e1e135381c9dc73b750b8855fe41c576d064b9620ea346078a006c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->