### PR TITLE
[frontend] dynamic-extent arrays and the tensor type

### DIFF
--- a/crates/reussir-codegen/src/lower/expr.rs
+++ b/crates/reussir-codegen/src/lower/expr.rs
@@ -847,30 +847,24 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
                     let index_ty = Type::index(self.context);
                     match func {
                         StrFn::Len => {
-                            let len = self.append(
-                                block,
-                                builders::str_len(self.context, operands[0], loc),
-                            );
+                            let len = self
+                                .append(block, builders::str_len(self.context, operands[0], loc));
                             let u64_ty = IntegerType::new(self.context, 64).into();
                             Ok(Some(
                                 self.append(block, arith::index_castui(len, u64_ty, loc)),
                             ))
                         }
                         StrFn::ByteAt => {
-                            let index = self.append(
-                                block,
-                                arith::index_castui(operands[1], index_ty, loc),
-                            );
+                            let index =
+                                self.append(block, arith::index_castui(operands[1], index_ty, loc));
                             Ok(Some(self.append(
                                 block,
                                 builders::str_byte_at(self.context, operands[0], index, loc),
                             )))
                         }
                         StrFn::Slice => {
-                            let offset = self.append(
-                                block,
-                                arith::index_castui(operands[1], index_ty, loc),
-                            );
+                            let offset =
+                                self.append(block, arith::index_castui(operands[1], index_ty, loc));
                             let result = self.tys.mlir_ty(e.ty)?;
                             Ok(Some(self.append(
                                 block,
@@ -950,6 +944,10 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
             Closure(c) => self.closure(block, env, c).map(Some),
             ClosureCall { target, args } => self.closure_call(block, env, target, args),
             ArrayOp { op, args } => self.lower_array_op(block, env, e, *op, args),
+            // Frontend-complete, backend-pending (docs/design/tensor-kernels.md):
+            // the tensor boundary ops lower to array views / linalg once the
+            // bufferization stages land in the pipeline.
+            TensorOp { .. } => err("tensor operations do not lower yet"),
             GlobalStr(token) => self.global_str(block, e, *token).map(Some),
             Poison => err("poison expression reached lowering"),
         }
@@ -2886,30 +2884,21 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
             let op = match op {
                 CmpOp::Eq => builders::str_equal(self.context, lv, rv, loc),
                 CmpOp::Ne => {
-                    let eq = self
-                        .append(block, builders::str_equal(self.context, lv, rv, loc));
+                    let eq = self.append(block, builders::str_equal(self.context, lv, rv, loc));
                     let i1_ty = IntegerType::new(self.context, 1).into();
                     let one = self.append(
                         block,
-                        arith::constant(
-                            self.context,
-                            IntegerAttribute::new(i1_ty, 1).into(),
-                            loc,
-                        ),
+                        arith::constant(self.context, IntegerAttribute::new(i1_ty, 1).into(), loc),
                     );
                     arith::xori(eq, one, loc)
                 }
                 ordering => {
-                    let order = self
-                        .append(block, builders::str_compare(self.context, lv, rv, loc));
+                    let order =
+                        self.append(block, builders::str_compare(self.context, lv, rv, loc));
                     let i32_ty = IntegerType::new(self.context, 32).into();
                     let zero = self.append(
                         block,
-                        arith::constant(
-                            self.context,
-                            IntegerAttribute::new(i32_ty, 0).into(),
-                            loc,
-                        ),
+                        arith::constant(self.context, IntegerAttribute::new(i32_ty, 0).into(), loc),
                     );
                     let pred = match ordering {
                         CmpOp::Lt => CmpiPredicate::Slt,
@@ -3252,12 +3241,23 @@ impl<'c, 'p, 'tcx> Lowerer<'c, 'p, 'tcx> {
         op: ArrayFn,
         args: &'tcx [Expr<'tcx>],
     ) -> Result<Option<Value<'c, 'b>>> {
+        // Frontend-complete, backend-pending: a dynamic-extent array
+        // (docs/design/dynamic-extent-arrays.md) lowers to the strided-header
+        // box; until that lands every op on one stops here.
+        let shaped = match op {
+            ArrayFn::Splat | ArrayFn::Tabulate => e.ty,
+            _ => args[0].ty,
+        };
+        if Self::array_dims(shaped).is_ok_and(reussir_core::semi::ty::has_dynamic_extent) {
+            return err("dynamic-extent arrays do not lower yet");
+        }
         match op {
             ArrayFn::Get => self.array_get(block, env, e, args).map(Some),
             ArrayFn::Set => self.array_set(block, env, args).map(Some),
             ArrayFn::Splat => self.array_splat(block, env, e, args).map(Some),
             ArrayFn::Tabulate => self.array_tabulate(block, env, e, args).map(Some),
             ArrayFn::Fold => self.array_fold(block, env, e, args).map(Some),
+            ArrayFn::Dim => err("`array::dim` does not lower yet"),
         }
     }
 

--- a/crates/reussir-codegen/src/lower/ty.rs
+++ b/crates/reussir-codegen/src/lower/ty.rs
@@ -151,6 +151,8 @@ impl<'c, 'p, 'tcx> TypeCtx<'c, 'p, 'tcx> {
             // A statically shaped array is one shared `rc` box holding the whole
             // payload (`!reussir.rc<!reussir.array<dims x elem>>`); see #344.
             TyKind::Array { .. } => Ok(self.rc_type(self.array_inner_of(ty)?)),
+            // Frontend-complete, backend-pending (docs/design/tensor-kernels.md).
+            TyKind::Tensor { .. } => err("tensor types do not lower yet"),
             // A cell is one shared rc box around its payload container. Unlike
             // arrays, its element may itself be a managed type. A sync-kind
             // cell is born in an *atomically counted* box — the dialect
@@ -464,6 +466,11 @@ impl<'c, 'p, 'tcx> TypeCtx<'c, 'p, 'tcx> {
         let TyKind::Array { elem, dims } = *ty.kind() else {
             return err("array payload requested for a non-array type");
         };
+        if reussir_core::semi::ty::has_dynamic_extent(dims) {
+            // Frontend-complete, backend-pending: the strided-header box
+            // (docs/design/dynamic-extent-arrays.md).
+            return err("dynamic-extent arrays do not lower yet");
+        }
         let elem = self.mlir_ty(elem)?;
         let shape: Vec<i64> = dims.iter().map(|&d| d as i64).collect();
         Ok(array(&shape, elem))
@@ -655,6 +662,7 @@ fn scalar_ty<'c>(context: &'c Context, ty: Ty<'_>) -> Result<Type<'c>> {
         TyKind::Str => Ok(str_type(context, ReussirLifeScope::Global)),
         TyKind::Record { .. } => err("record type reached scalar lowering without a layout"),
         TyKind::Array { .. } => err("array type reached scalar lowering without its rc wrapper"),
+        TyKind::Tensor { .. } => err("tensor types do not lower yet"),
         TyKind::Cell { .. } => err("cell type reached scalar lowering without its rc wrapper"),
         TyKind::Arc(_) => err("arc type reached scalar lowering without its rc wrapper"),
         TyKind::Nullable(_) => err("nullable type lowering not yet implemented"),

--- a/crates/reussir-core/src/full/ffi.rs
+++ b/crates/reussir-core/src/full/ffi.rs
@@ -304,11 +304,10 @@ impl<'a, 'tcx> FfiCtx<'a, 'tcx> {
             // `'static` global literal, so the spelled lifetime is sound —
             // and unlike `'_`, it is legal in the packed-args struct field
             // the nontrivial boundary generates.
-            TyKind::Str => {
-                Ok("::reussir_rt::collections::string::Str<'static>".into())
-            }
+            TyKind::Str => Ok("::reussir_rt::collections::string::Str<'static>".into()),
             TyKind::Cell { .. } => Err("a cell cannot cross the FFI boundary".into()),
             TyKind::Array { .. } => Err("an array cannot cross the FFI boundary yet".into()),
+            TyKind::Tensor { .. } => Err("a tensor cannot cross the FFI boundary".into()),
             TyKind::Closure { .. } => Err("a closure cannot cross the FFI boundary yet".into()),
             TyKind::Bottom | TyKind::Generic(_) | TyKind::Hole(_) => {
                 Err("the type is not ground".into())

--- a/crates/reussir-core/src/full/interface.rs
+++ b/crates/reussir-core/src/full/interface.rs
@@ -269,7 +269,7 @@ fn note_records<'tcx>(ty: Ty<'tcx>, records: &mut FxHashSet<DefId>, queue: &mut 
             }
             note_records(ret, records, queue);
         }
-        TyKind::Array { elem, .. } | TyKind::Cell { elem, .. } => {
+        TyKind::Array { elem, .. } | TyKind::Tensor { elem, .. } | TyKind::Cell { elem, .. } => {
             note_records(elem, records, queue);
         }
         TyKind::Nullable(inner) | TyKind::Arc(inner) => {

--- a/crates/reussir-core/src/full/mangle.rs
+++ b/crates/reussir-core/src/full/mangle.rs
@@ -165,14 +165,13 @@ impl<'a> Mangler<'a> {
             }
             TyKind::Array { elem, dims } => {
                 // An array mangles as a synthetic record whose identifier
-                // carries the extents (`Array512x512`), applied to the element.
-                let mut name = String::from("Array");
-                for (i, d) in dims.iter().enumerate() {
-                    if i > 0 {
-                        name.push('x');
-                    }
-                    name.push_str(&d.to_string());
-                }
+                // carries the extents (`Array512x512`), applied to the
+                // element; a dynamic dimension mangles as `D` (`ArrayDx512`).
+                let name = shaped_name("Array", dims);
+                self.path_with_args_segs(out, &[&name], &[elem]);
+            }
+            TyKind::Tensor { elem, dims } => {
+                let name = shaped_name("Tensor", dims);
                 self.path_with_args_segs(out, &[&name], &[elem]);
             }
             TyKind::Record { def, args, .. } => {
@@ -224,6 +223,24 @@ fn push_ident_body(out: &mut String, body: &str, len: usize) {
         out.push('_');
     }
     out.push_str(body);
+}
+
+/// The synthetic record identifier for a shaped type: the base name with
+/// `x`-joined extents (`Array512x512`); a dynamic dimension spells `D`
+/// (`ArrayDx512`), which cannot collide with a static extent's digits.
+fn shaped_name(base: &str, dims: &[u64]) -> String {
+    let mut name = String::from(base);
+    for (i, &d) in dims.iter().enumerate() {
+        if i > 0 {
+            name.push('x');
+        }
+        if d == crate::semi::ty::DYNAMIC_EXTENT {
+            name.push('D');
+        } else {
+            name.push_str(&d.to_string());
+        }
+    }
+    name
 }
 
 /// The integral-type code; panics on widths the ABI does not define.

--- a/crates/reussir-core/src/full/mir.rs
+++ b/crates/reussir-core/src/full/mir.rs
@@ -344,6 +344,12 @@ pub enum ExprKind<'tcx> {
         op: crate::intrinsic::ArrayFn,
         args: &'tcx [Expr<'tcx>],
     },
+    /// A built-in operation on a transient tensor, mirroring
+    /// [`crate::semi::hir::ExprKind::TensorOp`].
+    TensorOp {
+        op: crate::intrinsic::TensorFn,
+        args: &'tcx [Expr<'tcx>],
+    },
     Match(&'tcx Expr<'tcx>, DecisionTree<'tcx>),
     /// Error-recovery placeholder.
     Poison,

--- a/crates/reussir-core/src/full/mir/build.rs
+++ b/crates/reussir-core/src/full/mir/build.rs
@@ -343,6 +343,10 @@ impl<'tcx> Builder<'_, 'tcx> {
                 let elem = self.ty(elem);
                 self.tcx.mk_array(elem, dims)
             }
+            raw::Ty::Tensor { elem, dims } => {
+                let elem = self.ty(elem);
+                self.tcx.mk_tensor(elem, dims)
+            }
         }
     }
 
@@ -535,6 +539,11 @@ impl<'tcx> Builder<'_, 'tcx> {
             raw::Kind::ArrayOp { op, args } => M::ArrayOp {
                 op: crate::intrinsic::ArrayFn::parse(op)
                     .expect("known array op in machine-emitted IR"),
+                args: self.expr_slice(args),
+            },
+            raw::Kind::TensorOp { op, args } => M::TensorOp {
+                op: crate::intrinsic::TensorFn::parse(op)
+                    .expect("known tensor op in machine-emitted IR"),
                 args: self.expr_slice(args),
             },
             raw::Kind::NullableCall(inner) => {

--- a/crates/reussir-core/src/full/mir/grammar.lalrpop
+++ b/crates/reussir-core/src/full/mir/grammar.lalrpop
@@ -169,10 +169,19 @@ Ty: raw::Ty = {
     "Arc" "<" <t:Ty> ">" => raw::Ty::Arc(Box::new(t)),
     <cap:Cap> <path:TyPathArgs>
         => raw::Ty::Record { cap, path: path.0, args: path.1 },
-    "[" <elem:Ty> ";" <dims:CommaPlus<"int">> "]"
-        => raw::Ty::Array { elem: Box::new(elem), dims: dims.iter().map(raw::small_u64).collect() },
+    "[" <elem:Ty> ";" <dims:CommaPlus<Extent>> "]"
+        => raw::Ty::Array { elem: Box::new(elem), dims },
+    "Tensor" "<" "[" <elem:Ty> ";" <dims:CommaPlus<Extent>> "]" ">"
+        => raw::Ty::Tensor { elem: Box::new(elem), dims },
     "(" ")" "->" <ret:Ty> => raw::Ty::Closure { params: vec![], ret: Box::new(ret) },
     "(" <ps:CommaPlus<Ty>> ")" "->" <ret:Ty> => raw::Ty::Closure { params: ps, ret: Box::new(ret) },
+};
+
+/// One shape dimension: a static extent, or `_` for a dynamic one
+/// (the DYNAMIC_EXTENT sentinel, mirroring MLIR's `?`).
+Extent: u64 = {
+    <i:"int"> => raw::small_u64(&i),
+    "_" => crate::semi::ty::DYNAMIC_EXTENT,
 };
 
 /// A qualified record-type path with an optional turbofish
@@ -265,6 +274,8 @@ Atom: raw::Kind = {
         => raw::Kind::Intrinsic { family: family.to_string(), name: name.to_string(), imm: raw::small_u32(&imm), args },
     "array" "#" <op:"ident"> "(" <args:Comma<Expr>> ")"
         => raw::Kind::ArrayOp { op: op.to_string(), args },
+    "tensor" "#" <op:"ident"> "(" <args:Comma<Expr>> ")"
+        => raw::Kind::TensorOp { op: op.to_string(), args },
     "NonNull" "(" <e:Expr> ")" => raw::Kind::NullableCall(Some(e)),
     "Null" => raw::Kind::NullableCall(None),
     "apply" "(" <target:Expr> <args:("," <Expr>)*> ")"
@@ -413,6 +424,7 @@ extern {
         "proj" => Token::Proj,
         "intrinsic" => Token::Intrinsic,
         "array" => Token::Array,
+        "tensor" => Token::TensorKw,
         "assign" => Token::Assign,
         "Nullable" => Token::Nullable,
         "Cell" => Token::Cell,
@@ -422,6 +434,7 @@ extern {
         "FlatLock" => Token::FlatLockCell,
         "RwLock" => Token::RwLockCell,
         "Arc" => Token::Arc,
+        "Tensor" => Token::Tensor,
         "NonNull" => Token::NonNull,
         "Null" => Token::Null,
         "poison" => Token::Poison,

--- a/crates/reussir-core/src/full/mir/grammar.lalrpop
+++ b/crates/reussir-core/src/full/mir/grammar.lalrpop
@@ -177,11 +177,11 @@ Ty: raw::Ty = {
     "(" <ps:CommaPlus<Ty>> ")" "->" <ret:Ty> => raw::Ty::Closure { params: ps, ret: Box::new(ret) },
 };
 
-/// One shape dimension: a static extent, or `_` for a dynamic one
-/// (the DYNAMIC_EXTENT sentinel, mirroring MLIR's `?`).
+/// One shape dimension: a static extent, or `?` for a dynamic one
+/// (the DYNAMIC_EXTENT sentinel, matching MLIR's spelling).
 Extent: u64 = {
     <i:"int"> => raw::small_u64(&i),
-    "_" => crate::semi::ty::DYNAMIC_EXTENT,
+    "?" => crate::semi::ty::DYNAMIC_EXTENT,
 };
 
 /// A qualified record-type path with an optional turbofish
@@ -463,6 +463,7 @@ extern {
         "=" => Token::Eq,
         "=>" => Token::FatArrow,
         "_" => Token::Underscore,
+        "?" => Token::Question,
         "->" => Token::Arrow,
         "@" => Token::At,
         "#" => Token::Hash,

--- a/crates/reussir-core/src/full/mir/print.rs
+++ b/crates/reussir-core/src/full/mir/print.rs
@@ -302,14 +302,14 @@ impl Render<'_> {
 
     // ----- types -----
 
-    /// `[elem; d0, d1]`; a dynamic dimension prints as `_`, matching the
+    /// `[elem; d0, d1]`; a dynamic dimension prints as `?`, matching the
     /// grammar's extent rule.
     fn shape(&self, elem: Ty<'_>, dims: &[u64]) -> Doc<'static> {
         let mut d = text("[") + self.ty(elem) + text(";");
         for (i, &extent) in dims.iter().enumerate() {
             let sep = if i > 0 { "," } else { "" };
             if extent == crate::semi::ty::DYNAMIC_EXTENT {
-                d = d + text(format!("{sep} _"));
+                d = d + text(format!("{sep} ?"));
             } else {
                 d = d + text(format!("{sep} {extent}"));
             }

--- a/crates/reussir-core/src/full/mir/print.rs
+++ b/crates/reussir-core/src/full/mir/print.rs
@@ -302,6 +302,21 @@ impl Render<'_> {
 
     // ----- types -----
 
+    /// `[elem; d0, d1]`; a dynamic dimension prints as `_`, matching the
+    /// grammar's extent rule.
+    fn shape(&self, elem: Ty<'_>, dims: &[u64]) -> Doc<'static> {
+        let mut d = text("[") + self.ty(elem) + text(";");
+        for (i, &extent) in dims.iter().enumerate() {
+            let sep = if i > 0 { "," } else { "" };
+            if extent == crate::semi::ty::DYNAMIC_EXTENT {
+                d = d + text(format!("{sep} _"));
+            } else {
+                d = d + text(format!("{sep} {extent}"));
+            }
+        }
+        d + text("]")
+    }
+
     fn ty(&self, ty: Ty<'_>) -> Doc<'static> {
         match *ty.kind() {
             TyKind::Int(IntTy::Signed(w)) => text(format!("i{w}")),
@@ -319,14 +334,8 @@ impl Render<'_> {
                 text(kind.surface_name()) + text("<") + self.ty(elem) + text(">")
             }
             TyKind::Arc(inner) => text("Arc<") + self.ty(inner) + text(">"),
-            TyKind::Array { elem, dims } => {
-                let mut d = text("[") + self.ty(elem) + text(";");
-                for (i, extent) in dims.iter().enumerate() {
-                    let sep = if i > 0 { "," } else { "" };
-                    d = d + text(format!("{sep} {extent}"));
-                }
-                d + text("]")
-            }
+            TyKind::Array { elem, dims } => self.shape(elem, dims),
+            TyKind::Tensor { elem, dims } => text("Tensor<") + self.shape(elem, dims) + text(">"),
             TyKind::Record { def, args, flex } => {
                 let mut d = match flex {
                     Flexivity::Flex | Flexivity::Rigid | Flexivity::Regional => {
@@ -534,6 +543,9 @@ impl Render<'_> {
             }
             ArrayOp { op, args } => {
                 text(format!("array#{}(", op.as_str())) + self.arg_list(args) + text(")")
+            }
+            TensorOp { op, args } => {
+                text(format!("tensor#{}(", op.as_str())) + self.arg_list(args) + text(")")
             }
             Let { .. } | Seq(_) | If(..) | Match(..) => {
                 unreachable!("structural forms are rendered by `value`")

--- a/crates/reussir-core/src/full/mir/raw.rs
+++ b/crates/reussir-core/src/full/mir/raw.rs
@@ -282,6 +282,11 @@ pub enum Ty {
         elem: Box<Ty>,
         dims: Vec<u64>,
     },
+    /// `Tensor<[elem; extents…]>` — a transient value-semantics view.
+    Tensor {
+        elem: Box<Ty>,
+        dims: Vec<u64>,
+    },
 }
 
 /// The per-use capability prefix printed before a record type (absent = value).
@@ -424,6 +429,11 @@ pub enum Kind {
     /// `array#<op>(args…)` — a built-in array op; a `tabulate`/`fold`
     /// kernel closure is an ordinary argument.
     ArrayOp {
+        op: String,
+        args: Vec<Expr>,
+    },
+    /// `tensor#<op>(args…)` — a built-in tensor op.
+    TensorOp {
         op: String,
         args: Vec<Expr>,
     },

--- a/crates/reussir-core/src/full/mono.rs
+++ b/crates/reussir-core/src/full/mono.rs
@@ -253,7 +253,8 @@ pub(crate) fn for_each_expr<'e, 'tcx>(expr: &'e Expr<'tcx>, f: &mut impl FnMut(&
         CompoundCall { args, .. }
         | VariantCall { args, .. }
         | Intrinsic { args, .. }
-        | ArrayOp { args, .. } => {
+        | ArrayOp { args, .. }
+        | TensorOp { args, .. } => {
             args.iter().for_each(|e| for_each_expr(e, f));
         }
         NullableCall(inner) => {
@@ -867,7 +868,7 @@ fn ty_depth(ty: Ty<'_>) -> usize {
         TyKind::Nullable(inner) => 1 + ty_depth(inner),
         TyKind::Cell { elem: inner, .. } => 1 + ty_depth(inner),
         TyKind::Arc(inner) => 1 + ty_depth(inner),
-        TyKind::Array { elem, .. } => 1 + ty_depth(elem),
+        TyKind::Array { elem, .. } | TyKind::Tensor { elem, .. } => 1 + ty_depth(elem),
         TyKind::Record { args, .. } => 1 + args.iter().map(|&a| ty_depth(a)).max().unwrap_or(0),
         TyKind::Closure { params, ret } => {
             1 + params
@@ -1819,7 +1820,7 @@ impl<'a, 'tcx> Driver<'a, 'tcx> {
             TyKind::Nullable(inner) => self.note_records(inner),
             TyKind::Cell { elem: inner, .. } => self.note_records(inner),
             TyKind::Arc(inner) => self.note_records(inner),
-            TyKind::Array { elem, .. } => self.note_records(elem),
+            TyKind::Array { elem, .. } | TyKind::Tensor { elem, .. } => self.note_records(elem),
             _ => {}
         }
     }
@@ -1948,7 +1949,9 @@ impl<'a, 'tcx> Driver<'a, 'tcx> {
                 }
                 self.check_arc_inners(inner, span);
             }
-            TyKind::Array { elem, .. } => self.check_arc_inners(elem, span),
+            TyKind::Array { elem, .. } | TyKind::Tensor { elem, .. } => {
+                self.check_arc_inners(elem, span)
+            }
             _ => {}
         }
     }
@@ -1984,7 +1987,9 @@ impl<'a, 'tcx> Driver<'a, 'tcx> {
             TyKind::Nullable(inner) => self.discover_records(inner, worklist),
             TyKind::Cell { elem: inner, .. } => self.discover_records(inner, worklist),
             TyKind::Arc(inner) => self.discover_records(inner, worklist),
-            TyKind::Array { elem, .. } => self.discover_records(elem, worklist),
+            TyKind::Array { elem, .. } | TyKind::Tensor { elem, .. } => {
+                self.discover_records(elem, worklist)
+            }
             _ => {}
         }
     }
@@ -2409,11 +2414,14 @@ impl<'a, 'tcx> Driver<'a, 'tcx> {
                 use crate::semi::ty::TyKind;
                 use crate::semi::ty_eval::{array_element_rejection, is_plain_scalar_or_deferred};
                 let arg0 = args.first().map(|a| subst_ty(self.tcx, a.ty, subst));
+                // The constructors' payload operand is the *last* argument
+                // (dynamic extents, if any, lead).
+                let last = args.last().map(|a| subst_ty(self.tcx, a.ty, subst));
                 let elem = match op {
-                    // `splat`'s one argument *is* an element value.
-                    ArrayFn::Splat => arg0,
+                    // `splat`'s payload argument *is* an element value.
+                    ArrayFn::Splat => last,
                     // `tabulate`'s kernel returns the element.
-                    ArrayFn::Tabulate => arg0.and_then(|t| match t.kind() {
+                    ArrayFn::Tabulate => last.and_then(|t| match t.kind() {
                         TyKind::Closure { ret, .. } => Some(*ret),
                         _ => None,
                     }),
@@ -2450,6 +2458,14 @@ impl<'a, 'tcx> Driver<'a, 'tcx> {
                     args: self.lower_slice(args, subst),
                 }
             }
+            // The tensor boundary intrinsics are shape-generic pass-throughs
+            // here; `of`'s array operand goes through the array element
+            // checks on its own type, and the lowering stubs stop anything
+            // from reaching codegen.
+            ExprKind::TensorOp { op, args } => M::TensorOp {
+                op: *op,
+                args: self.lower_slice(args, subst),
+            },
             ExprKind::Match(scrut, tree) => {
                 M::Match(self.lower_ref(scrut, subst), self.lower_tree(tree, subst))
             }
@@ -3512,7 +3528,7 @@ mod tests {
             TyKind::Nullable(inner) => is_ground(inner),
             TyKind::Cell { elem: inner, .. } => is_ground(inner),
             TyKind::Arc(inner) => is_ground(inner),
-            TyKind::Array { elem, .. } => is_ground(elem),
+            TyKind::Array { elem, .. } | TyKind::Tensor { elem, .. } => is_ground(elem),
             _ => true,
         }
     }
@@ -3521,7 +3537,7 @@ mod tests {
     fn children<'tcx>(e: &mir::Expr<'tcx>) -> Vec<&'tcx mir::Expr<'tcx>> {
         use mir::ExprKind::*;
         match e.kind {
-            ArrayOp { args, .. } => args.iter().collect(),
+            ArrayOp { args, .. } | TensorOp { args, .. } => args.iter().collect(),
             GlobalStr(_) | ConstChar(_) | ConstInt(_) | ConstFloat(_) | ConstBool(_) | Var(_)
             | Poison => vec![],
             Negate(x) | Not(x) | Cast(x, _) | RegionRun(x) | Proj(x, _) => vec![x],

--- a/crates/reussir-core/src/full/ownership.rs
+++ b/crates/reussir-core/src/full/ownership.rs
@@ -313,6 +313,10 @@ impl<'a, 'tcx> Rr<'a, 'tcx> {
             // An array is one rc-managed box regardless of its (Plain)
             // element type.
             TyKind::Array { .. } => true,
+            // A tensor is a transient value-semantics view; it carries no rc
+            // box of its own (the backing array's reference is rooted by the
+            // intrinsic that produced the tensor, not by the tensor value).
+            TyKind::Tensor { .. } => false,
             // A cell is always one shared rc-managed box, independent of its
             // element type (which the cell's drop recursively releases).
             TyKind::Cell { .. } => true,
@@ -526,7 +530,7 @@ impl<'tcx> Analyzer<'_, 'tcx> {
             }
             // An array op uses its value operands (a Tabulate/Fold kernel is
             // an ordinary closure-typed operand among them).
-            ExprKind::ArrayOp { args, .. } => {
+            ExprKind::ArrayOp { args, .. } | ExprKind::TensorOp { args, .. } => {
                 for arg in args {
                     s.union_with(&self.free(arg));
                 }
@@ -647,6 +651,12 @@ impl<'tcx> Analyzer<'_, 'tcx> {
                 self.place_closure_call(target, args, live_after)
             }
             ExprKind::ArrayOp { op, args } => self.place_array_op(e, op, args, live_after),
+            // Tensor boundary ops consume their operands like call
+            // arguments: `of` consumes the array reference (the tensor owns
+            // the rooted dup — a later use of the array sees count ≥ 2 and
+            // clones, which is what makes the view's `restrict` contract
+            // hold); tensors themselves are not rc-managed.
+            ExprKind::TensorOp { args, .. } => self.place_args(args, live_after),
         }
     }
 
@@ -724,7 +734,7 @@ impl<'tcx> Analyzer<'_, 'tcx> {
         live_after: &VarSet,
     ) {
         use crate::intrinsic::ArrayFn;
-        let borrows_base = matches!(op, ArrayFn::Get | ArrayFn::Fold);
+        let borrows_base = matches!(op, ArrayFn::Get | ArrayFn::Fold | ArrayFn::Dim);
 
         let mut borrowed = VarSet::default();
         let mut base_is_borrowed_var = false;

--- a/crates/reussir-core/src/full/ownership/tests.rs
+++ b/crates/reussir-core/src/full/ownership/tests.rs
@@ -446,6 +446,7 @@ fn kind_name(kind: &ExprKind<'_>) -> &'static str {
         ExprKind::Closure(_) => "Closure",
         ExprKind::ClosureCall { .. } => "ClosureCall",
         ExprKind::ArrayOp { .. } => "ArrayOp",
+        ExprKind::TensorOp { .. } => "TensorOp",
         ExprKind::Match(..) => "Match",
         ExprKind::Poison => "Poison",
     }
@@ -856,13 +857,19 @@ fn interp<'tcx>(
         // array base, which follows the `Proj` borrow rule.
         ExprKind::ArrayOp { op, args } => {
             use crate::intrinsic::ArrayFn;
-            let borrows_base = matches!(op, ArrayFn::Get | ArrayFn::Fold);
+            let borrows_base = matches!(op, ArrayFn::Get | ArrayFn::Fold | ArrayFn::Dim);
             for (i, a) in args.iter().enumerate() {
                 if i == 0 && borrows_base {
                     interp_borrow(a, ot, rr, rc);
                 } else {
                     interp(a, ot, rr, rc);
                 }
+            }
+        }
+        // Tensor boundary ops consume all operands like call args.
+        ExprKind::TensorOp { args, .. } => {
+            for a in args {
+                interp(a, ot, rr, rc);
             }
         }
         ExprKind::GlobalStr(_)
@@ -980,7 +987,7 @@ fn uses_var(e: &Expr<'_>, y: VarId) -> bool {
 fn children<'tcx>(e: &Expr<'tcx>) -> Vec<&'tcx Expr<'tcx>> {
     use ExprKind::*;
     match e.kind {
-        ArrayOp { args, .. } => args.iter().collect(),
+        ArrayOp { args, .. } | TensorOp { args, .. } => args.iter().collect(),
         GlobalStr(_) | ConstChar(_) | ConstInt(_) | ConstFloat(_) | ConstBool(_) | Var(_)
         | Poison => vec![],
         Negate(x) | Not(x) | Cast(x, _) | RegionRun(x) | Proj(x, _) => vec![x],

--- a/crates/reussir-core/src/full/subst.rs
+++ b/crates/reussir-core/src/full/subst.rs
@@ -38,6 +38,7 @@ pub fn subst_ty<'tcx>(tcx: &TyCtxt<'tcx>, ty: Ty<'tcx>, subst: &Subst<'tcx>) -> 
         TyKind::Cell { elem, kind } => tcx.mk_cell(subst_ty(tcx, elem, subst), kind),
         TyKind::Arc(inner) => tcx.mk_arc(subst_ty(tcx, inner, subst)),
         TyKind::Array { elem, dims } => tcx.mk_array(subst_ty(tcx, elem, subst), dims),
+        TyKind::Tensor { elem, dims } => tcx.mk_tensor(subst_ty(tcx, elem, subst), dims),
         TyKind::Int(_)
         | TyKind::Fp(_)
         | TyKind::Bool

--- a/crates/reussir-core/src/intrinsic.rs
+++ b/crates/reussir-core/src/intrinsic.rs
@@ -180,7 +180,7 @@ pub enum ArrayFn {
     Fold,
     /// `dim(a, k)`: the `k`-th extent as `u64`. Value operands: `[a, k]`;
     /// `a` is borrowed, not consumed. The interesting case is a dynamic
-    /// dimension (`[T; _, 4]`), whose extent lives in the box header; on a
+    /// dimension (`[T; ?, 4]`), whose extent lives in the box header; on a
     /// fully static array it folds to a constant.
     Dim,
 }

--- a/crates/reussir-core/src/intrinsic.rs
+++ b/crates/reussir-core/src/intrinsic.rs
@@ -178,6 +178,11 @@ pub enum ArrayFn {
     /// `fold(a, init, |acc, x| e)`: row-major reduction. Value operands:
     /// `[a, init]`; `a` is borrowed, not consumed.
     Fold,
+    /// `dim(a, k)`: the `k`-th extent as `u64`. Value operands: `[a, k]`;
+    /// `a` is borrowed, not consumed. The interesting case is a dynamic
+    /// dimension (`[T; _, 4]`), whose extent lives in the box header; on a
+    /// fully static array it folds to a constant.
+    Dim,
 }
 
 /// A built-in operation on a shared mutable [`Cell`](crate::semi::ty::TyKind::Cell),
@@ -272,6 +277,7 @@ impl ArrayFn {
             "get" => Some(ArrayFn::Get),
             "set" => Some(ArrayFn::Set),
             "fold" => Some(ArrayFn::Fold),
+            "dim" => Some(ArrayFn::Dim),
             _ => None,
         }
     }
@@ -284,12 +290,52 @@ impl ArrayFn {
             ArrayFn::Get => "get",
             ArrayFn::Set => "set",
             ArrayFn::Fold => "fold",
+            ArrayFn::Dim => "dim",
         }
     }
 
     /// Whether the op takes an inline kernel body.
     pub fn has_kernel(self) -> bool {
         matches!(self, ArrayFn::Tabulate | ArrayFn::Fold)
+    }
+}
+
+/// A built-in operation on a transient tensor (`TyKind::Tensor`), spelled
+/// `core::intrinsic::tensor::<fn>`. Like [`ArrayFn`], these carry their own
+/// HIR/MIR node (`ExprKind::TensorOp`). The boundary contract
+/// (docs/design/tensor-kernels.md): `of` roots a reference to the backing
+/// array for the tensor's lifetime, `materialize` is the only way a
+/// tensor's data escapes back into the rc world.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub enum TensorFn {
+    /// `of(a)`: view an array as a tensor. Value operands: `[a]`; consumes
+    /// the reference (the tensor owns the rooted dup).
+    Of,
+    /// `materialize(t)`: build a fresh array from the tensor's value.
+    /// Value operands: `[t]`.
+    Materialize,
+    /// `dim(t, k)`: the `k`-th extent as `u64`. Value operands: `[t, k]`.
+    Dim,
+}
+
+impl TensorFn {
+    /// Parse a surface / textual-IR name.
+    pub fn parse(name: &str) -> Option<TensorFn> {
+        match name {
+            "of" => Some(TensorFn::Of),
+            "materialize" => Some(TensorFn::Materialize),
+            "dim" => Some(TensorFn::Dim),
+            _ => None,
+        }
+    }
+
+    /// The surface name, also used by the textual IR (`tensor#<name>`).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            TensorFn::Of => "of",
+            TensorFn::Materialize => "materialize",
+            TensorFn::Dim => "dim",
+        }
     }
 }
 

--- a/crates/reussir-core/src/ir_lex.rs
+++ b/crates/reussir-core/src/ir_lex.rs
@@ -98,6 +98,8 @@ pub enum Token<'a> {
     Intrinsic,
     #[token("array")]
     Array,
+    #[token("tensor")]
+    TensorKw,
     #[token("assign")]
     Assign,
     #[token("scrut")]
@@ -122,6 +124,8 @@ pub enum Token<'a> {
     RwLockCell,
     #[token("Arc")]
     Arc,
+    #[token("Tensor")]
+    Tensor,
     #[token("NonNull")]
     NonNull,
     #[token("Null")]

--- a/crates/reussir-core/src/ir_lex.rs
+++ b/crates/reussir-core/src/ir_lex.rs
@@ -202,6 +202,8 @@ pub enum Token<'a> {
     Hash,
     #[token("_", priority = 3)]
     Underscore,
+    #[token("?")]
+    Question,
 
     // ----- operators -----
     #[token("+")]

--- a/crates/reussir-core/src/semi.rs
+++ b/crates/reussir-core/src/semi.rs
@@ -189,10 +189,7 @@ mod tests {
             let prog = surface::program(&parse.root);
             let elab = elaborate(tcx, &prog, &interner);
             let msgs: Vec<_> = elab.reports.iter().map(|r| r.message.as_str()).collect();
-            assert!(
-                !msgs.iter().any(|m| m.contains("`str`")),
-                "{msgs:#?}"
-            );
+            assert!(!msgs.iter().any(|m| m.contains("`str`")), "{msgs:#?}");
             assert!(
                 msgs.iter()
                     .any(|m| m.contains("`P` does not implement `PartialOrd`")),

--- a/crates/reussir-core/src/semi/check.rs
+++ b/crates/reussir-core/src/semi/check.rs
@@ -2993,7 +2993,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             }
             return self.poison(span);
         };
-        // A dynamic dimension (`[T; _, 4]`) has no extent in the type; its
+        // A dynamic dimension (`[T; ?, 4]`) has no extent in the type; its
         // runtime value is a leading `u64` operand of the constructor, in
         // dimension order.
         let n_dynamic = dims

--- a/crates/reussir-core/src/semi/check.rs
+++ b/crates/reussir-core/src/semi/check.rs
@@ -556,11 +556,8 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 let bool_ty = self.tcx.mk_bool();
                 let l = self.check_expr(l, bool_ty);
                 let r = self.check_expr(r, bool_ty);
-                let shortcut = self.mk_expr(
-                    ExprKind::ConstBool(matches!(op, BinOp::Or)),
-                    bool_ty,
-                    span,
-                );
+                let shortcut =
+                    self.mk_expr(ExprKind::ConstBool(matches!(op, BinOp::Or)), bool_ty, span);
                 let (t, f) = match op {
                     // `l && r` ⇒ `if l { r } else { false }`
                     BinOp::And => (r, shortcut),
@@ -2147,6 +2144,8 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
 
         // A flex value cannot be materialized, so it cannot escape its region by
         // being captured in a closure (the closure may outlive the region).
+        // A tensor is confined the same way: the closure may outlive the
+        // chain the view belongs to (flex : freeze :: tensor : materialize).
         for &(v, ty) in &captures {
             if self.is_flex(ty) {
                 let name = self.sym(self.vars.def(v).name);
@@ -2154,6 +2153,16 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                     span,
                     format!(
                         "closure cannot capture `{name}`: a flex value cannot escape its region"
+                    ),
+                );
+            }
+            if crate::semi::ctxt::contains_tensor(self.infer.resolve(ty)) {
+                let name = self.sym(self.vars.def(v).name);
+                self.error(
+                    span,
+                    format!(
+                        "closure cannot capture `{name}`: a tensor is scope-confined \
+                         (materialize to an array first)"
                     ),
                 );
             }
@@ -2167,6 +2176,13 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             self.error(
                 span,
                 "closure cannot return a flex value: a flex value cannot escape its region",
+            );
+        }
+        if crate::semi::ctxt::contains_tensor(self.infer.resolve(body.ty)) {
+            self.error(
+                span,
+                "closure cannot return a tensor: tensors are scope-confined \
+                 (materialize to an array first)",
             );
         }
 
@@ -2442,6 +2458,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             "panic" => Some(self.infer_panic_intrinsic(fc, span)),
             "math" => Some(self.infer_math_intrinsic(fc, span)),
             "array" => Some(self.infer_array_intrinsic(fc, span)),
+            "tensor" => Some(self.infer_tensor_intrinsic(fc, span)),
             "cell" => Some(self.infer_cell_intrinsic(fc, span)),
             "str" => Some(self.infer_str_intrinsic(fc, span)),
             other => {
@@ -2976,13 +2993,31 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             }
             return self.poison(span);
         };
-        if fc.args.len() != 1 {
+        // A dynamic dimension (`[T; _, 4]`) has no extent in the type; its
+        // runtime value is a leading `u64` operand of the constructor, in
+        // dimension order.
+        let n_dynamic = dims
+            .iter()
+            .filter(|&&d| d == crate::semi::ty::DYNAMIC_EXTENT)
+            .count();
+        if fc.args.len() != n_dynamic + 1 {
+            let extents = if n_dynamic == 0 {
+                String::new()
+            } else {
+                format!(" and {n_dynamic} leading dynamic extent(s)")
+            };
             self.error(
                 span,
-                format!("`core::intrinsic::array::{method}` expects exactly one argument"),
+                format!("`core::intrinsic::array::{method}` expects exactly one argument{extents}"),
             );
             return self.poison(span);
         }
+        let u64_ty = self.tcx.mk_int(crate::semi::ty::IntTy::Unsigned(64));
+        let extent_args: Vec<Expr<'tcx>> = fc.args[..n_dynamic]
+            .iter()
+            .map(|a| self.check_expr(a, u64_ty))
+            .collect();
+        let payload_arg = &fc.args[n_dynamic];
         // `tabulate` fills the payload through the raw view with no
         // per-element ownership hooks, so rc elements stay out of it; a
         // deferred (generic) element re-checks at monomorphization. `splat`
@@ -3002,22 +3037,19 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         }
         match op {
             ArrayFn::Splat => {
-                let v = self.check_expr(&fc.args[0], elem);
-                self.mk_expr(ExprKind::ArrayOp { op, args: vec![v] }, arr, span)
+                let v = self.check_expr(payload_arg, elem);
+                let mut args = extent_args;
+                args.push(v);
+                self.mk_expr(ExprKind::ArrayOp { op, args }, arr, span)
             }
             ArrayFn::Tabulate => {
                 let i64_ty = self.tcx.mk_int(crate::semi::ty::IntTy::Signed(64));
                 let params = vec![i64_ty; dims.len()];
                 let kernel_ty = self.tcx.mk_closure(&params, elem);
-                let kernel = self.check_expr(&fc.args[0], kernel_ty);
-                self.mk_expr(
-                    ExprKind::ArrayOp {
-                        op,
-                        args: vec![kernel],
-                    },
-                    arr,
-                    span,
-                )
+                let kernel = self.check_expr(payload_arg, kernel_ty);
+                let mut args = extent_args;
+                args.push(kernel);
+                self.mk_expr(ExprKind::ArrayOp { op, args }, arr, span)
             }
             _ => unreachable!("filtered above"),
         }
@@ -3132,7 +3164,138 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                     span,
                 )
             }
-            _ => unreachable!("routed here only for get/set/fold"),
+            "dim" => {
+                if args.len() != 1 {
+                    self.error(span, "`dim` expects one dimension-index argument");
+                    return self.poison(span);
+                }
+                let u64_ty = self.tcx.mk_int(crate::semi::ty::IntTy::Unsigned(64));
+                let k = self.check_expr(&args[0], u64_ty);
+                self.mk_expr(
+                    ExprKind::ArrayOp {
+                        op: ArrayFn::Dim,
+                        args: vec![base, k],
+                    },
+                    u64_ty,
+                    span,
+                )
+            }
+            _ => unreachable!("routed here only for get/set/fold/dim"),
+        }
+    }
+
+    /// The tensor boundary intrinsics (docs/design/tensor-kernels.md):
+    /// `of(a)` views an array as a tensor of the same shape (consuming the
+    /// reference — the tensor owns the rooted dup, which is what keeps a
+    /// later in-place update of the array from mutating the viewed buffer);
+    /// `materialize(t)` builds a fresh array from the tensor's value;
+    /// `dim(t, k)` reads the `k`-th extent as `u64`.
+    fn infer_tensor_intrinsic(&mut self, fc: &surface::FuncCall, span: Option<Span>) -> Expr<'tcx> {
+        use crate::intrinsic::TensorFn;
+        let name = self.sym(fc.name.basename).to_string();
+        let Some(op) = TensorFn::parse(&name) else {
+            self.error(
+                span,
+                format!("unknown tensor intrinsic `core::intrinsic::tensor::{name}`"),
+            );
+            return self.poison(span);
+        };
+        if !fc.ty_args.is_empty() {
+            self.error(
+                span,
+                format!(
+                    "`core::intrinsic::tensor::{name}` takes no type arguments \
+                     (the shape comes from its argument)"
+                ),
+            );
+            return self.poison(span);
+        }
+        let expected_args = match op {
+            TensorFn::Of | TensorFn::Materialize => 1,
+            TensorFn::Dim => 2,
+        };
+        if fc.args.len() != expected_args {
+            self.error(
+                span,
+                format!(
+                    "`core::intrinsic::tensor::{name}` expects exactly \
+                     {expected_args} argument(s), got {}",
+                    fc.args.len()
+                ),
+            );
+            return self.poison(span);
+        }
+        let base = self.infer_expr(&fc.args[0]);
+        let bty = self.infer.shallow_resolve(base.ty);
+        match op {
+            TensorFn::Of => {
+                let TyKind::Array { elem, dims } = *bty.kind() else {
+                    let shown = self.infer.resolve(base.ty);
+                    self.error(
+                        span,
+                        format!(
+                            "`of` expects an array argument, found `{}`",
+                            self.ty_display(shown)
+                        ),
+                    );
+                    return self.poison(span);
+                };
+                let tensor = self.tcx.mk_tensor(elem, dims);
+                self.mk_expr(
+                    ExprKind::TensorOp {
+                        op,
+                        args: vec![base],
+                    },
+                    tensor,
+                    span,
+                )
+            }
+            TensorFn::Materialize => {
+                let TyKind::Tensor { elem, dims } = *bty.kind() else {
+                    let shown = self.infer.resolve(base.ty);
+                    self.error(
+                        span,
+                        format!(
+                            "`materialize` expects a tensor argument, found `{}`",
+                            self.ty_display(shown)
+                        ),
+                    );
+                    return self.poison(span);
+                };
+                let arr = self.tcx.mk_array(elem, dims);
+                self.mk_expr(
+                    ExprKind::TensorOp {
+                        op,
+                        args: vec![base],
+                    },
+                    arr,
+                    span,
+                )
+            }
+            TensorFn::Dim => {
+                if !matches!(bty.kind(), TyKind::Tensor { .. }) {
+                    let shown = self.infer.resolve(base.ty);
+                    self.error(
+                        span,
+                        format!(
+                            "`dim` expects a tensor argument, found `{}` \
+                             (use `core::intrinsic::array::dim` for arrays)",
+                            self.ty_display(shown)
+                        ),
+                    );
+                    return self.poison(span);
+                }
+                let u64_ty = self.tcx.mk_int(crate::semi::ty::IntTy::Unsigned(64));
+                let k = self.check_expr(&fc.args[1], u64_ty);
+                self.mk_expr(
+                    ExprKind::TensorOp {
+                        op,
+                        args: vec![base, k],
+                    },
+                    u64_ty,
+                    span,
+                )
+            }
         }
     }
 
@@ -3886,6 +4049,10 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 op,
                 args: args.into_iter().map(|e| self.zonk_expr(e)).collect(),
             },
+            TensorOp { op, args } => TensorOp {
+                op,
+                args: args.into_iter().map(|e| self.zonk_expr(e)).collect(),
+            },
             TraitCall {
                 trait_def,
                 method,
@@ -4007,7 +4174,9 @@ fn var_occurrences<'tcx>(e: &Expr<'tcx>, used: &mut Vec<VarId>, bound: &mut Vec<
             bound.extend(c.params.iter().map(|&(v, _)| v));
             var_occurrences(&c.body, used, bound);
         }
-        ArrayOp { args, .. } => args.iter().for_each(|e| var_occurrences(e, used, bound)),
+        ArrayOp { args, .. } | TensorOp { args, .. } => {
+            args.iter().for_each(|e| var_occurrences(e, used, bound))
+        }
         Match(scrut, tree) => {
             var_occurrences(scrut, used, bound);
             tree_occurrences(tree, used, bound);

--- a/crates/reussir-core/src/semi/ctxt.rs
+++ b/crates/reussir-core/src/semi/ctxt.rs
@@ -242,6 +242,31 @@ pub struct FuncProto<'tcx> {
 /// their arguments, through every structural former — for the
 /// private-in-public check. Deduplicated so each offender reports once per
 /// surface.
+/// Whether a tensor occurs anywhere in `ty`'s structure. Tensors are
+/// scope-confined values (docs/design/tensor-kernels.md); this is the
+/// predicate behind the escape rules (record members, function signatures,
+/// closure captures).
+pub(crate) fn contains_tensor(ty: Ty<'_>) -> bool {
+    match *ty.kind() {
+        TyKind::Tensor { .. } => true,
+        TyKind::Record { args, .. } => args.iter().any(|&a| contains_tensor(a)),
+        TyKind::Closure { params, ret } => {
+            params.iter().any(|&p| contains_tensor(p)) || contains_tensor(ret)
+        }
+        TyKind::Array { elem, .. } | TyKind::Cell { elem, .. } => contains_tensor(elem),
+        TyKind::Nullable(inner) | TyKind::Arc(inner) => contains_tensor(inner),
+        TyKind::Int(_)
+        | TyKind::Fp(_)
+        | TyKind::Bool
+        | TyKind::Str
+        | TyKind::Char
+        | TyKind::Unit
+        | TyKind::Generic(_)
+        | TyKind::Hole(_)
+        | TyKind::Bottom => false,
+    }
+}
+
 fn collect_private_records<'tcx>(
     records: &FxHashMap<DefId, Record<'tcx>>,
     ty: Ty<'tcx>,
@@ -266,7 +291,7 @@ fn collect_private_records<'tcx>(
             }
             collect_private_records(records, ret, out);
         }
-        TyKind::Array { elem, .. } | TyKind::Cell { elem, .. } => {
+        TyKind::Array { elem, .. } | TyKind::Tensor { elem, .. } | TyKind::Cell { elem, .. } => {
             collect_private_records(records, elem, out);
         }
         TyKind::Nullable(inner) | TyKind::Arc(inner) => {
@@ -676,6 +701,24 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         out
     }
 
+    /// `[elem; d0, d1]`, printing a dynamic dimension as `_` — the same
+    /// spelling the surface syntax uses.
+    fn push_shape_display(&self, out: &mut String, elem: Ty<'tcx>, dims: &[u64]) {
+        use std::fmt::Write as _;
+        out.push('[');
+        self.push_ty_display(out, elem);
+        out.push(';');
+        for (i, &extent) in dims.iter().enumerate() {
+            let sep = if i > 0 { "," } else { "" };
+            if extent == crate::semi::ty::DYNAMIC_EXTENT {
+                let _ = write!(out, "{sep} _");
+            } else {
+                let _ = write!(out, "{sep} {extent}");
+            }
+        }
+        out.push(']');
+    }
+
     fn push_ty_display(&self, out: &mut String, ty: Ty<'tcx>) {
         use crate::semi::ty::{FpTy, IntTy};
         use std::fmt::Write as _;
@@ -719,14 +762,12 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 out.push('>');
             }
             TyKind::Array { elem, dims } => {
-                out.push('[');
-                self.push_ty_display(out, elem);
-                out.push(';');
-                for (i, extent) in dims.iter().enumerate() {
-                    let sep = if i > 0 { "," } else { "" };
-                    let _ = write!(out, "{sep} {extent}");
-                }
-                out.push(']');
+                self.push_shape_display(out, elem, dims);
+            }
+            TyKind::Tensor { elem, dims } => {
+                out.push_str("Tensor<");
+                self.push_shape_display(out, elem, dims);
+                out.push('>');
             }
             TyKind::Record { def, args, flex } => {
                 match flex {
@@ -3160,6 +3201,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             if *flex {
                 collect_regional_generic(t, &mut regional_generics);
             }
+            self.reject_tensor_signature(t, Some(ty.span()));
             params.push((*name, t));
         }
         let return_ty = match &func.return_type {
@@ -3168,6 +3210,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 if *flex {
                     collect_regional_generic(t, &mut regional_generics);
                 }
+                self.reject_tensor_signature(t, Some(ty.span()));
                 t
             }
             None => self.tcx.mk_unit(),
@@ -3499,7 +3542,11 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         let params: Vec<Ty<'tcx>> = func
             .params
             .iter()
-            .map(|(_, ty, flex)| self.eval_type_flex(ty, *flex))
+            .map(|(_, ty, flex)| {
+                let t = self.eval_type_flex(ty, *flex);
+                self.reject_tensor_signature(t, Some(ty.span()));
+                t
+            })
             .collect();
         // The receiver is the leading parameter named `self`; its evaluated
         // type (or the `[flex]` marker) picks the form.
@@ -3526,7 +3573,11 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 }
             });
         let ret = match &func.return_type {
-            Some((ty, flex)) => self.eval_type_flex(ty, *flex),
+            Some((ty, flex)) => {
+                let t = self.eval_type_flex(ty, *flex);
+                self.reject_tensor_signature(t, Some(ty.span()));
+                t
+            }
             None => self.tcx.mk_unit(),
         };
         self.generic_names.clear();
@@ -3645,6 +3696,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                         let (name, ty, mutable, vis) = &f.value;
                         let fty = self.field_ty(ty, *mutable);
                         self.reject_arc_member(default_cap, fty, span);
+                        self.reject_tensor_member(fty, span);
                         if *mutable {
                             self.note_link_element(fty, &mut regional_generics, span);
                         }
@@ -3658,6 +3710,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                         let (ty, mutable, vis) = &f.value;
                         let fty = self.field_ty(ty, *mutable);
                         self.reject_arc_member(default_cap, fty, span);
+                        self.reject_tensor_member(fty, span);
                         if *mutable {
                             self.note_link_element(fty, &mut regional_generics, span);
                         }
@@ -3676,6 +3729,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                                 .map(|t| {
                                     let fty = self.eval_type(t);
                                     self.reject_arc_member(default_cap, fty, span);
+                                    self.reject_tensor_member(fty, span);
                                     fty
                                 })
                                 .collect(),
@@ -3882,6 +3936,32 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
     /// freeze/rigid release, region teardown) is deliberately left
     /// undecided. Shared and `[value]` records may hold `Arc` members —
     /// the member type spells its own atomic link (§3.3).
+    /// A tensor is scope-confined (docs/design/tensor-kernels.md): storing
+    /// one in a record would let the transient view outlive its chain, so a
+    /// member type may not contain a tensor anywhere in its structure.
+    fn reject_tensor_member(&mut self, fty: Ty<'tcx>, span: Option<Span>) {
+        if contains_tensor(fty) {
+            self.error(
+                span,
+                "a record member cannot contain a tensor: tensors are \
+                 scope-confined (materialize to an array to store the data)",
+            );
+        }
+    }
+
+    /// A tensor may not appear in a function signature: the transient view
+    /// stays inside the chain that produced it (kernels compose through
+    /// intrinsics for now; a future `kernel fn` would lift this).
+    fn reject_tensor_signature(&mut self, ty: Ty<'tcx>, span: Option<Span>) {
+        if contains_tensor(ty) {
+            self.error(
+                span,
+                "a tensor cannot appear in a function signature: tensors are \
+                 scope-confined (pass the array and take the view inside)",
+            );
+        }
+    }
+
     fn reject_arc_member(&mut self, record_cap: DefaultCap, fty: Ty<'tcx>, span: Option<Span>) {
         if record_cap == DefaultCap::Regional && matches!(fty.kind(), TyKind::Arc(_)) {
             self.error(
@@ -3916,7 +3996,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             // Arrays, cells, and arcs are pointer-like (one shared rc box), so
             // the `Nullable` check lets them through — but a `[field]` link
             // stores a regional record, never a shared box.
-            TyKind::Array { .. } | TyKind::Cell { .. } | TyKind::Arc(_) => {
+            TyKind::Array { .. } | TyKind::Tensor { .. } | TyKind::Cell { .. } | TyKind::Arc(_) => {
                 self.error(span, "a `[field]` link element must be a regional record")
             }
             // Regional records are fine; non-record elements are already rejected

--- a/crates/reussir-core/src/semi/ctxt.rs
+++ b/crates/reussir-core/src/semi/ctxt.rs
@@ -701,7 +701,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         out
     }
 
-    /// `[elem; d0, d1]`, printing a dynamic dimension as `_` — the same
+    /// `[elem; d0, d1]`, printing a dynamic dimension as `?` — the same
     /// spelling the surface syntax uses.
     fn push_shape_display(&self, out: &mut String, elem: Ty<'tcx>, dims: &[u64]) {
         use std::fmt::Write as _;
@@ -711,7 +711,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         for (i, &extent) in dims.iter().enumerate() {
             let sep = if i > 0 { "," } else { "" };
             if extent == crate::semi::ty::DYNAMIC_EXTENT {
-                let _ = write!(out, "{sep} _");
+                let _ = write!(out, "{sep} ?");
             } else {
                 let _ = write!(out, "{sep} {extent}");
             }

--- a/crates/reussir-core/src/semi/externs.rs
+++ b/crates/reussir-core/src/semi/externs.rs
@@ -584,6 +584,10 @@ impl<'tcx> Remapper<'_, '_, 'tcx> {
                 let elem = self.ty(elem);
                 self.tcx.mk_array(elem, dims)
             }
+            TyKind::Tensor { elem, dims } => {
+                let elem = self.ty(elem);
+                self.tcx.mk_tensor(elem, dims)
+            }
             TyKind::Closure { params, ret } => {
                 let params: Vec<Ty<'tcx>> = params.iter().map(|&p| self.ty(p)).collect();
                 let ret = self.ty(ret);
@@ -714,6 +718,10 @@ impl<'tcx> Remapper<'_, '_, 'tcx> {
                 args: self.exprs(args),
             },
             ExprKind::ArrayOp { op, args } => ExprKind::ArrayOp {
+                op: *op,
+                args: self.exprs(args),
+            },
+            ExprKind::TensorOp { op, args } => ExprKind::TensorOp {
                 op: *op,
                 args: self.exprs(args),
             },

--- a/crates/reussir-core/src/semi/fulfill.rs
+++ b/crates/reussir-core/src/semi/fulfill.rs
@@ -331,7 +331,7 @@ pub(super) fn ty_has_hole(ty: crate::semi::ty::Ty<'_>) -> bool {
         TyKind::Nullable(inner) => ty_has_hole(*inner),
         TyKind::Cell { elem: inner, .. } => ty_has_hole(*inner),
         TyKind::Arc(inner) => ty_has_hole(*inner),
-        TyKind::Array { elem, .. } => ty_has_hole(*elem),
+        TyKind::Array { elem, .. } | TyKind::Tensor { elem, .. } => ty_has_hole(*elem),
         _ => false,
     }
 }
@@ -351,7 +351,7 @@ pub(super) fn collect_holes(ty: crate::semi::ty::Ty<'_>, out: &mut Vec<HoleId>) 
         TyKind::Nullable(inner) => collect_holes(*inner, out),
         TyKind::Cell { elem: inner, .. } => collect_holes(*inner, out),
         TyKind::Arc(inner) => collect_holes(*inner, out),
-        TyKind::Array { elem, .. } => collect_holes(*elem, out),
+        TyKind::Array { elem, .. } | TyKind::Tensor { elem, .. } => collect_holes(*elem, out),
         _ => {}
     }
 }

--- a/crates/reussir-core/src/semi/hir.rs
+++ b/crates/reussir-core/src/semi/hir.rs
@@ -229,6 +229,13 @@ pub enum ExprKind<'tcx> {
         op: crate::intrinsic::ArrayFn,
         args: Vec<Expr<'tcx>>,
     },
+    /// A built-in operation on a transient tensor
+    /// (docs/design/tensor-kernels.md): the resolved op and its value
+    /// operands (see [`crate::intrinsic::TensorFn`]).
+    TensorOp {
+        op: crate::intrinsic::TensorFn,
+        args: Vec<Expr<'tcx>>,
+    },
     /// Error-recovery placeholder.
     Poison,
 }

--- a/crates/reussir-core/src/semi/hir/build.rs
+++ b/crates/reussir-core/src/semi/hir/build.rs
@@ -760,6 +760,10 @@ impl<'tcx> Builder<'_, 'tcx> {
                 let elem = self.ty(elem);
                 self.tcx.mk_array(elem, dims)
             }
+            raw::Ty::Tensor { elem, dims } => {
+                let elem = self.ty(elem);
+                self.tcx.mk_tensor(elem, dims)
+            }
         }
     }
 
@@ -883,6 +887,11 @@ impl<'tcx> Builder<'_, 'tcx> {
             raw::Kind::ArrayOp { op, args } => ExprKind::ArrayOp {
                 op: crate::intrinsic::ArrayFn::parse(op)
                     .expect("known array op in machine-emitted IR"),
+                args: self.exprs(args),
+            },
+            raw::Kind::TensorOp { op, args } => ExprKind::TensorOp {
+                op: crate::intrinsic::TensorFn::parse(op)
+                    .expect("known tensor op in machine-emitted IR"),
                 args: self.exprs(args),
             },
             raw::Kind::NullableCall(inner) => {

--- a/crates/reussir-core/src/semi/hir/grammar.lalrpop
+++ b/crates/reussir-core/src/semi/hir/grammar.lalrpop
@@ -373,10 +373,19 @@ Ty: raw::Ty = {
     "Arc" "<" <t:Ty> ">" => raw::Ty::Arc(Box::new(t)),
     <cap:Cap> "#" <path:PathArgs>
         => raw::Ty::Record { cap, path: path.0, args: path.1 },
-    "[" <elem:Ty> ";" <dims:CommaPlus<"int">> "]"
-        => raw::Ty::Array { elem: Box::new(elem), dims: dims.iter().map(raw::small_u64).collect() },
+    "[" <elem:Ty> ";" <dims:CommaPlus<Extent>> "]"
+        => raw::Ty::Array { elem: Box::new(elem), dims },
+    "Tensor" "<" "[" <elem:Ty> ";" <dims:CommaPlus<Extent>> "]" ">"
+        => raw::Ty::Tensor { elem: Box::new(elem), dims },
     "(" ")" "->" <ret:Ty> => raw::Ty::Closure { params: vec![], ret: Box::new(ret) },
     "(" <ps:CommaPlus<Ty>> ")" "->" <ret:Ty> => raw::Ty::Closure { params: ps, ret: Box::new(ret) },
+};
+
+/// One shape dimension: a static extent, or `_` for a dynamic one
+/// (the DYNAMIC_EXTENT sentinel, mirroring MLIR's `?`).
+Extent: u64 = {
+    <i:"int"> => raw::small_u64(&i),
+    "_" => crate::semi::ty::DYNAMIC_EXTENT,
 };
 
 Cap: raw::Cap = {
@@ -452,6 +461,8 @@ Atom: raw::Kind = {
         => raw::Kind::Intrinsic { family: family.to_string(), name: name.to_string(), imm: raw::small_u32(&imm), args },
     "array" "#" <op:"ident"> "(" <args:Comma<Expr>> ")"
         => raw::Kind::ArrayOp { op: op.to_string(), args },
+    "tensor" "#" <op:"ident"> "(" <args:Comma<Expr>> ")"
+        => raw::Kind::TensorOp { op: op.to_string(), args },
     "NonNull" "(" <e:Expr> ")" => raw::Kind::NullableCall(Some(e)),
     "Null" => raw::Kind::NullableCall(None),
     "apply" "(" <target:Expr> <args:("," <Expr>)*> ")"
@@ -599,6 +610,7 @@ extern {
         "proj" => Token::Proj,
         "intrinsic" => Token::Intrinsic,
         "array" => Token::Array,
+        "tensor" => Token::TensorKw,
         "assign" => Token::Assign,
         "Nullable" => Token::Nullable,
         "Cell" => Token::Cell,
@@ -608,6 +620,7 @@ extern {
         "FlatLock" => Token::FlatLockCell,
         "RwLock" => Token::RwLockCell,
         "Arc" => Token::Arc,
+        "Tensor" => Token::Tensor,
         "NonNull" => Token::NonNull,
         "Null" => Token::Null,
         "poison" => Token::Poison,

--- a/crates/reussir-core/src/semi/hir/grammar.lalrpop
+++ b/crates/reussir-core/src/semi/hir/grammar.lalrpop
@@ -381,11 +381,11 @@ Ty: raw::Ty = {
     "(" <ps:CommaPlus<Ty>> ")" "->" <ret:Ty> => raw::Ty::Closure { params: ps, ret: Box::new(ret) },
 };
 
-/// One shape dimension: a static extent, or `_` for a dynamic one
-/// (the DYNAMIC_EXTENT sentinel, mirroring MLIR's `?`).
+/// One shape dimension: a static extent, or `?` for a dynamic one
+/// (the DYNAMIC_EXTENT sentinel, matching MLIR's spelling).
 Extent: u64 = {
     <i:"int"> => raw::small_u64(&i),
-    "_" => crate::semi::ty::DYNAMIC_EXTENT,
+    "?" => crate::semi::ty::DYNAMIC_EXTENT,
 };
 
 Cap: raw::Cap = {
@@ -649,6 +649,7 @@ extern {
         "=" => Token::Eq,
         "=>" => Token::FatArrow,
         "_" => Token::Underscore,
+        "?" => Token::Question,
         "->" => Token::Arrow,
         "#" => Token::Hash,
         "+" => Token::Plus,

--- a/crates/reussir-core/src/semi/hir/print.rs
+++ b/crates/reussir-core/src/semi/hir/print.rs
@@ -596,14 +596,14 @@ impl<'a> Printer<'a> {
 
     // ----- types -----
 
-    /// `[elem; d0, d1]`; a dynamic dimension prints as `_`, matching the
+    /// `[elem; d0, d1]`; a dynamic dimension prints as `?`, matching the
     /// grammar's extent rule.
     fn shape(&self, elem: Ty<'_>, dims: &[u64]) -> Doc<'static> {
         let mut d = text("[") + self.ty(elem) + text(";");
         for (i, &extent) in dims.iter().enumerate() {
             let sep = if i > 0 { "," } else { "" };
             if extent == crate::semi::ty::DYNAMIC_EXTENT {
-                d = d + text(format!("{sep} _"));
+                d = d + text(format!("{sep} ?"));
             } else {
                 d = d + text(format!("{sep} {extent}"));
             }

--- a/crates/reussir-core/src/semi/hir/print.rs
+++ b/crates/reussir-core/src/semi/hir/print.rs
@@ -596,6 +596,21 @@ impl<'a> Printer<'a> {
 
     // ----- types -----
 
+    /// `[elem; d0, d1]`; a dynamic dimension prints as `_`, matching the
+    /// grammar's extent rule.
+    fn shape(&self, elem: Ty<'_>, dims: &[u64]) -> Doc<'static> {
+        let mut d = text("[") + self.ty(elem) + text(";");
+        for (i, &extent) in dims.iter().enumerate() {
+            let sep = if i > 0 { "," } else { "" };
+            if extent == crate::semi::ty::DYNAMIC_EXTENT {
+                d = d + text(format!("{sep} _"));
+            } else {
+                d = d + text(format!("{sep} {extent}"));
+            }
+        }
+        d + text("]")
+    }
+
     fn ty(&self, ty: Ty<'_>) -> Doc<'static> {
         match *ty.kind() {
             TyKind::Int(IntTy::Signed(w)) => text(format!("i{w}")),
@@ -615,14 +630,8 @@ impl<'a> Printer<'a> {
                 text(kind.surface_name()) + text("<") + self.ty(elem) + text(">")
             }
             TyKind::Arc(inner) => text("Arc<") + self.ty(inner) + text(">"),
-            TyKind::Array { elem, dims } => {
-                let mut d = text("[") + self.ty(elem) + text(";");
-                for (i, extent) in dims.iter().enumerate() {
-                    let sep = if i > 0 { "," } else { "" };
-                    d = d + text(format!("{sep} {extent}"));
-                }
-                d + text("]")
-            }
+            TyKind::Array { elem, dims } => self.shape(elem, dims),
+            TyKind::Tensor { elem, dims } => text("Tensor<") + self.shape(elem, dims) + text(">"),
             TyKind::Record { def, args, flex } => {
                 let mut d = match flex {
                     Flexivity::Flex | Flexivity::Rigid | Flexivity::Regional => {
@@ -854,6 +863,9 @@ impl<'a> Printer<'a> {
             }
             ExprKind::ArrayOp { op, args } => {
                 text(format!("array#{}(", op.as_str())) + self.arg_list(args) + text(")")
+            }
+            ExprKind::TensorOp { op, args } => {
+                text(format!("tensor#{}(", op.as_str())) + self.arg_list(args) + text(")")
             }
             ExprKind::Let { .. } | ExprKind::Seq(_) | ExprKind::If(..) | ExprKind::Match(..) => {
                 unreachable!("structural forms are rendered by `value`")

--- a/crates/reussir-core/src/semi/hir/raw.rs
+++ b/crates/reussir-core/src/semi/hir/raw.rs
@@ -311,6 +311,11 @@ pub enum Ty {
         elem: Box<Ty>,
         dims: Vec<u64>,
     },
+    /// `Tensor<[elem; extents…]>` — a transient value-semantics view.
+    Tensor {
+        elem: Box<Ty>,
+        dims: Vec<u64>,
+    },
 }
 
 /// The four raw words of an interned `StringToken`.
@@ -414,6 +419,11 @@ pub enum Kind {
     /// `array#<op>(args…)` — a built-in array op; a `tabulate`/`fold`
     /// kernel closure is an ordinary argument.
     ArrayOp {
+        op: String,
+        args: Vec<Expr>,
+    },
+    /// `tensor#<op>(args…)` — a built-in tensor op.
+    TensorOp {
         op: String,
         args: Vec<Expr>,
     },

--- a/crates/reussir-core/src/semi/infer.rs
+++ b/crates/reussir-core/src/semi/infer.rs
@@ -223,6 +223,10 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 let elem = self.resolve(*elem);
                 self.tcx.mk_array(elem, dims)
             }
+            TyKind::Tensor { elem, dims } => {
+                let elem = self.resolve(*elem);
+                self.tcx.mk_tensor(elem, dims)
+            }
             TyKind::Cell { elem, kind } => {
                 let elem = self.resolve(*elem);
                 self.tcx.mk_cell(elem, *kind)
@@ -324,6 +328,11 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
             {
                 self.unify(*e1, *e2)
             }
+            (TyKind::Tensor { elem: e1, dims: d1 }, TyKind::Tensor { elem: e2, dims: d2 })
+                if d1 == d2 =>
+            {
+                self.unify(*e1, *e2)
+            }
 
             (TyKind::Int(x), TyKind::Int(y)) if x == y => Ok(()),
             (TyKind::Fp(x), TyKind::Fp(y)) if x == y => Ok(()),
@@ -374,7 +383,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
             TyKind::Nullable(inner) => self.occurs(h, *inner),
             TyKind::Arc(inner) => self.occurs(h, *inner),
             TyKind::Cell { elem: inner, .. } => self.occurs(h, *inner),
-            TyKind::Array { elem, .. } => self.occurs(h, *elem),
+            TyKind::Array { elem, .. } | TyKind::Tensor { elem, .. } => self.occurs(h, *elem),
             _ => false,
         }
     }
@@ -536,6 +545,11 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
             {
                 self.unify_instantiated(*e1, inst, *e2)
             }
+            (TyKind::Tensor { elem: e1, dims: d1 }, TyKind::Tensor { elem: e2, dims: d2 })
+                if d1 == d2 =>
+            {
+                self.unify_instantiated(*e1, inst, *e2)
+            }
 
             (TyKind::Int(x), TyKind::Int(y)) if x == y => Ok(()),
             (TyKind::Fp(x), TyKind::Fp(y)) if x == y => Ok(()),
@@ -596,6 +610,10 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
             TyKind::Array { elem, dims } => {
                 let elem = self.materialize(*elem, inst);
                 self.tcx.mk_array(elem, dims)
+            }
+            TyKind::Tensor { elem, dims } => {
+                let elem = self.materialize(*elem, inst);
+                self.tcx.mk_tensor(elem, dims)
             }
             TyKind::Cell { elem, kind } => {
                 let elem = self.materialize(*elem, inst);

--- a/crates/reussir-core/src/semi/lang.rs
+++ b/crates/reussir-core/src/semi/lang.rs
@@ -32,6 +32,7 @@ pub enum IntrinsicItem {
     Panic,
     Math(crate::intrinsic::MathFn),
     Array(crate::intrinsic::ArrayFn),
+    Tensor(crate::intrinsic::TensorFn),
     Cell(crate::intrinsic::CellFn),
     Str(crate::intrinsic::StrFn),
 }
@@ -42,6 +43,7 @@ impl IntrinsicItem {
             IntrinsicItem::Panic => "panic",
             IntrinsicItem::Math(_) => "math",
             IntrinsicItem::Array(_) => "array",
+            IntrinsicItem::Tensor(_) => "tensor",
             IntrinsicItem::Cell(_) => "cell",
             IntrinsicItem::Str(_) => "str",
         }
@@ -52,6 +54,7 @@ impl IntrinsicItem {
             IntrinsicItem::Panic => "panic",
             IntrinsicItem::Math(f) => f.as_str(),
             IntrinsicItem::Array(f) => f.as_str(),
+            IntrinsicItem::Tensor(f) => f.as_str(),
             IntrinsicItem::Cell(f) => f.as_str(),
             IntrinsicItem::Str(f) => f.as_str(),
         }
@@ -62,6 +65,7 @@ impl IntrinsicItem {
             "panic" if name == "panic" => Some(IntrinsicItem::Panic),
             "math" => crate::intrinsic::MathFn::parse(name).map(IntrinsicItem::Math),
             "array" => crate::intrinsic::ArrayFn::parse(name).map(IntrinsicItem::Array),
+            "tensor" => crate::intrinsic::TensorFn::parse(name).map(IntrinsicItem::Tensor),
             "cell" => crate::intrinsic::CellFn::parse(name).map(IntrinsicItem::Cell),
             "str" => crate::intrinsic::StrFn::parse(name).map(IntrinsicItem::Str),
             _ => None,

--- a/crates/reussir-core/src/semi/traits/coherence.rs
+++ b/crates/reussir-core/src/semi/traits/coherence.rs
@@ -40,6 +40,7 @@ pub enum HeadKey {
     Unit,
     Closure,
     Array,
+    Tensor,
     Cell(CellKind),
     Nullable,
     Arc,
@@ -58,6 +59,7 @@ pub fn head_key(ty: Ty<'_>) -> Option<HeadKey> {
         TyKind::Unit => HeadKey::Unit,
         TyKind::Closure { .. } => HeadKey::Closure,
         TyKind::Array { .. } => HeadKey::Array,
+        TyKind::Tensor { .. } => HeadKey::Tensor,
         TyKind::Cell { kind, .. } => HeadKey::Cell(kind),
         TyKind::Nullable(_) => HeadKey::Nullable,
         TyKind::Arc(_) => HeadKey::Arc,
@@ -99,7 +101,9 @@ fn occurs(g: GenericId, ty: Ty<'_>, subst: &FxHashMap<GenericId, Ty<'_>>) -> boo
     match *ty.kind() {
         TyKind::Generic(h) => g == h,
         TyKind::Nullable(inner) | TyKind::Arc(inner) => occurs(g, inner, subst),
-        TyKind::Cell { elem, .. } | TyKind::Array { elem, .. } => occurs(g, elem, subst),
+        TyKind::Cell { elem, .. } | TyKind::Array { elem, .. } | TyKind::Tensor { elem, .. } => {
+            occurs(g, elem, subst)
+        }
         TyKind::Record { args, .. } => args.iter().any(|&a| occurs(g, a, subst)),
         TyKind::Closure { params, ret } => {
             params.iter().any(|&p| occurs(g, p, subst)) || occurs(g, ret, subst)
@@ -158,6 +162,9 @@ fn unify_ty<'tcx>(
                 ret: ry,
             },
         ) => unify_args(xs, ys, vars, subst) && unify_ty(*rx, *ry, vars, subst),
+        (TyKind::Tensor { elem: x, dims: dx }, TyKind::Tensor { elem: y, dims: dy }) => {
+            dx == dy && unify_ty(*x, *y, vars, subst)
+        }
         (TyKind::Array { elem: x, dims: dx }, TyKind::Array { elem: y, dims: dy }) => {
             dx == dy && unify_ty(*x, *y, vars, subst)
         }

--- a/crates/reussir-core/src/semi/traits/subst.rs
+++ b/crates/reussir-core/src/semi/traits/subst.rs
@@ -51,6 +51,10 @@ pub fn replace_generics<'tcx>(
                 tcx.mk_closure(&new, r)
             }
         }
+        TyKind::Tensor { elem, dims } => {
+            let elem = replace_generics(tcx, elem, map);
+            tcx.mk_tensor(elem, dims)
+        }
         TyKind::Array { elem, dims } => {
             let n = replace_generics(tcx, elem, map);
             if n == elem { ty } else { tcx.mk_array(n, dims) }
@@ -72,7 +76,7 @@ pub fn collect_generics_of(ty: Ty<'_>, out: &mut rustc_hash::FxHashSet<GenericId
             params.iter().for_each(|&p| collect_generics_of(p, out));
             collect_generics_of(ret, out);
         }
-        TyKind::Array { elem, .. } => collect_generics_of(elem, out),
+        TyKind::Array { elem, .. } | TyKind::Tensor { elem, .. } => collect_generics_of(elem, out),
         _ => {}
     }
 }

--- a/crates/reussir-core/src/semi/traits/sync.rs
+++ b/crates/reussir-core/src/semi/traits/sync.rs
@@ -77,7 +77,9 @@ pub fn collect_record_defs<'tcx>(ty: Ty<'tcx>, out: &mut Vec<DefId>) {
             }
         }
         TyKind::Arc(inner) | TyKind::Nullable(inner) => collect_record_defs(inner, out),
-        TyKind::Cell { elem, .. } | TyKind::Array { elem, .. } => collect_record_defs(elem, out),
+        TyKind::Cell { elem, .. } | TyKind::Array { elem, .. } | TyKind::Tensor { elem, .. } => {
+            collect_record_defs(elem, out)
+        }
         TyKind::Closure { params, ret } => {
             for &p in params {
                 collect_record_defs(p, out);
@@ -313,8 +315,9 @@ impl<'tcx> Cx<'_, 'tcx> {
             }
             // Bare shared rc boxes: never `Sync`, regardless of contents —
             // shareability is carried by the box coloring (`Arc`), not the
-            // nominal type.
-            TyKind::Array { .. } | TyKind::Closure { .. } => {
+            // nominal type. A tensor refutes for the same reason its backing
+            // array does: it is a scope-confined view of that box's data.
+            TyKind::Array { .. } | TyKind::Tensor { .. } | TyKind::Closure { .. } => {
                 self.refute(ty, NotSyncReason::NonAtomicBox)
             }
             TyKind::Record { def, args, .. } => match self.env.default_cap(def) {

--- a/crates/reussir-core/src/semi/ty.rs
+++ b/crates/reussir-core/src/semi/ty.rs
@@ -36,6 +36,19 @@ pub struct GenericId(pub u32);
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, PartialOrd, Ord)]
 pub struct HoleId(pub u32);
 
+/// The sentinel marking a dynamic dimension in an array or tensor shape
+/// (`[f64; _, 4]`) — the extent is a runtime value carried by the
+/// constructing intrinsic, not by the type. Same `~0` convention as the
+/// dialect's dynamic `token<align, ?>` size and MLIR's
+/// `ShapedType::kDynamic`. A static extent can never collide with it: the
+/// element-count cap (2^32) rejects any product that large.
+pub const DYNAMIC_EXTENT: u64 = u64::MAX;
+
+/// Whether a shape has any dynamic dimension.
+pub fn has_dynamic_extent(dims: &[u64]) -> bool {
+    dims.contains(&DYNAMIC_EXTENT)
+}
+
 /// The per-use *flexivity* a value carries — its regional memory coloring:
 /// `Flex` is mutable but cannot be materialized out of its region, `Rigid` is
 /// immutable but materializable (the frozen form that escapes a region),
@@ -210,10 +223,25 @@ pub enum TyKind<'tcx> {
         params: &'tcx [Ty<'tcx>],
         ret: Ty<'tcx>,
     },
-    /// A statically shaped multidimensional array of `Plain` elements,
-    /// reference counted as a whole; the extents are part of the type
-    /// (`[f64; 512, 512]`). See issue #344.
+    /// A multidimensional array of `Plain` elements, reference counted as a
+    /// whole; the extents are part of the type (`[f64; 512, 512]`). See
+    /// issue #344. A dimension may be dynamic (`[f64; _, 512]`), encoded as
+    /// the [`DYNAMIC_EXTENT`] sentinel — the same `~0` convention as the
+    /// dialect's `token<align, ?>` and MLIR's `ShapedType::kDynamic`; the
+    /// runtime extent then travels as an operand of the constructing
+    /// intrinsic, not in the type.
     Array {
+        elem: Ty<'tcx>,
+        dims: &'tcx [u64],
+    },
+    /// A transient value-semantics view of an array's data
+    /// (`Tensor<[f64; _, 4]>`): the kernel-side tier that lowers to
+    /// linalg-on-tensors (docs/design/tensor-kernels.md). Same element and
+    /// extent rules as [`TyKind::Array`], including [`DYNAMIC_EXTENT`].
+    /// Tensors are scope-confined: not storable in records, not capturable
+    /// by closures, not FFI-crossing, and absent from plain `fn`
+    /// signatures — materialization back to an array is the only way out.
+    Tensor {
         elem: Ty<'tcx>,
         dims: &'tcx [u64],
     },
@@ -359,6 +387,11 @@ impl<'tcx> TyCtxt<'tcx> {
     pub fn mk_array(&self, elem: Ty<'tcx>, dims: &[u64]) -> Ty<'tcx> {
         let dims = self.alloc_slice(dims);
         self.mk(TyKind::Array { elem, dims })
+    }
+
+    pub fn mk_tensor(&self, elem: Ty<'tcx>, dims: &[u64]) -> Ty<'tcx> {
+        let dims = self.alloc_slice(dims);
+        self.mk(TyKind::Tensor { elem, dims })
     }
 
     pub fn mk_cell(&self, elem: Ty<'tcx>, kind: CellKind) -> Ty<'tcx> {

--- a/crates/reussir-core/src/semi/ty.rs
+++ b/crates/reussir-core/src/semi/ty.rs
@@ -37,7 +37,7 @@ pub struct GenericId(pub u32);
 pub struct HoleId(pub u32);
 
 /// The sentinel marking a dynamic dimension in an array or tensor shape
-/// (`[f64; _, 4]`) — the extent is a runtime value carried by the
+/// (`[f64; ?, 4]`) — the extent is a runtime value carried by the
 /// constructing intrinsic, not by the type. Same `~0` convention as the
 /// dialect's dynamic `token<align, ?>` size and MLIR's
 /// `ShapedType::kDynamic`. A static extent can never collide with it: the
@@ -225,7 +225,7 @@ pub enum TyKind<'tcx> {
     },
     /// A multidimensional array of `Plain` elements, reference counted as a
     /// whole; the extents are part of the type (`[f64; 512, 512]`). See
-    /// issue #344. A dimension may be dynamic (`[f64; _, 512]`), encoded as
+    /// issue #344. A dimension may be dynamic (`[f64; ?, 512]`), encoded as
     /// the [`DYNAMIC_EXTENT`] sentinel — the same `~0` convention as the
     /// dialect's `token<align, ?>` and MLIR's `ShapedType::kDynamic`; the
     /// runtime extent then travels as an operand of the constructing
@@ -235,7 +235,7 @@ pub enum TyKind<'tcx> {
         dims: &'tcx [u64],
     },
     /// A transient value-semantics view of an array's data
-    /// (`Tensor<[f64; _, 4]>`): the kernel-side tier that lowers to
+    /// (`Tensor<[f64; ?, 4]>`): the kernel-side tier that lowers to
     /// linalg-on-tensors (docs/design/tensor-kernels.md). Same element and
     /// extent rules as [`TyKind::Array`], including [`DYNAMIC_EXTENT`].
     /// Tensors are scope-confined: not storable in records, not capturable

--- a/crates/reussir-core/src/semi/ty_eval.rs
+++ b/crates/reussir-core/src/semi/ty_eval.rs
@@ -230,6 +230,41 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             };
         }
 
+        // The built-in tensor type former, `core::intrinsic::tensor::Tensor`.
+        // `Tensor<[f64; _, 4]>` is the transient value-semantics view of an
+        // array of that shape (docs/design/tensor-kernels.md): same element
+        // and extent rules as the array type argument it wraps, but
+        // scope-confined — not storable, capturable, or FFI-crossing.
+        if (bare_unshadowed || self.is_core_intrinsic_prefix(&path.segments, "tensor"))
+            && self.sym(key) == "Tensor"
+        {
+            return match args {
+                [inner] => {
+                    let inner = self.eval_type(inner);
+                    match *inner.kind() {
+                        TyKind::Array { elem, dims } => self.tcx.mk_tensor(elem, dims),
+                        // Error recovery from the argument itself.
+                        TyKind::Bottom => inner,
+                        _ => {
+                            self.error(
+                                Some(span),
+                                format!(
+                                    "`Tensor` takes an array type argument \
+                                     (`Tensor<[f64; 4, 4]>`), got `{}`",
+                                    self.ty_display(inner)
+                                ),
+                            );
+                            self.tcx.mk(TyKind::Bottom)
+                        }
+                    }
+                }
+                _ => {
+                    self.error(Some(span), "`Tensor` takes exactly one type argument");
+                    self.tcx.mk(TyKind::Bottom)
+                }
+            };
+        }
+
         // Nothing else under the reserved `core` package names a type.
         if path.segments.first().map(|&k| self.sym(k)) == Some("core") {
             let shown = self.path_display(path);
@@ -255,12 +290,14 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         array_element_rejection(|def| self.records.get(&def).map(|r| r.default_cap), t)
     }
 
-    /// Evaluate a statically shaped array type (`[f64; 512]`,
-    /// `[f64; 5, 16, 8]`) into a [`TyKind::Array`].
+    /// Evaluate an array type (`[f64; 512]`, `[f64; 5, 16, 8]`,
+    /// `[f64; _, 4]`) into a [`TyKind::Array`]. A `_` extent marks the
+    /// dimension dynamic ([`DYNAMIC_EXTENT`]): its runtime value travels as
+    /// an operand of the constructing intrinsic, not in the type.
     pub(crate) fn eval_array_type(
         &mut self,
         elem: &surface::Type,
-        extents: &[surface::Expr],
+        extents: &[surface::ArrayExtent],
         span: surface::Span,
     ) -> Ty<'tcx> {
         if extents.is_empty() {
@@ -283,14 +320,23 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
             );
         }
         let mut dims = Vec::with_capacity(extents.len());
+        // The element-count cap applies to the static factor of the shape;
+        // dynamic dimensions are bounded at construction, not here.
         let mut product: u128 = 1;
         for e in extents {
-            let extent = self.eval_extent(e);
-            if extent == 0 {
-                self.error(Some(e.span()), "array extents must be positive");
+            match e {
+                surface::ArrayExtent::Dynamic(_) => {
+                    dims.push(crate::semi::ty::DYNAMIC_EXTENT);
+                }
+                surface::ArrayExtent::Expr(e) => {
+                    let extent = self.eval_extent(e);
+                    if extent == 0 {
+                        self.error(Some(e.span()), "array extents must be positive");
+                    }
+                    product = product.saturating_mul(u128::from(extent.max(1)));
+                    dims.push(extent.max(1));
+                }
             }
-            product = product.saturating_mul(u128::from(extent.max(1)));
-            dims.push(extent.max(1));
         }
         if product > (1u128 << 32) {
             self.error(Some(span), "array is too large (more than 2^32 elements)");
@@ -300,12 +346,18 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
 
     /// Evaluate one array extent expression. The grammar admits any
     /// expression; for now only an integer literal evaluates — everything
-    /// else reports and recovers with extent 1. An out-of-range literal
-    /// clamps; the product check reports it as too large.
+    /// else reports and recovers with extent 1 (a *dynamic* dimension is
+    /// spelled `_`, not an expression).
     fn eval_extent(&mut self, e: &surface::Expr) -> u64 {
         match e.kind() {
             surface::ExprKind::ConstExpr(crate::surface::Const::ConstInt(n)) => {
-                u64::try_from(&n).unwrap_or(u64::MAX)
+                match u64::try_from(&n) {
+                    Ok(v) => v,
+                    Err(_) => {
+                        self.error(Some(e.span()), "array extent is out of range");
+                        1
+                    }
+                }
             }
             _ => {
                 self.error(
@@ -461,6 +513,7 @@ pub fn array_element_rejection<'tcx>(
         TyKind::Cell { .. } => Some("a cell"),
         TyKind::Closure { .. } => Some("a closure"),
         TyKind::Array { .. } => Some("a nested rc array"),
+        TyKind::Tensor { .. } => Some("a tensor"),
         TyKind::Str => Some("a string"),
         _ => Some("not a scalar or `[shared]` record"),
     }
@@ -531,6 +584,7 @@ pub fn arc_inner_rejection<'tcx>(
         // An array or a closure is one shared rc box exactly like a
         // `[shared]` record, so it takes the atomic coloring the same way.
         TyKind::Array { .. } | TyKind::Closure { .. } => None,
+        TyKind::Tensor { .. } => Some("a tensor is scope-confined and cannot be arc'd"),
         TyKind::Generic(_) | TyKind::Hole(_) | TyKind::Bottom => None,
         // A cell is a shared box too, but synchronization is the cell's own
         // axis (plain vs exclusive, and the atomic flavor at the MLIR level)
@@ -778,7 +832,9 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
                 self.report_cell_wf(elem, kind, span);
                 self.sweep_arc_wf(elem, span);
             }
-            TyKind::Array { elem, .. } => self.sweep_arc_wf(elem, span),
+            TyKind::Array { elem, .. } | TyKind::Tensor { elem, .. } => {
+                self.sweep_arc_wf(elem, span)
+            }
             _ => {}
         }
     }

--- a/crates/reussir-core/src/semi/ty_eval.rs
+++ b/crates/reussir-core/src/semi/ty_eval.rs
@@ -231,7 +231,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
         }
 
         // The built-in tensor type former, `core::intrinsic::tensor::Tensor`.
-        // `Tensor<[f64; _, 4]>` is the transient value-semantics view of an
+        // `Tensor<[f64; ?, 4]>` is the transient value-semantics view of an
         // array of that shape (docs/design/tensor-kernels.md): same element
         // and extent rules as the array type argument it wraps, but
         // scope-confined — not storable, capturable, or FFI-crossing.
@@ -291,7 +291,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
     }
 
     /// Evaluate an array type (`[f64; 512]`, `[f64; 5, 16, 8]`,
-    /// `[f64; _, 4]`) into a [`TyKind::Array`]. A `_` extent marks the
+    /// `[f64; ?, 4]`) into a [`TyKind::Array`]. A `?` extent marks the
     /// dimension dynamic ([`DYNAMIC_EXTENT`]): its runtime value travels as
     /// an operand of the constructing intrinsic, not in the type.
     pub(crate) fn eval_array_type(
@@ -347,7 +347,7 @@ impl<'a, 'tcx> Elaborator<'a, 'tcx> {
     /// Evaluate one array extent expression. The grammar admits any
     /// expression; for now only an integer literal evaluates — everything
     /// else reports and recovers with extent 1 (a *dynamic* dimension is
-    /// spelled `_`, not an expression).
+    /// spelled `?`, not an expression).
     fn eval_extent(&mut self, e: &surface::Expr) -> u64 {
         match e.kind() {
             surface::ExprKind::ConstExpr(crate::surface::Const::ConstInt(n)) => {

--- a/crates/reussir-core/src/surface.rs
+++ b/crates/reussir-core/src/surface.rs
@@ -421,7 +421,16 @@ pub enum TypeKind {
     /// A statically shaped array: an element type and one extent expression
     /// per dimension (`[f64; 512]`, `[f64; 5, 16, 8]`). The extents are kept
     /// as expressions; the elaborator decides which forms it can evaluate.
-    TypeArray(Type, SmallVec<[Expr; 2]>),
+    TypeArray(Type, SmallVec<[ArrayExtent; 2]>),
+}
+
+/// One dimension of an array (or tensor) type: an extent expression, or `_`
+/// for a dynamic dimension whose value is a runtime operand of the
+/// constructing intrinsic.
+#[derive(Debug, Clone)]
+pub enum ArrayExtent {
+    Expr(Expr),
+    Dynamic(Span),
 }
 
 /// A type expression (a view over a `PrimType` / `PathType` / `ArrowType` node).
@@ -456,7 +465,17 @@ impl Type {
                 let elem = nodes(node)
                     .find(|n| is_type_kind(n.kind()))
                     .expect("array element type");
-                let extents = expr_children(node).map(Expr::new).collect();
+                let extents = node
+                    .children()
+                    .filter(|n| is_expr_kind(n.kind()) || n.kind() == InferType)
+                    .map(|n| {
+                        if n.kind() == InferType {
+                            ArrayExtent::Dynamic(node_span(n))
+                        } else {
+                            ArrayExtent::Expr(Expr::new(n))
+                        }
+                    })
+                    .collect();
                 TypeKind::TypeArray(Type::new(elem), extents)
             }
             PathType => {

--- a/crates/reussir-core/src/surface.rs
+++ b/crates/reussir-core/src/surface.rs
@@ -424,9 +424,9 @@ pub enum TypeKind {
     TypeArray(Type, SmallVec<[ArrayExtent; 2]>),
 }
 
-/// One dimension of an array (or tensor) type: an extent expression, or `_`
+/// One dimension of an array (or tensor) type: an extent expression, or `?`
 /// for a dynamic dimension whose value is a runtime operand of the
-/// constructing intrinsic.
+/// constructing intrinsic (mirroring MLIR's `memref<?x…>`).
 #[derive(Debug, Clone)]
 pub enum ArrayExtent {
     Expr(Expr),
@@ -467,9 +467,9 @@ impl Type {
                     .expect("array element type");
                 let extents = node
                     .children()
-                    .filter(|n| is_expr_kind(n.kind()) || n.kind() == InferType)
+                    .filter(|n| is_expr_kind(n.kind()) || n.kind() == DynExtent)
                     .map(|n| {
-                        if n.kind() == InferType {
+                        if n.kind() == DynExtent {
                             ArrayExtent::Dynamic(node_span(n))
                         } else {
                             ArrayExtent::Expr(Expr::new(n))

--- a/crates/reussir-repl/src/session.rs
+++ b/crates/reussir-repl/src/session.rs
@@ -616,6 +616,21 @@ impl<'a, 'tcx> ReplSession<'a, 'tcx> {
         Self::render_ty_with(&self.elab, ty)
     }
 
+    /// `d0, d1` with a dynamic dimension rendered as `_`.
+    fn render_dims(dims: &[u64]) -> String {
+        let parts: Vec<String> = dims
+            .iter()
+            .map(|&d| {
+                if d == reussir_core::semi::ty::DYNAMIC_EXTENT {
+                    "_".to_owned()
+                } else {
+                    d.to_string()
+                }
+            })
+            .collect();
+        parts.join(", ")
+    }
+
     fn render_ty_with(elab: &Elaborator<'a, 'tcx>, ty: Ty<'tcx>) -> String {
         match *ty.kind() {
             TyKind::Int(reussir_core::semi::ty::IntTy::Signed(w)) => format!("i{w}"),
@@ -642,11 +657,17 @@ impl<'a, 'tcx> ReplSession<'a, 'tcx> {
                 format!("Arc<{}>", Self::render_ty_with(elab, inner))
             }
             TyKind::Array { elem, dims } => {
-                let dims: Vec<String> = dims.iter().map(|d| d.to_string()).collect();
                 format!(
                     "[{}; {}]",
                     Self::render_ty_with(elab, elem),
-                    dims.join(", ")
+                    Self::render_dims(dims)
+                )
+            }
+            TyKind::Tensor { elem, dims } => {
+                format!(
+                    "Tensor<[{}; {}]>",
+                    Self::render_ty_with(elab, elem),
+                    Self::render_dims(dims)
                 )
             }
             TyKind::Record { def, args, .. } => {

--- a/crates/reussir-repl/src/session.rs
+++ b/crates/reussir-repl/src/session.rs
@@ -616,13 +616,13 @@ impl<'a, 'tcx> ReplSession<'a, 'tcx> {
         Self::render_ty_with(&self.elab, ty)
     }
 
-    /// `d0, d1` with a dynamic dimension rendered as `_`.
+    /// `d0, d1` with a dynamic dimension rendered as `?`.
     fn render_dims(dims: &[u64]) -> String {
         let parts: Vec<String> = dims
             .iter()
             .map(|&d| {
                 if d == reussir_core::semi::ty::DYNAMIC_EXTENT {
-                    "_".to_owned()
+                    "?".to_owned()
                 } else {
                     d.to_string()
                 }

--- a/crates/reussir-syntax/src/ast.rs
+++ b/crates/reussir-syntax/src/ast.rs
@@ -498,13 +498,13 @@ impl Emitter<'_> {
                 let elem = nodes(node)
                     .find(|n| is_type_kind(n.kind()))
                     .expect("array element type");
-                // A `_` extent (dynamic dimension) projects as `null`, the
+                // A `?` extent (dynamic dimension) projects as `null`, the
                 // same convention as `_` in a type argument list.
                 let extents: Vec<Value> = node
                     .children()
-                    .filter(|n| is_expr_kind(n.kind()) || n.kind() == InferType)
+                    .filter(|n| is_expr_kind(n.kind()) || n.kind() == DynExtent)
                     .map(|n| {
-                        if n.kind() == InferType {
+                        if n.kind() == DynExtent {
                             Value::Null
                         } else {
                             self.expr(n)

--- a/crates/reussir-syntax/src/ast.rs
+++ b/crates/reussir-syntax/src/ast.rs
@@ -498,7 +498,19 @@ impl Emitter<'_> {
                 let elem = nodes(node)
                     .find(|n| is_type_kind(n.kind()))
                     .expect("array element type");
-                let extents: Vec<Value> = expr_children(node).map(|e| self.expr(e)).collect();
+                // A `_` extent (dynamic dimension) projects as `null`, the
+                // same convention as `_` in a type argument list.
+                let extents: Vec<Value> = node
+                    .children()
+                    .filter(|n| is_expr_kind(n.kind()) || n.kind() == InferType)
+                    .map(|n| {
+                        if n.kind() == InferType {
+                            Value::Null
+                        } else {
+                            self.expr(n)
+                        }
+                    })
+                    .collect();
                 tagged("TypeArray", json!([self.type_(elem), extents]))
             }
             k => unreachable!("unexpected type node {k:?}"),

--- a/crates/reussir-syntax/src/kind.rs
+++ b/crates/reussir-syntax/src/kind.rs
@@ -112,6 +112,8 @@ pub enum SyntaxKind {
     Pound,
     /// `_`
     Underscore,
+    /// `?`
+    Question,
     /// Unrecognized input or token-level error (kept in the tree for
     /// losslessness).
     ErrorToken,
@@ -175,7 +177,10 @@ pub enum SyntaxKind {
     TypeArgList,
     /// `_` placeholder inside a type argument list.
     InferType,
-    /// A statically shaped array type: `[T; 512]`, `[T; 5, 16, 8]`.
+    /// `?` in array-extent position: a dynamic dimension (`[T; ?, 4]`),
+    /// mirroring MLIR's `memref<?x…>` spelling.
+    DynExtent,
+    /// An array type: `[T; 512]`, `[T; 5, 16, 8]`, `[T; ?, 4]`.
     ArrayType,
 
     // ===== Nodes: expressions =====
@@ -323,6 +328,7 @@ impl SyntaxKind {
             Caret => "`^`",
             Pound => "`#`",
             Underscore => "`_`",
+            Question => "`?`",
             Eof => "the end of the input",
             ErrorToken => "invalid input",
             _ => "a syntax node",

--- a/crates/reussir-syntax/src/lexer.rs
+++ b/crates/reussir-syntax/src/lexer.rs
@@ -152,6 +152,8 @@ pub enum RawToken {
     Pound,
     #[token("_")]
     Underscore,
+    #[token("?")]
+    Question,
 }
 
 /// Pre-classified identifier-or-keyword. Hard keywords get their own class;
@@ -393,6 +395,7 @@ impl RawToken {
             RawToken::Caret => SyntaxKind::Caret,
             RawToken::Pound => SyntaxKind::Pound,
             RawToken::Underscore => SyntaxKind::Underscore,
+            RawToken::Question => SyntaxKind::Question,
         }
     }
 }

--- a/crates/reussir-syntax/src/parser/grammar.rs
+++ b/crates/reussir-syntax/src/parser/grammar.rs
@@ -718,11 +718,11 @@ impl Parser<'_> {
     }
 
     /// An array type: `[T; e1, e2, ...]` with one extent per dimension. An
-    /// extent is an expression, or `_` for a dynamic dimension (its value is
-    /// then a runtime operand of the constructing intrinsic). The grammar
-    /// accepts any expression so the tree stays forward-compatible with
-    /// constant expressions; what an extent may evaluate to is the
-    /// elaborator's concern.
+    /// extent is an expression, or `?` for a dynamic dimension (its value is
+    /// then a runtime operand of the constructing intrinsic), mirroring
+    /// MLIR's `memref<?x…>`. The grammar accepts any expression so the tree
+    /// stays forward-compatible with constant expressions; what an extent
+    /// may evaluate to is the elaborator's concern.
     fn array_type(&mut self) -> CompletedMarker {
         let m = self.start();
         self.bump();
@@ -737,13 +737,13 @@ impl Parser<'_> {
         m.complete(self, ArrayType)
     }
 
-    /// One extent position: `_` (a dynamic dimension, kept as an `InferType`
+    /// One extent position: `?` (a dynamic dimension, kept as a `DynExtent`
     /// node so it never enters the expression grammar) or an expression.
     fn array_extent(&mut self) {
-        if self.at(Underscore) {
+        if self.at(Question) {
             let h = self.start();
             self.bump();
-            h.complete(self, InferType);
+            h.complete(self, DynExtent);
         } else {
             self.expr();
         }

--- a/crates/reussir-syntax/src/parser/grammar.rs
+++ b/crates/reussir-syntax/src/parser/grammar.rs
@@ -717,22 +717,36 @@ impl Parser<'_> {
         m.complete(self, PathType)
     }
 
-    /// A statically shaped array type: `[T; e1, e2, ...]` with one extent
-    /// expression per dimension. The grammar accepts any expression so the
-    /// tree stays forward-compatible with constant expressions; what an
-    /// extent may evaluate to is the elaborator's concern.
+    /// An array type: `[T; e1, e2, ...]` with one extent per dimension. An
+    /// extent is an expression, or `_` for a dynamic dimension (its value is
+    /// then a runtime operand of the constructing intrinsic). The grammar
+    /// accepts any expression so the tree stays forward-compatible with
+    /// constant expressions; what an extent may evaluate to is the
+    /// elaborator's concern.
     fn array_type(&mut self) -> CompletedMarker {
         let m = self.start();
         self.bump();
         self.type_();
         self.expect(Semicolon);
-        self.expr();
+        self.array_extent();
         while self.at(Comma) {
             self.bump();
-            self.expr();
+            self.array_extent();
         }
         self.expect(RBracket);
         m.complete(self, ArrayType)
+    }
+
+    /// One extent position: `_` (a dynamic dimension, kept as an `InferType`
+    /// node so it never enters the expression grammar) or an expression.
+    fn array_extent(&mut self) {
+        if self.at(Underscore) {
+            let h = self.start();
+            self.bump();
+            h.complete(self, InferType);
+        } else {
+            self.expr();
+        }
     }
 
     // ===== Patterns =====

--- a/docs/design/dynamic-extent-arrays.md
+++ b/docs/design/dynamic-extent-arrays.md
@@ -111,6 +111,14 @@ aliased elements would break the drop traversal's exactly-once contract.
   dim dynamic and the value an argument of `splat`/`tabulate`); add an
   `array::dim` intrinsic; lengths stay `u64` until `usize` lands.
 
+## Status
+
+Frontend landed: `_` extents, the `DYNAMIC_EXTENT` sentinel through the
+type system, leading runtime extents on `splat`/`tabulate`, `array::dim`,
+display/mangling/textual-IR spellings, and `err(…)` stubs at every
+lowering path (`--emit mlir` reports "do not lower yet"). The
+strided-header box and the descriptor lowering are the open backend half.
+
 ## Deferred
 
 - Const-generic extents (the monomorphization half of #344 Phase C)

--- a/docs/design/dynamic-extent-arrays.md
+++ b/docs/design/dynamic-extent-arrays.md
@@ -113,7 +113,7 @@ aliased elements would break the drop traversal's exactly-once contract.
 
 ## Status
 
-Frontend landed: `_` extents, the `DYNAMIC_EXTENT` sentinel through the
+Frontend landed: `?` extents, the `DYNAMIC_EXTENT` sentinel through the
 type system, leading runtime extents on `splat`/`tabulate`, `array::dim`,
 display/mangling/textual-IR spellings, and `err(…)` stubs at every
 lowering path (`--emit mlir` reports "do not lower yet"). The

--- a/docs/design/tensor-kernels.md
+++ b/docs/design/tensor-kernels.md
@@ -10,6 +10,16 @@ unmaterialized. (`str<local>`'s transient lifescope and the #344 note
 "`modify`'s view must not escape its region" are the other in-tree
 precedents.)
 
+## Status
+
+Frontend landed: `Tensor<[T; dims]>` (path-based builtin former),
+`core::intrinsic::tensor::{of, materialize, dim}` on a `TensorOp`
+HIR/MIR node, the escape rules below (record members, closure
+captures/returns, signatures, container elements, FFI), and ownership
+treating `of` as consuming the rooted dup. Lowering stops at `err(…)`
+stubs; the pipeline/registry stages and the combinator surface are the
+open half.
+
 ## Why combinators cannot live on arrays directly
 
 The two in-place systems do not compose per-op. Rc/CoW decides

--- a/tests/integration/frontend/dynamic_extent_arrays.rr
+++ b/tests/integration/frontend/dynamic_extent_arrays.rr
@@ -1,0 +1,48 @@
+// Dynamic-extent arrays (docs/design/dynamic-extent-arrays.md): a `_`
+// extent marks a dimension dynamic; its runtime value is a leading operand
+// of the constructing intrinsic. Frontend-complete; lowering is pending the
+// strided-header box, so `--emit mlir` stops with a diagnostic.
+
+// RUN: %rrc %s --emit hir -o - | %FileCheck %s
+// RUN: %not %rrc %s --emit mlir -o - 2>&1 | %FileCheck %s --check-prefix=STUB
+
+// STUB: not lower yet
+
+import core::intrinsic::array;
+
+// CHECK: pub fn #make(v0 (n): u64) -> [i32; _]
+// CHECK: array#splat(v0 : u64 {{.*}}, 42 : i32 {{.*}}) : [i32; _]
+pub fn make(n : u64) -> [i32; _] {
+    array::splat<[i32; _]>(n, 42)
+}
+
+// CHECK: pub fn #make2(v0 (n): u64) -> [i32; _, 4]
+// CHECK: array#tabulate(v0 : u64 {{.*}}, closure
+pub fn make2(n : u64) -> [i32; _, 4] {
+    array::tabulate<[i32; _, 4]>(n, |i : i64, j : i64| 0)
+}
+
+// CHECK: pub fn #read(v0 (a): [i32; _], v1 (i): i64) -> i32
+// CHECK: array#get(v0 : [i32; _] {{.*}}, v1 : i64 {{.*}}) : i32
+pub fn read(a : [i32; _], i : i64) -> i32 {
+    array::get(a, i)
+}
+
+// CHECK: pub fn #put(v0 (a): [i32; _], v1 (i): i64, v2 (v): i32) -> [i32; _]
+// CHECK: array#set(v0 : [i32; _] {{.*}}) : [i32; _]
+pub fn put(a : [i32; _], i : i64, v : i32) -> [i32; _] {
+    array::set(a, i, v)
+}
+
+// CHECK: pub fn #extent(v0 (a): [i32; _, 4]) -> u64
+// CHECK: array#dim(v0 : [i32; _, 4] {{.*}}, 0 : u64 {{.*}}) : u64
+pub fn extent(a : [i32; _, 4]) -> u64 {
+    array::dim(a, 0)
+}
+
+// A fully static array still takes no leading extents and `dim` works on it.
+// CHECK: pub fn #static_dim(v0 (a): [f64; 4, 4]) -> u64
+// CHECK: array#dim(v0 : [f64; 4, 4] {{.*}}, 1 : u64 {{.*}}) : u64
+pub fn static_dim(a : [f64; 4, 4]) -> u64 {
+    array::dim(a, 1)
+}

--- a/tests/integration/frontend/dynamic_extent_arrays.rr
+++ b/tests/integration/frontend/dynamic_extent_arrays.rr
@@ -1,4 +1,4 @@
-// Dynamic-extent arrays (docs/design/dynamic-extent-arrays.md): a `_`
+// Dynamic-extent arrays (docs/design/dynamic-extent-arrays.md): a `?`
 // extent marks a dimension dynamic; its runtime value is a leading operand
 // of the constructing intrinsic. Frontend-complete; lowering is pending the
 // strided-header box, so `--emit mlir` stops with a diagnostic.
@@ -10,33 +10,33 @@
 
 import core::intrinsic::array;
 
-// CHECK: pub fn #make(v0 (n): u64) -> [i32; _]
-// CHECK: array#splat(v0 : u64 {{.*}}, 42 : i32 {{.*}}) : [i32; _]
-pub fn make(n : u64) -> [i32; _] {
-    array::splat<[i32; _]>(n, 42)
+// CHECK: pub fn #make(v0 (n): u64) -> [i32; ?]
+// CHECK: array#splat(v0 : u64 {{.*}}, 42 : i32 {{.*}}) : [i32; ?]
+pub fn make(n : u64) -> [i32; ?] {
+    array::splat<[i32; ?]>(n, 42)
 }
 
-// CHECK: pub fn #make2(v0 (n): u64) -> [i32; _, 4]
+// CHECK: pub fn #make2(v0 (n): u64) -> [i32; ?, 4]
 // CHECK: array#tabulate(v0 : u64 {{.*}}, closure
-pub fn make2(n : u64) -> [i32; _, 4] {
-    array::tabulate<[i32; _, 4]>(n, |i : i64, j : i64| 0)
+pub fn make2(n : u64) -> [i32; ?, 4] {
+    array::tabulate<[i32; ?, 4]>(n, |i : i64, j : i64| 0)
 }
 
-// CHECK: pub fn #read(v0 (a): [i32; _], v1 (i): i64) -> i32
-// CHECK: array#get(v0 : [i32; _] {{.*}}, v1 : i64 {{.*}}) : i32
-pub fn read(a : [i32; _], i : i64) -> i32 {
+// CHECK: pub fn #read(v0 (a): [i32; ?], v1 (i): i64) -> i32
+// CHECK: array#get(v0 : [i32; ?] {{.*}}, v1 : i64 {{.*}}) : i32
+pub fn read(a : [i32; ?], i : i64) -> i32 {
     array::get(a, i)
 }
 
-// CHECK: pub fn #put(v0 (a): [i32; _], v1 (i): i64, v2 (v): i32) -> [i32; _]
-// CHECK: array#set(v0 : [i32; _] {{.*}}) : [i32; _]
-pub fn put(a : [i32; _], i : i64, v : i32) -> [i32; _] {
+// CHECK: pub fn #put(v0 (a): [i32; ?], v1 (i): i64, v2 (v): i32) -> [i32; ?]
+// CHECK: array#set(v0 : [i32; ?] {{.*}}) : [i32; ?]
+pub fn put(a : [i32; ?], i : i64, v : i32) -> [i32; ?] {
     array::set(a, i, v)
 }
 
-// CHECK: pub fn #extent(v0 (a): [i32; _, 4]) -> u64
-// CHECK: array#dim(v0 : [i32; _, 4] {{.*}}, 0 : u64 {{.*}}) : u64
-pub fn extent(a : [i32; _, 4]) -> u64 {
+// CHECK: pub fn #extent(v0 (a): [i32; ?, 4]) -> u64
+// CHECK: array#dim(v0 : [i32; ?, 4] {{.*}}, 0 : u64 {{.*}}) : u64
+pub fn extent(a : [i32; ?, 4]) -> u64 {
     array::dim(a, 0)
 }
 

--- a/tests/integration/frontend/dynamic_extent_arrays_errors.rr
+++ b/tests/integration/frontend/dynamic_extent_arrays_errors.rr
@@ -1,5 +1,5 @@
 // Dynamic-extent arrays: what still errors. A dynamic dimension is spelled
-// `_` and only `_`; extent expressions stay literal-only, and the
+// `?` and only `?`; extent expressions stay literal-only, and the
 // constructor arity accounts for the leading runtime extents.
 
 // RUN: %not %rrc %s --emit hir -o - 2>&1 | %FileCheck %s
@@ -13,11 +13,11 @@ fn expr_extent(a : [f64; 2 + 2]) -> i64 { 0 }
 fn name_extent(a : [f64; n]) -> i64 { 0 }
 
 // CHECK-DAG: array extents must be positive
-fn zero_extent(a : [f64; 0, _]) -> i64 { 0 }
+fn zero_extent(a : [f64; 0, ?]) -> i64 { 0 }
 
 // CHECK: `core::intrinsic::array::splat` expects exactly one argument and 1 leading dynamic extent(s)
-fn missing_extent() -> [i32; _] {
-    array::splat<[i32; _]>(42)
+fn missing_extent() -> [i32; ?] {
+    array::splat<[i32; ?]>(42)
 }
 
 // CHECK: `core::intrinsic::array::splat` expects exactly one argument
@@ -26,6 +26,6 @@ fn extra_arg_static() -> [i32; 4] {
 }
 
 // CHECK: `dim` expects one dimension-index argument
-fn dim_arity(a : [i32; _]) -> u64 {
+fn dim_arity(a : [i32; ?]) -> u64 {
     array::dim(a)
 }

--- a/tests/integration/frontend/dynamic_extent_arrays_errors.rr
+++ b/tests/integration/frontend/dynamic_extent_arrays_errors.rr
@@ -1,0 +1,31 @@
+// Dynamic-extent arrays: what still errors. A dynamic dimension is spelled
+// `_` and only `_`; extent expressions stay literal-only, and the
+// constructor arity accounts for the leading runtime extents.
+
+// RUN: %not %rrc %s --emit hir -o - 2>&1 | %FileCheck %s
+
+import core::intrinsic::array;
+
+// CHECK-DAG: this kind of array extent cannot be evaluated yet
+fn expr_extent(a : [f64; 2 + 2]) -> i64 { 0 }
+
+// CHECK-DAG: this kind of array extent cannot be evaluated yet
+fn name_extent(a : [f64; n]) -> i64 { 0 }
+
+// CHECK-DAG: array extents must be positive
+fn zero_extent(a : [f64; 0, _]) -> i64 { 0 }
+
+// CHECK: `core::intrinsic::array::splat` expects exactly one argument and 1 leading dynamic extent(s)
+fn missing_extent() -> [i32; _] {
+    array::splat<[i32; _]>(42)
+}
+
+// CHECK: `core::intrinsic::array::splat` expects exactly one argument
+fn extra_arg_static() -> [i32; 4] {
+    array::splat<[i32; 4]>(1, 42)
+}
+
+// CHECK: `dim` expects one dimension-index argument
+fn dim_arity(a : [i32; _]) -> u64 {
+    array::dim(a)
+}

--- a/tests/integration/frontend/tensor_basics.rr
+++ b/tests/integration/frontend/tensor_basics.rr
@@ -1,0 +1,38 @@
+// The tensor type and its boundary intrinsics
+// (docs/design/tensor-kernels.md): `Tensor<[T; dims]>` is the transient
+// value-semantics view of an array — `of` takes the view (consuming the
+// reference; the tensor owns the rooted dup), `materialize` builds a fresh
+// array back, `dim` reads an extent. Frontend-complete; lowering is pending
+// the linalg pipeline stages, so `--emit mlir` stops with a diagnostic.
+
+// RUN: %rrc %s --emit hir -o - | %FileCheck %s
+// RUN: %not %rrc %s --emit mlir -o - 2>&1 | %FileCheck %s --check-prefix=STUB
+
+// STUB: not lower yet
+
+import core::intrinsic::tensor;
+
+// CHECK: pub fn #roundtrip(v0 (a): [i32; 8]) -> [i32; 8]
+// CHECK: tensor#of(v0 : [i32; 8] {{.*}}) : Tensor<[i32; 8]>
+// CHECK: tensor#materialize(v1 : Tensor<[i32; 8]> {{.*}}) : [i32; 8]
+pub fn roundtrip(a : [i32; 8]) -> [i32; 8] {
+    let t = tensor::of(a);
+    tensor::materialize(t)
+}
+
+// A tensor over a dynamic-extent array keeps the dynamic shape.
+// CHECK: pub fn #tdim(v0 (a): [i32; _, 4]) -> u64
+// CHECK: tensor#of(v0 : [i32; _, 4] {{.*}}) : Tensor<[i32; _, 4]>
+// CHECK: tensor#dim(v1 : Tensor<[i32; _, 4]> {{.*}}, 1 : u64 {{.*}}) : u64
+pub fn tdim(a : [i32; _, 4]) -> u64 {
+    let t = tensor::of(a);
+    tensor::dim(t, 1)
+}
+
+// Tensors flow through let-bindings and branches (scf-shaped control flow);
+// only escapes are rejected (see tensor_errors.rr).
+// CHECK: pub fn #pick(v0 (a): [i32; 8], v1 (b): [i32; 8], v2 (c): bool) -> [i32; 8]
+pub fn pick(a : [i32; 8], b : [i32; 8], c : bool) -> [i32; 8] {
+    let t = if c { tensor::of(a) } else { tensor::of(b) };
+    tensor::materialize(t)
+}

--- a/tests/integration/frontend/tensor_basics.rr
+++ b/tests/integration/frontend/tensor_basics.rr
@@ -21,10 +21,10 @@ pub fn roundtrip(a : [i32; 8]) -> [i32; 8] {
 }
 
 // A tensor over a dynamic-extent array keeps the dynamic shape.
-// CHECK: pub fn #tdim(v0 (a): [i32; _, 4]) -> u64
-// CHECK: tensor#of(v0 : [i32; _, 4] {{.*}}) : Tensor<[i32; _, 4]>
-// CHECK: tensor#dim(v1 : Tensor<[i32; _, 4]> {{.*}}, 1 : u64 {{.*}}) : u64
-pub fn tdim(a : [i32; _, 4]) -> u64 {
+// CHECK: pub fn #tdim(v0 (a): [i32; ?, 4]) -> u64
+// CHECK: tensor#of(v0 : [i32; ?, 4] {{.*}}) : Tensor<[i32; ?, 4]>
+// CHECK: tensor#dim(v1 : Tensor<[i32; ?, 4]> {{.*}}, 1 : u64 {{.*}}) : u64
+pub fn tdim(a : [i32; ?, 4]) -> u64 {
     let t = tensor::of(a);
     tensor::dim(t, 1)
 }

--- a/tests/integration/frontend/tensor_errors.rr
+++ b/tests/integration/frontend/tensor_errors.rr
@@ -1,0 +1,49 @@
+// Tensor escape rules (docs/design/tensor-kernels.md): a tensor is
+// scope-confined — flex : freeze :: tensor : materialize. It may not be
+// stored in a record, captured or returned by a closure, appear in a
+// function signature, or sit inside another container.
+
+// RUN: %not %rrc %s --emit hir -o - 2>&1 | %FileCheck %s
+
+import core::intrinsic::tensor;
+
+// CHECK-DAG: a record member cannot contain a tensor
+pub struct Holder { t : Tensor<[i32; 4]> }
+
+// CHECK-DAG: a tensor cannot appear in a function signature
+fn sig_escape(t : Tensor<[i32; 4]>) -> u64 {
+    tensor::dim(t, 0)
+}
+
+// CHECK-DAG: array element type `Tensor<[i32; 4]>` is not supported yet (a tensor)
+fn bad_elem(x : [Tensor<[i32; 4]>; 2]) -> i64 { 0 }
+
+// CHECK-DAG: `Tensor` takes an array type argument
+fn bad_arg(x : [i32; 4]) -> i64 {
+    let t : Tensor<i32> = tensor::of(x);
+    0
+}
+
+// CHECK: closure cannot capture `t`: a tensor is scope-confined
+fn capture_escape(a : [i32; 8]) -> i64 {
+    let t = tensor::of(a);
+    let f = |x : i64| tensor::dim(t, 0);
+    0
+}
+
+// CHECK: closure cannot return a tensor
+fn ret_escape(a : [i32; 8]) -> i64 {
+    let f = |x : i64| tensor::of(a);
+    0
+}
+
+// CHECK: `of` expects an array argument
+fn of_scalar() -> i64 {
+    let t = tensor::of(0);
+    0
+}
+
+// CHECK: `materialize` expects a tensor argument
+fn mat_scalar(a : [i32; 8]) -> [i32; 8] {
+    tensor::materialize(a)
+}


### PR DESCRIPTION
Implements the frontend half of `docs/design/dynamic-extent-arrays.md` and `docs/design/tensor-kernels.md` (both landed in #595). Every lowering path stops at an `err(…)` stub — `--emit hir`/`--emit mir` work end-to-end, `--emit mlir` reports `… not lower yet` — so the semantics are reviewable before any backend work starts.

## Dynamic-extent arrays

- **Surface**: `?` in array-extent position marks a dynamic dimension (`[i32; ?, 4]`), matching MLIR's `memref<?x…>`. Parsed as a dedicated `DynExtent` node special-cased in `array_type()`, so `?` never enters the expression grammar (`_` stays the placeholder/infer convention); surface carries `ArrayExtent::{Expr, Dynamic}`. Non-literal extent *expressions* (`2+2`, `n`) still error, unchanged.
- **Types**: dims stay `&'tcx [u64]`; dynamic encodes as `DYNAMIC_EXTENT = u64::MAX` — the same `~0` sentinel as the dialect's `token<align, ?>` and MLIR's `ShapedType::kDynamic`. The 2^32-element cap now applies to the static factor only; slice-structural `Eq`/`Hash` keeps unification/interning correct with no new machinery.
- **Intrinsics**: `splat`/`tabulate` take one leading `u64` operand per dynamic dimension (in dimension order); new `array::dim(a, k) -> u64` borrowing its base like `get`/`fold` (ownership + the interpreter-test oracle updated).
- **Spellings**: display and HIR/MIR printers/grammars spell a dynamic dim `?`; mangling spells it `D` (`ArrayDx4`).

## Tensor type

- `Tensor<[T; dims]>` lands via the path-based builtin former route (like `Arc`/`Nullable` — zero parser changes), spelled `core::intrinsic::tensor::Tensor` with the bare-name prelude convention.
- `TyKind::Tensor` mirrors `Array` through interning (`mk_tensor`), unification (rank+extent guard), occurs/resolve/materialize, coherence (`HeadKey::Tensor`), `Sync` (refutes — a scope-confined view of a non-atomic box), subst/mono traversals, and FFI (rejected outright, exhaustively).
- **Boundary intrinsics** `of`/`materialize`/`dim` ride a new `ExprKind::TensorOp` mirroring `ArrayOp` through HIR/MIR/raw/textual grammars (`tensor#op(…)`). Ownership: all operands consume like call args — `of` owns the rooted dup, so a later in-place update of the viewed array sees count ≥ 2 and clones (the `restrict` contract from the design doc, by construction).
- **Escape rules** (flex : freeze :: tensor : materialize), all via a structural `contains_tensor`: no record members, no closure captures or returns, no plain/trait fn signatures, no array/cell/arc elements, no FFI. Tensors flow freely through lets and branches.

## Deliberate calls to review

- `is_rr(Tensor) = false`: the tensor value itself carries no rc box; the backing reference is rooted by `of`'s consume. 
- Tensor as a *generic type argument* (`SomeRecord<Tensor<…>>`) is caught when it grounds into a member/signature position, not eagerly at the instantiation site — a known small hole to tighten later if wanted.
- `Tensor<T>` with a non-array argument is a hard error rather than deferred inference.

## Tests

`dynamic_extent_arrays{,_errors}.rr`, `tensor_basics.rr`, `tensor_errors.rr` (HIR-positive, error-tier, and `%not --emit mlir` stub checks). Full integration suite 502/502 green, unit tests 525 green, workspace clippy-clean fmt applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EpQbdaWoHeGduNHRQzSH8V

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/597"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790576446&installation_model_id=426051&pr_number=597&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F597&signature=d769b73c0eb70f7d8198c697b8ad4a22208265b03efa6dbf9bd8a732727d02a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
