### PR TITLE
[mlir] dynamic-extent arrays: type, strided-header box, view, alloc, dec

### DIFF
--- a/crates/reussir-backend/src/builders.rs
+++ b/crates/reussir-backend/src/builders.rs
@@ -288,10 +288,11 @@ pub fn record_compound<'c>(
 /// `reussir.rc.create value(<value> : <type>) : <result_type>` — box a value into
 /// a fresh reference-counted pointer with an initial count of 1.
 ///
-/// The op carries `AttrSizedOperandSegments` over its `[value, token, region]`
-/// operand groups, but melior's generated builder leaves the required
-/// `operandSegmentSizes` attribute unset, so it is constructed here with the
-/// single value operand present (`[1, 0, 0]`). The allocation token and any
+/// The op carries `AttrSizedOperandSegments` over its
+/// `[value, token, region, extents]` operand groups, but melior's generated
+/// builder leaves the required `operandSegmentSizes` attribute unset, so it
+/// is constructed here with the
+/// single value operand present (`[1, 0, 0, 0]`). The allocation token and any
 /// region are supplied later by the token-instantiation pass; the rc-create
 /// fusion pass then folds an immediately preceding `record.compound` into this
 /// op (`reussir.rc.create_compound`).
@@ -305,7 +306,7 @@ pub fn rc_create<'c>(
         .add_operands(&[value])
         .add_attributes(&[(
             Identifier::new(context, "operandSegmentSizes"),
-            DenseI32ArrayAttribute::new(context, &[1, 0, 0]).into(),
+            DenseI32ArrayAttribute::new(context, &[1, 0, 0, 0]).into(),
         )])
         .add_results(&[result_type])
         .build()
@@ -317,8 +318,9 @@ pub fn rc_create<'c>(
 /// capability and an initial count of 1.
 ///
 /// Like [`rc_create`] the op carries `AttrSizedOperandSegments` over its
-/// `[value, token, region]` operand groups; here the value and region are
-/// present and the token absent (`[1, 0, 1]`). Supplying the region is what
+/// `[value, token, region, extents]` operand groups; here the value and
+/// region are
+/// present and the token absent (`[1, 0, 1, 0]`). Supplying the region is what
 /// gives the result `flex` (region-local, mutable) capability — the region
 /// patterns pass later attaches the box vtable and freezes the value to `rigid`
 /// where it escapes its region.
@@ -333,9 +335,9 @@ pub fn rc_create_in_region<'c>(
         .add_operands(&[value, region])
         .add_attributes(&[(
             Identifier::new(context, "operandSegmentSizes"),
-            // operandSegmentSizes over [value, token, region]: value and region
-            // present, token absent.
-            DenseI32ArrayAttribute::new(context, &[1, 0, 1]).into(),
+            // operandSegmentSizes over [value, token, region, extents]:
+            // value and region present, token and extents absent.
+            DenseI32ArrayAttribute::new(context, &[1, 0, 1, 0]).into(),
         )])
         .add_results(&[result_type])
         .build()

--- a/crates/reussir-jit/tests/jit_examples.rs
+++ b/crates/reussir-jit/tests/jit_examples.rs
@@ -65,7 +65,7 @@ fn result_of<'c, 'a>(block: &'a Block<'c>, operation: impl Into<Operation<'c>>) 
 // Builds a `reussir.rc.create` that takes only a value (no token/region). The op
 // carries `AttrSizedOperandSegments`, and melior's generated builder does not
 // populate `operandSegmentSizes`, so we construct it directly and set the segment
-// sizes ([value, token, region] = [1, 0, 0]). The pipeline's token-instantiation
+// sizes ([value, token, region, extents] = [1, 0, 0, 0]). The pipeline's token-instantiation
 // pass supplies the missing allocation token.
 fn rc_create_value<'c, 'a>(
     context: &'c Context,
@@ -78,7 +78,7 @@ fn rc_create_value<'c, 'a>(
         .add_operands(&[value])
         .add_attributes(&[(
             Identifier::new(context, "operandSegmentSizes"),
-            DenseI32ArrayAttribute::new(context, &[1, 0, 0]).into(),
+            DenseI32ArrayAttribute::new(context, &[1, 0, 0, 0]).into(),
         )])
         .add_results(&[rc_type])
         .build()

--- a/docs/design/dynamic-extent-arrays.md
+++ b/docs/design/dynamic-extent-arrays.md
@@ -122,9 +122,17 @@ ref by the static header offset); `token.alloc` takes an SSA byte size
 for `token<align, ?>`; `rc.create … extents(…)` writes the canonical
 header and its instantiated token computes `header + product(sizes) *
 elemsize`; `rc.dec`/`rc.reinterpret` produce dynamic tokens freed
-unsized. Executable e2e: `dynamic_array_e2e.mlir`. Open backend halves:
-the `with_unique_view` clone branch (runtime-length copy), dynamic
-`array.project`, restride ops, `expand-strided-metadata` in the shipping
+unsized; `array.project` accepts the dynamic strided view and every
+projection of it keeps that layout (descriptor arithmetic on the live
+offset field); the ownership traversal (`emitArrayElementTraversal`, the
+drop/acquire nest) unrolls only static shapes and takes dynamic bounds from
+`memref.dim`; the `with_unique_view` clone branch reads the source header
+through `memref.extract_strided_metadata`, sizes its token at runtime,
+constructs the clone canonical from the same sizes, and copies flat
+(`ref.memcpy … size(%bytes)`) when the source is canonical or element-wise
+otherwise. Executable e2e: `dynamic_array_e2e.mlir`,
+`dynamic_array_clone_e2e.mlir`, `dynamic_array_managed_e2e.mlir`. Open
+backend halves: restride ops, `expand-strided-metadata` in the shipping
 pipeline, and wiring the frontend codegen off its `err(…)` stubs.
 
 Frontend landed: `?` extents, the `DYNAMIC_EXTENT` sentinel through the

--- a/docs/design/dynamic-extent-arrays.md
+++ b/docs/design/dynamic-extent-arrays.md
@@ -39,6 +39,11 @@ Static arrays keep today's headerless box and identity-layout
 `memref<NxT>` view — no regression, and the two forms stay distinct
 types.
 
+Dynamic arrays currently support shared boxes only. Regional (`flex`/`rigid`)
+RC pointers and references, and regional dynamic-array box types, are rejected
+by the type verifiers: the regional state/next/vtable header has no strided
+metadata extension yet.
+
 ## Views and projection
 
 `getArrayViewMemRefType` for a dynamic array returns
@@ -81,6 +86,10 @@ aliased elements would break the drop traversal's exactly-once contract.
   the existing universal fallback donor; `token.alloc` gains an SSA size
   operand (the `__reussir_allocate` entry point already takes a runtime
   size — only the constant-gated `_small` fast path stays static-only).
+  Dynamic arrays can donate tokens to statically sized constructions, but
+  dynamic recipients retain their original allocation: `token.ensure` and
+  `token.realloc` do not yet carry the requested SSA byte count. Equality of
+  two dynamic token types does not establish equal allocation sizes.
   Boxes past `kAllocatorBinModelMax` are excluded from reuse pairing,
   implementing the #344 integration note.
 

--- a/docs/design/dynamic-extent-arrays.md
+++ b/docs/design/dynamic-extent-arrays.md
@@ -113,6 +113,20 @@ aliased elements would break the drop traversal's exactly-once contract.
 
 ## Status
 
+Dialect landed: `!reussir.array<? x T>` parses/verifies (`?` extents,
+`ShapedType::kDynamic`); the strided-header box (`RcBoxType`
+`hasDynamicArrayPayload` — `{i32 count | index offset | sizes | strides |
+tail}`, index-typed so the width follows the target); `array.view` builds
+the strided descriptor from header loads (box recovered from the payload
+ref by the static header offset); `token.alloc` takes an SSA byte size
+for `token<align, ?>`; `rc.create … extents(…)` writes the canonical
+header and its instantiated token computes `header + product(sizes) *
+elemsize`; `rc.dec`/`rc.reinterpret` produce dynamic tokens freed
+unsized. Executable e2e: `dynamic_array_e2e.mlir`. Open backend halves:
+the `with_unique_view` clone branch (runtime-length copy), dynamic
+`array.project`, restride ops, `expand-strided-metadata` in the shipping
+pipeline, and wiring the frontend codegen off its `err(…)` stubs.
+
 Frontend landed: `?` extents, the `DYNAMIC_EXTENT` sentinel through the
 type system, leading runtime extents on `splat`/`tabulate`, `array::dim`,
 display/mangling/textual-IR spellings, and `err(…)` stubs at every

--- a/include/Reussir/Conversion/Passes.td
+++ b/include/Reussir/Conversion/Passes.td
@@ -232,6 +232,7 @@ def ReussirTokenInstantiationPass
                         "rebuild TokenProducers with their token result">];
 
   let dependentDialects = ["::reussir::ReussirDialect",
+                           "::mlir::arith::ArithDialect",
                            "::mlir::sync::SyncDialect"];
 }
 

--- a/include/Reussir/IR/ReussirDialect.h
+++ b/include/Reussir/IR/ReussirDialect.h
@@ -20,6 +20,7 @@
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/LLVMIR/LLVMDialect.h>
 #include <mlir/Dialect/Math/IR/Math.h>
+#include <mlir/Dialect/MemRef/IR/MemRef.h>
 #include <mlir/Dialect/SCF/IR/SCF.h>
 #include <mlir/Dialect/UB/IR/UBOps.h>
 #include <mlir/IR/Dialect.h>

--- a/include/Reussir/IR/ReussirDialect.td
+++ b/include/Reussir/IR/ReussirDialect.td
@@ -40,6 +40,10 @@ def ReussirDialect : Dialect {
       "mlir::LLVM::LLVMDialect",
       // UB Dialect
       "mlir::ub::UBDialect",
+      // Array views are memrefs; the ownership traversal of a dynamic-extent
+      // array (`emitArrayElementTraversal`) takes its loop bounds from
+      // `memref.dim` on the view.
+      "mlir::memref::MemRefDialect",
       // Lock-guarded cells: their data layout is the layout of the
       // corresponding `!sync.*` primitive, so any DataLayout query on such a
       // cell constructs a sync type — including paths that run before any

--- a/include/Reussir/IR/ReussirOps.h
+++ b/include/Reussir/IR/ReussirOps.h
@@ -88,8 +88,20 @@ mlir::LogicalResult emitOwnershipAcquisition(mlir::Value value,
                                              mlir::OpBuilder &builder,
                                              mlir::Location loc);
 
-/// Traverses a statically shaped Reussir array view and invokes `emitElement`
-/// with a reference to each element.
+/// The memref type `reussir.array.view` produces for an array: identity
+/// layout for a static shape, a fully dynamic strided layout for a
+/// dynamic-extent one (the box header carries the strided encoding).
+mlir::MemRefType getArrayViewMemRefType(ArrayType arrayType);
+
+/// The memref type `reussir.array.project` produces for a non-final
+/// dimension of `viewType`: the shape loses its front, and the layout kind
+/// (identity or dynamic strided) is inherited from the view being projected.
+mlir::MemRefType getProjectedArrayViewType(mlir::MemRefType viewType);
+
+/// Traverses a Reussir array view and invokes `emitElement` with a reference
+/// to each element. A static shape at or below the unroll threshold is
+/// emitted straight-line; anything else is an `scf.for` nest whose bounds are
+/// constants for static extents and `memref.dim` loads for dynamic ones.
 mlir::LogicalResult emitArrayElementTraversal(
     mlir::Value view, mlir::OpBuilder &builder, mlir::Location loc,
     llvm::function_ref<mlir::LogicalResult(mlir::OpBuilder &, mlir::Location,

--- a/include/Reussir/IR/ReussirOps.td
+++ b/include/Reussir/IR/ReussirOps.td
@@ -144,15 +144,25 @@ def ReussirTokenAllocOp : ReussirTokenOp<"alloc", []> {
     ```mlir
     reussir.token.alloc : !reussir.token<align: 8, size: 16>
     ```
+    A dynamically sized token (`token<align, ?>`) takes its byte size as an
+    SSA operand instead (a dynamic-extent array box, whose size is
+    `header + product(sizes) * elemsize`):
+    ```mlir
+    reussir.token.alloc(%bytes : index) : !reussir.token<align: 8, size: ?>
+    ```
   }];
+
+  let arguments = (ins Arg<Optional<Index>, "dynamic byte size">:$dynamicSize);
 
   let results =
       (outs Res<ReussirTokenType,
                 "Allocated Memory Token", [MemAlloc<DefaultResource>]>:$token);
 
   let assemblyFormat = [{
-    `:` type($token) attr-dict
+    ( `(` $dynamicSize^ `:` `index` `)` )? `:` type($token) attr-dict
   }];
+
+  let hasVerifier = 1;
 }
 
 def ReussirTokenFreeOp : ReussirTokenOp<"free", []> {
@@ -581,6 +591,7 @@ def ReussirRcCreateOp
 
   let arguments = (ins Arg<AnyType, "value">:$value,
       Optional<ReussirTokenType>:$token, Optional<ReussirRegionType>:$region,
+      Variadic<Index>:$extents,
       OptionalAttr<FlatSymbolRefAttr>:$vtable, UnitAttr:$skipRc);
   let results = (outs Res<ReussirRcType, "Created RC pointer">:$rcPtr);
 
@@ -589,6 +600,7 @@ def ReussirRcCreateOp
     oilist ( 
       `token` `(` $token `:` type($token) `)`
     | `region` `(` $region `:` type($region) `)` 
+    | `extents` `(` $extents `)`
     | `vtable` `(` $vtable `)`
     | `skip_rc` $skipRc
     )

--- a/include/Reussir/IR/ReussirOps.td
+++ b/include/Reussir/IR/ReussirOps.td
@@ -1026,13 +1026,21 @@ class ReussirArrayOp<string mnemonic, list<Trait> traits>
     : ReussirOp<"array."#mnemonic, traits>;
 
 def ReussirArrayProjectOp : ReussirArrayOp<"project", [Pure]> {
-  let summary = "Project a fixed-size array view";
+  let summary = "Project the leading dimension of an array view";
   let description = [{
-    `reussir.array.project` projects the leading dimension of a statically
-    shaped memref produced by `reussir.array.view`.
+    `reussir.array.project` projects the leading dimension of a memref
+    produced by `reussir.array.view` (or by a previous projection).
     When the remaining element is scalar, the result is a field reference.
-    Otherwise, the result is another statically shaped memref with one fewer
-    dimension.
+    Otherwise, the result is another memref with one fewer dimension.
+
+    A static array views as an identity-layout memref and projects to one; a
+    dynamic-extent array views as a strided memref with dynamic offset and
+    strides (docs/design/dynamic-extent-arrays.md) and every projection of it
+    keeps that dynamic strided layout, even once the remaining shape is
+    static — the strides live in the box header, not in the type. The
+    projection is descriptor arithmetic (`offset += index * stride[0]`, drop
+    the leading size/stride) guarded by a bounds assumption against the
+    leading extent, static or loaded.
   }];
   let arguments = (ins Arg<AnyType, "array view to project">:$view,
       Arg<Index, "dynamic index">:$index);
@@ -1582,12 +1590,23 @@ def ReussirRefMemcpyOp : ReussirReferenceOp<"memcpy", []> {
 
     This is a low-level operation that does not perform any reference counting
     or ownership transfer. It simply copies the bytes from source to destination.
+
+    The byte count is the element's static size. An element without one — a
+    dynamic-extent array payload, whose size is `product(sizes) * elemsize`
+    at runtime — takes the count as an SSA operand instead, and the operand
+    is required exactly then:
+    ```mlir
+    reussir.ref.memcpy %src to %dst size(%bytes : index)
+        : <!reussir.array<? x i32>> to <!reussir.array<? x i32>>
+    ```
   }];
   let arguments = (ins Arg<ReussirRefType, "source reference",
       [MemRead]>:$src,
-      Arg<ReussirRefType, "destination reference", [MemWrite]>:$dst);
+      Arg<ReussirRefType, "destination reference", [MemWrite]>:$dst,
+      Arg<Optional<Index>, "byte count of a dynamically sized element">:$size);
   let assemblyFormat = [{
-    $src `to` $dst `:` type($src) `to` type($dst) attr-dict
+    $src `to` $dst (`size` `(` $size^ `:` `index` `)`)?
+    `:` type($src) `to` type($dst) attr-dict
   }];
   let hasVerifier = 1;
 }

--- a/include/Reussir/IR/ReussirTypes.td
+++ b/include/Reussir/IR/ReussirTypes.td
@@ -549,6 +549,7 @@ def ReussirRcBoxType
   ]}];
   let parameters = (ins "mlir::Type":$eleTy, "bool":$regional);
   let hasCustomAssemblyFormat = 1;
+  let genVerifyDecl = 1;
   let skipDefaultBuilders = 1;
   let builders = [TypeBuilder<(ins "mlir::Type":$eleTy, "bool":$regional), [{
       return $_get($_ctxt, eleTy, regional);

--- a/include/Reussir/IR/ReussirTypes.td
+++ b/include/Reussir/IR/ReussirTypes.td
@@ -567,6 +567,17 @@ def ReussirRcBoxType
     // LLVM type conversion.
     llvm::SmallVector<mlir::Type> getHeaderTypes() const;
     size_t getElementIndex() const { return getHeaderTypes().size(); }
+    // Whether the payload is a dynamic-extent array
+    // (docs/design/dynamic-extent-arrays.md): the box then carries the full
+    // strided-memref encoding in its header —
+    // `{ i32 count | index offset | index size[r] | index stride[r] | payload }`
+    // (padding per the data layout; the two descriptor pointers are derived
+    // as box + header). The header prefix is static per rank; only the
+    // payload tail size is dynamic.
+    bool hasDynamicArrayPayload() const;
+    // Byte offset of the dynamic payload tail (the aligned end of the
+    // header), and the box alignment. Valid only for a dynamic array payload.
+    uint64_t getDynamicPayloadOffset(const mlir::DataLayout &dataLayout) const;
   }];
 }
 

--- a/lib/Conversion/AcquireDropExpansion/AcquireDropExpansion.cpp
+++ b/lib/Conversion/AcquireDropExpansion/AcquireDropExpansion.cpp
@@ -115,9 +115,7 @@ private:
                                        mlir::PatternRewriter &rewriter) const {
     mlir::Value view = ReussirArrayViewOp::create(
                            rewriter, op.getLoc(),
-                           mlir::MemRefType::get(arrayType.getShape(),
-                                                 arrayType.getElementType()),
-                           op.getRef())
+                           getArrayViewMemRefType(arrayType), op.getRef())
                            .getView();
     if (mlir::failed(emitArrayElementTraversal(
             view, rewriter, op.getLoc(),

--- a/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
+++ b/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
@@ -431,6 +431,21 @@ struct ReussirTokenAllocConversionPattern
     auto indexType = converter->getIndexType();
     auto moduleOp = op->getParentOfType<mlir::ModuleOp>();
 
+    // A dynamically sized token (a dynamic-extent array box) carries its
+    // byte size as an operand; it always takes the generic entry point (the
+    // small fast path requires a compile-time-constant size).
+    if (tokenType.isDynamicSize()) {
+      auto alignConst = mlir::arith::ConstantOp::create(
+          rewriter, loc, mlir::IntegerAttr::get(indexType, alignment));
+      auto allocFunc =
+          moduleOp.lookupSymbol<mlir::LLVM::LLVMFuncOp>("__reussir_allocate");
+      auto funcOp = mlir::LLVM::CallOp::create(
+          rewriter, loc, allocFunc,
+          mlir::ValueRange{alignConst, adaptor.getDynamicSize()});
+      rewriter.replaceOp(op, funcOp.getResult());
+      return mlir::success();
+    }
+
     // A statically small, naturally aligned layout takes the sized fast
     // path: `__reussir_allocate_small(size)` is `mi_malloc_small` behind an
     // OOM check — no alignment/divisibility recheck, no size
@@ -1492,8 +1507,45 @@ struct ReussirArrayViewConversionPattern
           "tensor array.view must be bufferized before lowering basic ops");
     ArrayType arrayType = llvm::cast<ArrayType>(
         llvm::cast<RefType>(op.getRef().getType()).getElementType());
-    mlir::Type llvmArrayType = converter->convertType(arrayType);
     auto llvmPtrType = mlir::LLVM::LLVMPointerType::get(rewriter.getContext());
+    if (!arrayType.hasStaticShape()) {
+      // A dynamic-extent view is a straight header copy: the box stores the
+      // full strided encoding (offset, sizes, strides) right before the
+      // payload, so the descriptor's fields are loads at statically known
+      // offsets and both descriptor pointers are the payload ref itself.
+      auto boxType =
+          RcBoxType::get(rewriter.getContext(), arrayType, /*regional=*/false);
+      mlir::Type llvmBoxType = converter->convertType(boxType);
+      mlir::DataLayout dataLayout = mlir::DataLayout::closest(op);
+      uint64_t payloadOffset = boxType.getDynamicPayloadOffset(dataLayout);
+      auto i8Type = rewriter.getI8Type();
+      auto boxPtr = mlir::LLVM::GEPOp::create(
+          rewriter, loc, llvmPtrType, i8Type, adaptor.getRef(),
+          {mlir::LLVM::GEPArg(-static_cast<int32_t>(payloadOffset))});
+      mlir::Type indexType = converter->getIndexType();
+      auto loadHeaderField = [&](int32_t fieldIndex) -> mlir::Value {
+        auto fieldPtr = mlir::LLVM::GEPOp::create(
+            rewriter, loc, llvmPtrType, llvmBoxType, boxPtr,
+            {mlir::LLVM::GEPArg(0), mlir::LLVM::GEPArg(fieldIndex)});
+        return mlir::LLVM::LoadOp::create(rewriter, loc, indexType, fieldPtr);
+      };
+      auto descriptor =
+          mlir::MemRefDescriptor::poison(rewriter, loc,
+                                         converter->convertType(viewType));
+      descriptor.setAllocatedPtr(rewriter, loc, adaptor.getRef());
+      descriptor.setAlignedPtr(rewriter, loc, adaptor.getRef());
+      // Header layout: {i32 count, index offset, index size[r], index
+      // stride[r], payload}; field 0 is the refcount.
+      descriptor.setOffset(rewriter, loc, loadHeaderField(1));
+      int64_t rank = arrayType.getRank();
+      for (int64_t i = 0; i < rank; ++i)
+        descriptor.setSize(rewriter, loc, i, loadHeaderField(2 + i));
+      for (int64_t i = 0; i < rank; ++i)
+        descriptor.setStride(rewriter, loc, i, loadHeaderField(2 + rank + i));
+      rewriter.replaceOp(op, mlir::Value(descriptor));
+      return mlir::success();
+    }
+    mlir::Type llvmArrayType = converter->convertType(arrayType);
     llvm::SmallVector<mlir::LLVM::GEPArg> zeroIndices(arrayType.getRank() + 1,
                                                       0);
     auto elementPtr =
@@ -1791,6 +1843,56 @@ struct ReussirRcCreateOpConversionPattern
         initializeRcCreateStorage(op, adaptor, getTypeConverter(), rewriter);
     if (mlir::failed(storage))
       return mlir::failure();
+    RcBoxType boxType = op.getRcPtr().getType().getInnerBoxType();
+    if (boxType.hasDynamicArrayPayload()) {
+      // Canonical strided-header construction: offset 0, the merged
+      // static/runtime sizes, and row-major suffix-product strides. The
+      // payload itself starts poison (the value operand is the zero-length
+      // tail placeholder — nothing to store).
+      mlir::Location loc = op.getLoc();
+      auto converter =
+          static_cast<const mlir::LLVMTypeConverter *>(getTypeConverter());
+      auto llvmBoxType = converter->convertType(boxType);
+      auto llvmPtrType =
+          mlir::LLVM::LLVMPointerType::get(rewriter.getContext());
+      mlir::Type indexType = converter->getIndexType();
+      auto storeHeaderField = [&](int32_t fieldIndex, mlir::Value value) {
+        auto fieldPtr = mlir::LLVM::GEPOp::create(
+            rewriter, loc, llvmPtrType, llvmBoxType, storage->token,
+            llvm::ArrayRef<mlir::LLVM::GEPArg>{0, fieldIndex});
+        mlir::LLVM::StoreOp::create(rewriter, loc, value, fieldPtr);
+      };
+      auto indexConst = [&](int64_t v) -> mlir::Value {
+        return mlir::LLVM::ConstantOp::create(
+            rewriter, loc, indexType,
+            mlir::IntegerAttr::get(indexType, v));
+      };
+      auto arrayType = llvm::cast<ArrayType>(boxType.getElementType());
+      int64_t rank = arrayType.getRank();
+      storeHeaderField(1, indexConst(0)); // offset
+      llvm::SmallVector<mlir::Value> sizes;
+      size_t nextExtent = 0;
+      for (int64_t dim : arrayType.getShape())
+        sizes.push_back(mlir::ShapedType::isDynamic(dim)
+                            ? adaptor.getExtents()[nextExtent++]
+                            : indexConst(dim));
+      for (int64_t i = 0; i < rank; ++i)
+        storeHeaderField(static_cast<int32_t>(2 + i), sizes[i]);
+      mlir::Value stride = indexConst(1);
+      llvm::SmallVector<mlir::Value> strides(rank);
+      for (int64_t i = rank - 1; i >= 0; --i) {
+        strides[i] = stride;
+        if (i > 0)
+          stride =
+              mlir::LLVM::MulOp::create(rewriter, loc, stride, sizes[i]);
+      }
+      for (int64_t i = 0; i < rank; ++i)
+        storeHeaderField(static_cast<int32_t>(2 + rank + i), strides[i]);
+      if (storage->countPtr)
+        storeInitialRcCount(storage->countPtr, op.getLoc(), rewriter);
+      rewriter.replaceOp(op, storage->token);
+      return mlir::success();
+    }
     auto objectStore = mlir::LLVM::StoreOp::create(
         rewriter, op.getLoc(), adaptor.getValue(), storage->elementPtr);
     if (!storage->regional)

--- a/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
+++ b/lib/Conversion/BasicOpsLowering/BasicOpsLowering.cpp
@@ -1427,13 +1427,20 @@ struct ReussirArrayProjectConversionPattern
     auto converter =
         static_cast<const mlir::LLVMTypeConverter *>(getTypeConverter());
     auto viewType = llvm::cast<mlir::MemRefType>(op.getView().getType());
-    auto extent = mlir::arith::ConstantOp::create(
-        rewriter, loc,
-        mlir::IntegerAttr::get(converter->getIndexType(),
-                               viewType.getShape().front()));
-    auto inBounds = mlir::arith::CmpIOp::create(
-        rewriter, loc, mlir::arith::CmpIPredicate::ult, adaptor.getIndex(),
-        extent.getResult());
+    mlir::MemRefDescriptor srcDesc(adaptor.getView());
+    // The leading extent is a constant for a static dim and a descriptor
+    // (box header) load for a dynamic one.
+    mlir::Value extent =
+        viewType.isDynamicDim(0)
+            ? srcDesc.size(rewriter, loc, 0)
+            : mlir::arith::ConstantOp::create(
+                  rewriter, loc,
+                  mlir::IntegerAttr::get(converter->getIndexType(),
+                                         viewType.getShape().front()))
+                  .getResult();
+    auto inBounds = mlir::arith::CmpIOp::create(rewriter, loc,
+                                                mlir::arith::CmpIPredicate::ult,
+                                                adaptor.getIndex(), extent);
     mlir::LLVM::AssumeOp::create(rewriter, loc, inBounds);
 
     if (viewType.getRank() == 1) {
@@ -1457,28 +1464,37 @@ struct ReussirArrayProjectConversionPattern
     auto resultMemRefType =
         llvm::cast<mlir::MemRefType>(op.getProjected().getType());
     mlir::Type resultType = converter->convertType(resultMemRefType);
-    mlir::MemRefDescriptor srcDesc(adaptor.getView());
     auto resultDesc = mlir::MemRefDescriptor::poison(rewriter, loc, resultType);
     resultDesc.setAllocatedPtr(rewriter, loc,
                                srcDesc.allocatedPtr(rewriter, loc));
 
-    // The projected type keeps the static identity layout (offset 0), and
-    // consumers such as `getStridedElementPtr` fold that static offset —
-    // the descriptor's runtime offset field is dead to them. Carry the row
-    // shift in the aligned pointer itself instead.
     auto offset = srcDesc.offset(rewriter, loc);
     auto stride0 = srcDesc.stride(rewriter, loc, 0);
     auto delta =
         mlir::arith::MulIOp::create(rewriter, loc, adaptor.getIndex(), stride0);
     auto shift = mlir::arith::AddIOp::create(rewriter, loc, offset, delta);
-    mlir::Type llvmElemTy =
-        converter->convertType(resultMemRefType.getElementType());
-    auto llvmPtrTy = mlir::LLVM::LLVMPointerType::get(rewriter.getContext());
-    auto shifted = mlir::LLVM::GEPOp::create(
-        rewriter, loc, llvmPtrTy, llvmElemTy, srcDesc.alignedPtr(rewriter, loc),
-        mlir::ValueRange{shift.getResult()});
-    resultDesc.setAlignedPtr(rewriter, loc, shifted);
-    resultDesc.setConstantOffset(rewriter, loc, 0);
+    if (resultMemRefType.getLayout().isIdentity()) {
+      // The projected type keeps the static identity layout (offset 0), and
+      // consumers such as `getStridedElementPtr` fold that static offset —
+      // the descriptor's runtime offset field is dead to them. Carry the row
+      // shift in the aligned pointer itself instead.
+      mlir::Type llvmElemTy =
+          converter->convertType(resultMemRefType.getElementType());
+      auto llvmPtrTy = mlir::LLVM::LLVMPointerType::get(rewriter.getContext());
+      auto shifted =
+          mlir::LLVM::GEPOp::create(rewriter, loc, llvmPtrTy, llvmElemTy,
+                                    srcDesc.alignedPtr(rewriter, loc),
+                                    mlir::ValueRange{shift.getResult()});
+      resultDesc.setAlignedPtr(rewriter, loc, shifted);
+      resultDesc.setConstantOffset(rewriter, loc, 0);
+    } else {
+      // A dynamic strided projection is pure descriptor arithmetic: the
+      // offset field is live to consumers, so the row shift lands there and
+      // the aligned pointer stays the payload.
+      resultDesc.setAlignedPtr(rewriter, loc,
+                               srcDesc.alignedPtr(rewriter, loc));
+      resultDesc.setOffset(rewriter, loc, shift);
+    }
 
     for (int64_t i = 0, e = resultMemRefType.getRank(); i < e; ++i) {
       resultDesc.setSize(rewriter, loc, i, srcDesc.size(rewriter, loc, i + 1));
@@ -3455,19 +3471,23 @@ struct ReussirRefMemcpyConversionPattern
         static_cast<const mlir::LLVMTypeConverter *>(getTypeConverter());
     auto dataLayout = getDataLayout(*converter, op.getOperation());
 
-    // Get the element type and its size
-    RefType srcType = op.getSrc().getType();
-    mlir::Type elementType = converter->convertType(srcType.getElementType());
-    size_t size = dataLayout.getTypeSize(elementType);
+    // The byte count: the `size` operand for a dynamically sized element (a
+    // dynamic-extent array payload), the element's static size otherwise.
+    mlir::Value sizeVal = adaptor.getSize();
+    if (!sizeVal) {
+      RefType srcType = op.getSrc().getType();
+      mlir::Type elementType = converter->convertType(srcType.getElementType());
+      size_t size = dataLayout.getTypeSize(elementType);
+      sizeVal = mlir::LLVM::ConstantOp::create(
+          rewriter, op.getLoc(), converter->getIndexType(),
+          rewriter.getIntegerAttr(converter->getIndexType(), size));
+    }
 
     // Create LLVM memcpy intrinsic (non-overlapping, so isVolatile = false).
     // The plain form, not memcpy.inline: with a constant length LLVM already
     // expands small copies to loads/stores and picks the best strategy
     // (expansion or libcall) for large ones — forcing inline expansion on a
     // big payload (e.g. a whole array clone) just unrolls it.
-    auto sizeVal = mlir::LLVM::ConstantOp::create(
-        rewriter, op.getLoc(), converter->getIndexType(),
-        rewriter.getIntegerAttr(converter->getIndexType(), size));
     rewriter.replaceOpWithNewOp<mlir::LLVM::MemcpyOp>(op, adaptor.getDst(),
                                                       adaptor.getSrc(), sizeVal,
                                                       /*isVolatile=*/false);

--- a/lib/Conversion/ClosureOutlining/ClosureOutlining.cpp
+++ b/lib/Conversion/ClosureOutlining/ClosureOutlining.cpp
@@ -451,7 +451,8 @@ mlir::func::FuncOp ClosureOutliningPass::createClosureCloneFunction(
   size_t size = dataLayout.getTypeSize(rcBoxType).getFixedValue();
   size_t align = dataLayout.getTypeABIAlignment(rcBoxType);
   TokenType tokenType = TokenType::get(rewriter.getContext(), align, size);
-  mlir::Value token = ReussirTokenAllocOp::create(rewriter, loc, tokenType);
+  mlir::Value token = ReussirTokenAllocOp::create(rewriter, loc, tokenType,
+                                  /*dynamicSize=*/mlir::Value());
 
   // Allocate assemble space on stack first
   mlir::Value dstRc = ReussirClosureInstantiateOp::create(

--- a/lib/Conversion/ConvertToSTD/ConvertToSTD.cpp
+++ b/lib/Conversion/ConvertToSTD/ConvertToSTD.cpp
@@ -849,11 +849,13 @@ struct ReussirArrayWithUniqueViewOpRewritePattern
       TokenType tokenType = TokenType::get(
           rewriter.getContext(), dataLayout.getTypeABIAlignment(rcBoxType),
           dataLayout.getTypeSize(rcBoxType).getFixedValue());
-      auto token = ReussirTokenAllocOp::create(rewriter, loc, tokenType);
+      auto token = ReussirTokenAllocOp::create(rewriter, loc, tokenType,
+                                  /*dynamicSize=*/mlir::Value());
       auto poison = mlir::ub::PoisonOp::create(rewriter, loc, arrayType);
       auto cloned = ReussirRcCreateOp::create(
           rewriter, loc, rcType, poison.getResult(), token.getResult(),
-          mlir::Value{}, mlir::FlatSymbolRefAttr{}, mlir::UnitAttr{});
+          mlir::Value{}, mlir::ValueRange{}, mlir::FlatSymbolRefAttr{},
+          mlir::UnitAttr{});
       auto dstRef = ReussirRcBorrowOp::create(rewriter, loc, borrowedType,
                                               cloned.getResult());
       ReussirRefMemcpyOp::create(rewriter, loc, srcRef.getResult(),
@@ -955,7 +957,8 @@ struct ReussirTokenEnsureOpRewritePattern
           rewriter.createBlock(&nullableDispatchOp.getNullRegion());
       rewriter.setInsertionPointToStart(elseBlock);
       auto allocatedToken =
-          ReussirTokenAllocOp::create(rewriter, op.getLoc(), op.getType());
+          ReussirTokenAllocOp::create(rewriter, op.getLoc(), op.getType(),
+                                      /*dynamicSize=*/mlir::Value());
       mlir::scf::YieldOp::create(rewriter, op.getLoc(),
                                  allocatedToken->getResults());
     }
@@ -1420,7 +1423,8 @@ public:
         mlir::ub::PoisonOp::create(rewriter, op.getLoc(), cellType);
     auto created = ReussirRcCreateOp::create(
         rewriter, op.getLoc(), op.getCell().getType(), poison, op.getToken(),
-        mlir::Value{}, mlir::FlatSymbolRefAttr{}, mlir::UnitAttr{});
+        mlir::Value{}, mlir::ValueRange{}, mlir::FlatSymbolRefAttr{},
+        mlir::UnitAttr{});
     CellAccess access = borrowCell(created.getRcPtr(), op.getLoc(), rewriter);
     if (cellType.getKind() == CellKind::mutex) {
       mlir::Value mutexView = getMutexView(access, op.getLoc(), rewriter);

--- a/lib/Conversion/ConvertToSTD/ConvertToSTD.cpp
+++ b/lib/Conversion/ConvertToSTD/ConvertToSTD.cpp
@@ -774,11 +774,6 @@ static void cloneArrayWithUniqueViewBody(ReussirArrayWithUniqueViewOp op,
   mlir::scf::YieldOp::create(rewriter, op.getLoc(), yieldedValues);
 }
 
-static mlir::MemRefType getArrayViewMemRefType(ArrayType arrayType) {
-  return mlir::MemRefType::get(arrayType.getShape(),
-                               arrayType.getElementType());
-}
-
 static mlir::Value
 materializeArrayViewValue(mlir::Location loc, mlir::PatternRewriter &rewriter,
                           ArrayType arrayType, mlir::Value ref,
@@ -818,6 +813,125 @@ struct ReussirArrayViewOpRewritePattern
   }
 };
 
+// The clone branch of `array.with_unique_view` for a dynamic-extent array
+// (docs/design/dynamic-extent-arrays.md, "Clone compacts"): the source's
+// strided header is read through `memref.extract_strided_metadata` on its
+// view, the clone is constructed canonical (offset 0, suffix-product
+// strides) from the same sizes with a runtime-sized token, and the payload
+// is copied as one flat `ref.memcpy` when the source is canonical too, or
+// through an element-wise loop nest that walks the source strides otherwise.
+// Returns the clone and the borrowed reference to its payload.
+static std::pair<mlir::Value, mlir::Value> cloneDynamicArrayPayload(
+    mlir::PatternRewriter &rewriter, mlir::Location loc, ArrayType arrayType,
+    RcType rcType, RcBoxType rcBoxType, const mlir::DataLayout &dataLayout,
+    mlir::Value srcRef) {
+  auto borrowedType = RefType::get(rewriter.getContext(), arrayType);
+  mlir::MemRefType viewType = getArrayViewMemRefType(arrayType);
+  auto srcView =
+      ReussirArrayViewOp::create(rewriter, loc, viewType, srcRef).getView();
+  auto metadata =
+      mlir::memref::ExtractStridedMetadataOp::create(rewriter, loc, srcView);
+  mlir::ValueRange sizes = metadata.getSizes();
+  mlir::ValueRange strides = metadata.getStrides();
+  int64_t rank = arrayType.getRank();
+
+  auto indexConst = [&](int64_t value) -> mlir::Value {
+    return mlir::arith::ConstantIndexOp::create(rewriter, loc, value);
+  };
+  auto mul = [&](mlir::Value a, mlir::Value b) -> mlir::Value {
+    return mlir::arith::MulIOp::create(rewriter, loc, a, b);
+  };
+
+  // Canonical suffix-product strides from the sizes; the product of all
+  // sizes falls out as `stride[0] * size[0]`.
+  llvm::SmallVector<mlir::Value> canonicalStrides(rank);
+  mlir::Value stride = indexConst(1);
+  for (int64_t i = rank - 1; i >= 0; --i) {
+    canonicalStrides[i] = stride;
+    stride = mul(stride, sizes[i]);
+  }
+  mlir::Value elementCount = stride;
+  mlir::Value payloadBytes =
+      mul(elementCount,
+          indexConst(dataLayout.getTypeSize(arrayType.getElementType())));
+  mlir::Value boxBytes = mlir::arith::AddIOp::create(
+      rewriter, loc, payloadBytes,
+      indexConst(rcBoxType.getDynamicPayloadOffset(dataLayout)));
+
+  TokenType tokenType = TokenType::getDynamic(
+      rewriter.getContext(), dataLayout.getTypeABIAlignment(rcBoxType));
+  auto token = ReussirTokenAllocOp::create(rewriter, loc, tokenType, boxBytes);
+  auto poison = mlir::ub::PoisonOp::create(rewriter, loc, arrayType);
+  llvm::SmallVector<mlir::Value> extents;
+  for (auto [dim, extent] : llvm::enumerate(arrayType.getShape()))
+    if (mlir::ShapedType::isDynamic(extent))
+      extents.push_back(sizes[dim]);
+  auto cloned = ReussirRcCreateOp::create(
+      rewriter, loc, rcType, poison.getResult(), token.getResult(),
+      mlir::Value{}, extents, mlir::FlatSymbolRefAttr{}, mlir::UnitAttr{});
+  mlir::Value dstRef = ReussirRcBorrowOp::create(rewriter, loc, borrowedType,
+                                                 cloned.getResult());
+
+  // Canonical source: offset 0 and suffix-product strides, so the payload is
+  // one contiguous run of `elementCount` elements.
+  mlir::Value canonical =
+      mlir::arith::CmpIOp::create(rewriter, loc, mlir::arith::CmpIPredicate::eq,
+                                  metadata.getOffset(), indexConst(0));
+  for (int64_t i = 0; i < rank; ++i) {
+    mlir::Value same = mlir::arith::CmpIOp::create(
+        rewriter, loc, mlir::arith::CmpIPredicate::eq, strides[i],
+        canonicalStrides[i]);
+    canonical = mlir::arith::AndIOp::create(rewriter, loc, canonical, same);
+  }
+
+  auto ifOp = mlir::scf::IfOp::create(rewriter, loc, canonical,
+                                      /*withElseRegion=*/true);
+  {
+    mlir::OpBuilder::InsertionGuard guard(rewriter);
+    rewriter.setInsertionPointToStart(ifOp.thenBlock());
+    ReussirRefMemcpyOp::create(rewriter, loc, srcRef, dstRef, payloadBytes);
+  }
+  {
+    mlir::OpBuilder::InsertionGuard guard(rewriter);
+    rewriter.setInsertionPointToStart(ifOp.elseBlock());
+    // Strided-to-canonical compaction: walk the logical index space and
+    // copy element by element; both sides project through their own
+    // descriptor, so the source strides and the clone's canonical strides
+    // are each honoured.
+    auto dstView =
+        ReussirArrayViewOp::create(rewriter, loc, viewType, dstRef).getView();
+    llvm::SmallVector<mlir::Value> lowerBounds(rank, indexConst(0));
+    llvm::SmallVector<mlir::Value> steps(rank, indexConst(1));
+    llvm::SmallVector<mlir::Value> upperBounds(sizes.begin(), sizes.end());
+    mlir::scf::buildLoopNest(
+        rewriter, loc, lowerBounds, upperBounds, steps,
+        [&](mlir::OpBuilder &bodyBuilder, mlir::Location bodyLoc,
+            mlir::ValueRange indices) {
+          RefType elementRefType =
+              RefType::get(bodyBuilder.getContext(), arrayType.getElementType(),
+                           Capability::unspecified);
+          auto projectElement = [&](mlir::Value view) -> mlir::Value {
+            for (mlir::Value index : indices) {
+              auto currentType = llvm::cast<mlir::MemRefType>(view.getType());
+              mlir::Type projectedType =
+                  currentType.getRank() == 1
+                      ? mlir::Type(elementRefType)
+                      : mlir::Type(getProjectedArrayViewType(currentType));
+              view = ReussirArrayProjectOp::create(bodyBuilder, bodyLoc,
+                                                   projectedType, view, index)
+                         .getProjected();
+            }
+            return view;
+          };
+          ReussirRefMemcpyOp::create(bodyBuilder, bodyLoc,
+                                     projectElement(srcView),
+                                     projectElement(dstView),
+                                     /*size=*/mlir::Value());
+        });
+  }
+  return {cloned.getResult(), dstRef};
+}
+
 struct ReussirArrayWithUniqueViewOpRewritePattern
     : public mlir::OpConversionPattern<ReussirArrayWithUniqueViewOp> {
   using OpConversionPattern::OpConversionPattern;
@@ -846,22 +960,26 @@ struct ReussirArrayWithUniqueViewOpRewritePattern
       RcBoxType rcBoxType = RcBoxType::get(rewriter.getContext(), arrayType,
                                            /*regional=*/false);
       auto dataLayout = mlir::DataLayout::closest(op.getOperation());
-      TokenType tokenType = TokenType::get(
-          rewriter.getContext(), dataLayout.getTypeABIAlignment(rcBoxType),
-          dataLayout.getTypeSize(rcBoxType).getFixedValue());
-      auto token = ReussirTokenAllocOp::create(rewriter, loc, tokenType,
-                                  /*dynamicSize=*/mlir::Value());
-      auto poison = mlir::ub::PoisonOp::create(rewriter, loc, arrayType);
-      auto cloned = ReussirRcCreateOp::create(
-          rewriter, loc, rcType, poison.getResult(), token.getResult(),
-          mlir::Value{}, mlir::ValueRange{}, mlir::FlatSymbolRefAttr{},
-          mlir::UnitAttr{});
-      auto dstRef = ReussirRcBorrowOp::create(rewriter, loc, borrowedType,
-                                              cloned.getResult());
-      ReussirRefMemcpyOp::create(rewriter, loc, srcRef.getResult(),
-                                 dstRef.getResult());
-      ReussirRefAcquireOp::create(rewriter, loc, dstRef.getResult(), false,
-                                  nullptr);
+      mlir::Value cloned, dstRef;
+      if (arrayType.hasStaticShape()) {
+        TokenType tokenType = TokenType::get(
+            rewriter.getContext(), dataLayout.getTypeABIAlignment(rcBoxType),
+            dataLayout.getTypeSize(rcBoxType).getFixedValue());
+        auto token = ReussirTokenAllocOp::create(rewriter, loc, tokenType,
+                                                 /*dynamicSize=*/mlir::Value());
+        auto poison = mlir::ub::PoisonOp::create(rewriter, loc, arrayType);
+        cloned = ReussirRcCreateOp::create(
+            rewriter, loc, rcType, poison.getResult(), token.getResult(),
+            mlir::Value{}, mlir::ValueRange{}, mlir::FlatSymbolRefAttr{},
+            mlir::UnitAttr{});
+        dstRef = ReussirRcBorrowOp::create(rewriter, loc, borrowedType, cloned);
+        ReussirRefMemcpyOp::create(rewriter, loc, srcRef.getResult(), dstRef,
+                                   /*size=*/mlir::Value());
+      } else {
+        std::tie(cloned, dstRef) = cloneDynamicArrayPayload(
+            rewriter, loc, arrayType, rcType, rcBoxType, dataLayout, srcRef);
+      }
+      ReussirRefAcquireOp::create(rewriter, loc, dstRef, false, nullptr);
 
       auto refCount = ReussirRcFetchOp::create(rewriter, loc, op.getArray());
       auto decremented = mlir::arith::SubIOp::create(
@@ -869,7 +987,7 @@ struct ReussirArrayWithUniqueViewOpRewritePattern
           mlir::arith::ConstantIndexOp::create(rewriter, loc, 1));
       ReussirRcSetOp::create(rewriter, loc, op.getArray(),
                              decremented.getResult());
-      return {cloned.getResult(), dstRef.getResult()};
+      return {cloned, dstRef};
     };
 
     auto isUnique =

--- a/lib/Conversion/TokenInstantiation/TokenInstantiation.cpp
+++ b/lib/Conversion/TokenInstantiation/TokenInstantiation.cpp
@@ -22,6 +22,7 @@
 #include "Reussir/IR/ReussirTypes.h"
 #include "Sync/IR/SyncDialect.h"
 
+#include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/IR/PatternMatch.h>
 #include <mlir/Pass/Pass.h>
@@ -60,8 +61,49 @@ struct TokenInstantiationPattern : public mlir::RewritePattern {
     // Create the token allocation operation before the current operation
     mlir::OpBuilder::InsertionGuard guard(rewriter);
     rewriter.setInsertionPoint(op);
-    auto allocOp =
-        ReussirTokenAllocOp::create(rewriter, op->getLoc(), tokenType);
+
+    // A dynamically sized token means a dynamic-extent array box: its byte
+    // size is `header + product(sizes) * elemsize`, assembled here from the
+    // construction's extent operands (canonical layout — offset 0, suffix
+    // strides — so the payload is exactly the element product).
+    mlir::Value dynamicSize;
+    if (tokenType.isDynamicSize()) {
+      auto rcCreate = dyn_cast<ReussirRcCreateOp>(op);
+      if (!rcCreate)
+        return op->emitOpError("cannot instantiate a dynamically sized token "
+                               "for this acceptor"),
+               mlir::failure();
+      auto arrayType = llvm::cast<ArrayType>(
+          rcCreate.getRcPtr().getType().getElementType());
+      auto boxType = rcCreate.getRcPtr().getType().getInnerBoxType();
+      mlir::DataLayout dataLayout = mlir::DataLayout::closest(op);
+      uint64_t payloadOffset = boxType.getDynamicPayloadOffset(dataLayout);
+      uint64_t elementSize =
+          dataLayout.getTypeSize(arrayType.getElementType());
+      mlir::Location loc = op->getLoc();
+      mlir::Value count;
+      size_t nextExtent = 0;
+      for (int64_t dim : arrayType.getShape()) {
+        mlir::Value factor =
+            mlir::ShapedType::isDynamic(dim)
+                ? rcCreate.getExtents()[nextExtent++]
+                : mlir::arith::ConstantIndexOp::create(rewriter, loc, dim)
+                      .getResult();
+        count = count ? mlir::arith::MulIOp::create(rewriter, loc, count,
+                                                    factor)
+                            .getResult()
+                      : factor;
+      }
+      mlir::Value elemBytes = mlir::arith::MulIOp::create(
+          rewriter, loc, count,
+          mlir::arith::ConstantIndexOp::create(rewriter, loc, elementSize));
+      dynamicSize = mlir::arith::AddIOp::create(
+          rewriter, loc, elemBytes,
+          mlir::arith::ConstantIndexOp::create(rewriter, loc, payloadOffset));
+    }
+
+    auto allocOp = ReussirTokenAllocOp::create(rewriter, op->getLoc(),
+                                               tokenType, dynamicSize);
 
     // Assign the token to the operation
     tokenAcceptor.assignToken(allocOp.getToken());

--- a/lib/Conversion/TypeConverter/TypeConverter.cpp
+++ b/lib/Conversion/TypeConverter/TypeConverter.cpp
@@ -317,8 +317,13 @@ void populateReussirToLLVMTypeConversions(mlir::LLVMTypeConverter &converter) {
                                                   {ptrTy, indexTy});
   });
 
-  converter.addConversion([&converter](ArrayType type) {
+  converter.addConversion([&converter](ArrayType type) -> mlir::Type {
     mlir::Type lowered = converter.convertType(type.getElementType());
+    // A dynamic-extent array has no LLVM array type; as a box payload it is
+    // the zero-length tail after the strided header (GEPs index it by
+    // element, never by whole-payload value).
+    if (!type.hasStaticShape())
+      return mlir::LLVM::LLVMArrayType::get(lowered, 0);
     for (int64_t extent : llvm::reverse(type.getShape()))
       lowered = mlir::LLVM::LLVMArrayType::get(lowered, extent);
     return lowered;

--- a/lib/IR/ReussirOps.cpp
+++ b/lib/IR/ReussirOps.cpp
@@ -85,6 +85,19 @@ namespace reussir {
 namespace {
 
 static mlir::MemRefType getArrayViewMemRefType(ArrayType arrayType) {
+  // A static array views as an identity-layout memref. A dynamic-extent
+  // array views as a strided memref with dynamic offset and strides — the
+  // box header carries the full strided encoding
+  // (docs/design/dynamic-extent-arrays.md), and static dims stay static in
+  // the shape while the layout is uniformly dynamic.
+  if (!arrayType.hasStaticShape()) {
+    auto layout = mlir::StridedLayoutAttr::get(
+        arrayType.getContext(), mlir::ShapedType::kDynamic,
+        llvm::SmallVector<int64_t>(arrayType.getRank(),
+                                   mlir::ShapedType::kDynamic));
+    return mlir::MemRefType::get(arrayType.getShape(),
+                                 arrayType.getElementType(), layout);
+  }
   return mlir::MemRefType::get(arrayType.getShape(),
                                arrayType.getElementType());
 }
@@ -129,7 +142,7 @@ static mlir::LogicalResult verifyArrayViewType(mlir::Operation *op,
   }
 
   return op->emitOpError(valueName)
-         << " must be a statically shaped memref or tensor";
+         << " must be a memref or tensor of the array's shape";
 }
 
 static mlir::FailureOr<CellType> verifySharedCellOperand(mlir::Operation *op,
@@ -313,6 +326,15 @@ mlir::LogicalResult verifyHoleFields(mlir::Operation *op,
 // ReussirTokenReinterpretOp
 //===----------------------------------------------------------------------===//
 // ReinterpretOp verification
+mlir::LogicalResult ReussirTokenAllocOp::verify() {
+  bool dynamicToken = getToken().getType().isDynamicSize();
+  if (dynamicToken != static_cast<bool>(getDynamicSize()))
+    return emitOpError(dynamicToken
+                           ? "a dynamically sized token requires a size operand"
+                           : "a statically sized token takes no size operand");
+  return mlir::success();
+}
+
 mlir::LogicalResult ReussirTokenReinterpretOp::verify() {
   TokenType tokenType = getToken().getType();
   RefType resultType = getReinterpreted().getType();
@@ -382,19 +404,30 @@ mlir::LogicalResult ReussirRcReinterpretOp::verify() {
   // Get the RC box type for the RC pointer
   RcBoxType rcBoxType = rcType.getInnerBoxType();
 
-  // Get the data layout to compute alignment and size
+  // Get the data layout to compute alignment
   auto dataLayout = mlir::DataLayout::closest(getOperation());
   auto alignment = dataLayout.getTypeABIAlignment(rcBoxType);
-  auto size = dataLayout.getTypeSize(rcBoxType);
-
-  if (!size.isFixed())
-    return emitOpError("RC box type must have a fixed size");
 
   // Check that token alignment matches RC box alignment
   if (tokenType.getAlign() != alignment)
     return emitOpError("token alignment must match RC box alignment, ")
            << "token alignment: " << tokenType.getAlign()
            << ", RC box alignment: " << alignment;
+
+  // A dynamic-extent array box has no static size (checked before any size
+  // query — the box's size is not computable); its decrement reinterprets it
+  // as a dynamic token, which the size-recovering allocator frees or
+  // resizes from the pointer alone.
+  if (rcBoxType.hasDynamicArrayPayload())
+    return tokenType.isDynamicSize()
+               ? mlir::success()
+               : emitOpError("a dynamic-extent array box reinterprets as a "
+                             "dynamically sized token");
+
+  auto size = dataLayout.getTypeSize(rcBoxType);
+
+  if (!size.isFixed())
+    return emitOpError("RC box type must have a fixed size");
 
   // Check that token size matches RC box size. Under per-constructor box
   // sizing a fused-header variant box may be any arm's cell: a
@@ -665,6 +698,11 @@ TokenType ReussirRcDecOp::getTokenType() {
     }
     return TokenType::getDynamic(getContext(), alignment);
   }
+  // A dynamic-extent array box has no static size (the strided header
+  // carries the shape); its token is dynamic and the size-recovering
+  // allocator frees/resizes it from the pointer alone.
+  if (rcBoxType.hasDynamicArrayPayload())
+    return TokenType::getDynamic(getContext(), alignment);
   auto size = dataLayout.getTypeSize(rcBoxType);
 
   return TokenType::get(getContext(), alignment, size.getFixedValue());
@@ -701,6 +739,20 @@ ReussirRcDecOp::replaceWithProduced(mlir::PatternRewriter &builder) {
 // RcCreateOp verification
 //===----------------------------------------------------------------------===//
 mlir::LogicalResult ReussirRcCreateOp::verify() {
+  // A dynamic-extent array construction supplies one runtime extent per
+  // dynamic dimension (in dimension order); construction is canonical
+  // (offset 0, row-major suffix strides), written into the strided header.
+  size_t expectedExtents = 0;
+  if (auto arrayType =
+          llvm::dyn_cast<ArrayType>(getRcPtr().getType().getElementType());
+      arrayType && !arrayType.hasStaticShape())
+    expectedExtents = llvm::count_if(arrayType.getShape(), [](int64_t d) {
+      return mlir::ShapedType::isDynamic(d);
+    });
+  if (getExtents().size() != expectedExtents)
+    return emitOpError("expects ")
+           << expectedExtents << " extent operand(s), got "
+           << getExtents().size();
   return verifyRcCreateLikeOp(getOperation(), getRcPtr().getType(),
                               getValue().getType(), getToken(), getRegion());
 }
@@ -730,6 +782,10 @@ TokenType ReussirRcCreateOp::getTokenType() {
       return TokenType::get(getContext(), alignment, armSize.getFixedValue());
     }
   }
+  // A dynamic-extent array box is dynamically sized; the instantiation pass
+  // computes `header + product(sizes) * elemsize` from the extents.
+  if (rcBoxType.hasDynamicArrayPayload())
+    return TokenType::getDynamic(getContext(), alignment);
   auto size = dataLayout.getTypeSize(rcBoxType);
   return TokenType::get(getContext(), alignment, size.getFixedValue());
 }

--- a/lib/IR/ReussirOps.cpp
+++ b/lib/IR/ReussirOps.cpp
@@ -32,6 +32,7 @@
 #include <llvm/Support/raw_ostream.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/Dialect/LLVMIR/LLVMAttrs.h>
+#include <mlir/Dialect/MemRef/IR/MemRef.h>
 #include <mlir/Dialect/SCF/IR/SCF.h>
 #include <mlir/IR/Attributes.h>
 #include <mlir/IR/Builders.h>
@@ -82,24 +83,51 @@ static void printCompiledModule(mlir::OpAsmPrinter &printer,
 #include "Reussir/IR/ReussirOps.cpp.inc"
 
 namespace reussir {
-namespace {
 
-static mlir::MemRefType getArrayViewMemRefType(ArrayType arrayType) {
+// The uniformly dynamic strided layout of a dynamic-extent array view: the
+// offset and every stride are loaded from the box header.
+static mlir::StridedLayoutAttr getDynamicStridedLayout(mlir::MLIRContext *ctx,
+                                                       int64_t rank) {
+  return mlir::StridedLayoutAttr::get(
+      ctx, mlir::ShapedType::kDynamic,
+      llvm::SmallVector<int64_t>(rank, mlir::ShapedType::kDynamic));
+}
+
+mlir::MemRefType getArrayViewMemRefType(ArrayType arrayType) {
   // A static array views as an identity-layout memref. A dynamic-extent
   // array views as a strided memref with dynamic offset and strides — the
   // box header carries the full strided encoding
   // (docs/design/dynamic-extent-arrays.md), and static dims stay static in
   // the shape while the layout is uniformly dynamic.
-  if (!arrayType.hasStaticShape()) {
-    auto layout = mlir::StridedLayoutAttr::get(
-        arrayType.getContext(), mlir::ShapedType::kDynamic,
-        llvm::SmallVector<int64_t>(arrayType.getRank(),
-                                   mlir::ShapedType::kDynamic));
-    return mlir::MemRefType::get(arrayType.getShape(),
-                                 arrayType.getElementType(), layout);
-  }
+  if (!arrayType.hasStaticShape())
+    return mlir::MemRefType::get(
+        arrayType.getShape(), arrayType.getElementType(),
+        getDynamicStridedLayout(arrayType.getContext(), arrayType.getRank()));
   return mlir::MemRefType::get(arrayType.getShape(),
                                arrayType.getElementType());
+}
+
+mlir::MemRefType getProjectedArrayViewType(mlir::MemRefType viewType) {
+  llvm::ArrayRef<int64_t> shape = viewType.getShape().drop_front();
+  if (viewType.getLayout().isIdentity())
+    return mlir::MemRefType::get(shape, viewType.getElementType());
+  return mlir::MemRefType::get(
+      shape, viewType.getElementType(),
+      getDynamicStridedLayout(viewType.getContext(), shape.size()));
+}
+
+namespace {
+
+// Whether `type` is a memref an array view or a projection of one can carry:
+// a statically shaped identity-layout memref (static arrays) or a memref of
+// any shape under the uniformly dynamic strided layout (dynamic-extent
+// arrays and their projections — the remaining shape may be static while
+// the strides stay runtime values).
+static bool isArrayViewMemRefType(mlir::MemRefType type) {
+  if (type.getLayout().isIdentity())
+    return type.hasStaticShape();
+  return type.getLayout() ==
+         getDynamicStridedLayout(type.getContext(), type.getRank());
 }
 
 static mlir::RankedTensorType getArrayViewTensorType(ArrayType arrayType) {
@@ -1265,11 +1293,13 @@ mlir::LogicalResult ReussirArrayViewOp::verify() {
 mlir::LogicalResult ReussirArrayProjectOp::verify() {
   auto memrefType = llvm::dyn_cast<mlir::MemRefType>(getView().getType());
   if (!memrefType)
-    return emitOpError(
-        "array.project input must be a statically shaped memref");
-  if (!memrefType.hasStaticShape() || !memrefType.getLayout().isIdentity())
-    return emitOpError("array.project input memref must have a static "
-                       "identity-layout type");
+    return emitOpError("array.project input must be an array view memref");
+  if (!isArrayViewMemRefType(memrefType))
+    return emitOpError("array.project input memref must be an array view: a "
+                       "statically shaped identity-layout memref or a memref "
+                       "with the dynamic strided layout of a dynamic-extent "
+                       "array view, got ")
+           << memrefType;
   ArrayType arrayType = ArrayType::get(getContext(), memrefType.getShape(),
                                        memrefType.getElementType());
   if (arrayType.getRank() == 0)
@@ -1296,10 +1326,10 @@ mlir::LogicalResult ReussirArrayProjectOp::verify() {
       llvm::dyn_cast<mlir::MemRefType>(getProjected().getType());
   if (!projectedMemRefType)
     return emitOpError("projecting a non-final array dimension must produce "
-                       "another statically shaped memref");
-  if (projectedMemRefType != getArrayViewMemRefType(arrayType.dropFront()))
+                       "another memref");
+  if (projectedMemRefType != getProjectedArrayViewType(memrefType))
     return emitOpError("projected subview type mismatch: expected ")
-           << getArrayViewMemRefType(arrayType.dropFront()) << ", got "
+           << getProjectedArrayViewType(memrefType) << ", got "
            << projectedMemRefType;
   return mlir::success();
 }
@@ -1936,6 +1966,18 @@ mlir::LogicalResult ReussirRefMemcpyOp::verify() {
                "source and destination element types must be identical, ")
            << "source element type: " << srcType.getElementType()
            << ", destination element type: " << dstType.getElementType();
+
+  // The byte count is static unless the element has no static size — a
+  // dynamic-extent array payload — in which case it is the `size` operand.
+  auto arrayType = llvm::dyn_cast<ArrayType>(srcType.getElementType());
+  bool dynamicallySized = arrayType && !arrayType.hasStaticShape();
+  if (dynamicallySized && !getSize())
+    return emitOpError("copying a dynamic-extent array payload requires the "
+                       "`size` operand");
+  if (!dynamicallySized && getSize())
+    return emitOpError("the `size` operand is only for a dynamic-extent "
+                       "array payload; ")
+           << srcType.getElementType() << " has a static size";
 
   return mlir::success();
 }
@@ -3324,7 +3366,10 @@ mlir::LogicalResult emitArrayElementTraversal(
   ArrayType arrayType = ArrayType::get(
       builder.getContext(), viewType.getShape(), viewType.getElementType());
 
-  if (viewType.getNumElements() <= kArrayOwnershipUnrollThreshold) {
+  // Only a static shape has an element count to unroll by; a dynamic one
+  // always loops, with its extents loaded from the box header.
+  if (viewType.hasStaticShape() &&
+      viewType.getNumElements() <= kArrayOwnershipUnrollThreshold) {
     auto emitDimension =
         [&](auto &&self, mlir::Value currentView, ArrayType currentType,
             mlir::OpBuilder &currentBuilder) -> mlir::LogicalResult {
@@ -3344,7 +3389,9 @@ mlir::LogicalResult emitArrayElementTraversal(
         } else {
           ArrayType nestedType = currentType.dropFront();
           auto nestedView = ReussirArrayProjectOp::create(
-              currentBuilder, loc, getArrayViewMemRefType(nestedType),
+              currentBuilder, loc,
+              getProjectedArrayViewType(
+                  llvm::cast<mlir::MemRefType>(currentView.getType())),
               currentView, indexValue);
           if (mlir::failed(self(self, nestedView.getProjected(), nestedType,
                                 currentBuilder)))
@@ -3362,9 +3409,14 @@ mlir::LogicalResult emitArrayElementTraversal(
   llvm::SmallVector<mlir::Value> upperBounds;
   llvm::SmallVector<mlir::Value> steps(arrayType.getRank(), step);
   upperBounds.reserve(arrayType.getRank());
-  for (int64_t extent : arrayType.getShape())
+  for (auto [dim, extent] : llvm::enumerate(arrayType.getShape()))
     upperBounds.push_back(
-        mlir::arith::ConstantIndexOp::create(builder, loc, extent));
+        mlir::ShapedType::isDynamic(extent)
+            ? mlir::memref::DimOp::create(builder, loc, view,
+                                          static_cast<int64_t>(dim))
+                  .getResult()
+            : mlir::arith::ConstantIndexOp::create(builder, loc, extent)
+                  .getResult());
 
   mlir::LogicalResult bodyResult = mlir::success();
   mlir::scf::buildLoopNest(
@@ -3386,7 +3438,9 @@ mlir::LogicalResult emitArrayElementTraversal(
             currentType = currentType.dropFront();
             currentView =
                 ReussirArrayProjectOp::create(
-                    bodyBuilder, bodyLoc, getArrayViewMemRefType(currentType),
+                    bodyBuilder, bodyLoc,
+                    getProjectedArrayViewType(
+                        llvm::cast<mlir::MemRefType>(currentView.getType())),
                     currentView, index)
                     .getProjected();
           }

--- a/lib/IR/ReussirTypes.cpp
+++ b/lib/IR/ReussirTypes.cpp
@@ -1010,6 +1010,14 @@ RcType::verify(llvm::function_ref<::mlir::InFlightDiagnostic()> emitError,
     return mlir::failure();
   }
 
+  // The strided array header currently extends only the shared RC header.
+  // Regional boxes use their header words for state, next, and the vtable.
+  if (auto arrayTy = llvm::dyn_cast<ArrayType>(eleTy);
+      arrayTy && !arrayTy.hasStaticShape() && capability != Capability::shared) {
+    emitError() << "dynamic-extent arrays require shared RC capability";
+    return mlir::failure();
+  }
+
   // An atomic scalar or lock-guarded cell only exists to be shared across
   // threads, so the box managing it must itself be shared with an atomic
   // refcount.
@@ -1338,6 +1346,15 @@ RefType::verify(llvm::function_ref<::mlir::InFlightDiagnostic()> emitError,
     emitError() << "Capability must not be Value for RefType";
     return mlir::failure();
   }
+  // A dynamic array view recovers the shared strided header from its payload
+  // reference. Regional payloads have a different header and offset.
+  if (auto arrayTy = llvm::dyn_cast<ArrayType>(eleTy);
+      arrayTy && !arrayTy.hasStaticShape() &&
+      (capability == Capability::flex || capability == Capability::rigid ||
+       capability == Capability::regional)) {
+    emitError() << "dynamic-extent arrays do not support regional references";
+    return mlir::failure();
+  }
   return mlir::success();
 }
 
@@ -1362,6 +1379,17 @@ CctxType::verify(llvm::function_ref<::mlir::InFlightDiagnostic()> emitError,
 //===----------------------------------------------------------------------===//
 // Reussir Rc Box Type
 //===----------------------------------------------------------------------===//
+mlir::LogicalResult
+RcBoxType::verify(llvm::function_ref<::mlir::InFlightDiagnostic()> emitError,
+                  mlir::Type eleTy, bool regional) {
+  if (auto arrayTy = llvm::dyn_cast<ArrayType>(eleTy);
+      regional && arrayTy && !arrayTy.hasStaticShape()) {
+    emitError() << "dynamic-extent arrays do not support regional boxes";
+    return mlir::failure();
+  }
+  return mlir::success();
+}
+
 // RcBoxType Parse/Print
 //===----------------------------------------------------------------------===//
 mlir::Type RcBoxType::parse(mlir::AsmParser &parser) {

--- a/lib/IR/ReussirTypes.cpp
+++ b/lib/IR/ReussirTypes.cpp
@@ -149,24 +149,34 @@ parseShapeAndElementType(mlir::AsmParser &parser,
     shape.push_back(extent.getSExtValue());
     return mlir::success();
   };
+  // An extent is an integer or `?` for a dynamic dimension
+  // (`ShapedType::kDynamic`), mirroring the memref spelling.
+  auto parseOptionalExtent = [&]() -> mlir::OptionalParseResult {
+    if (mlir::succeeded(parser.parseOptionalQuestion())) {
+      shape.push_back(mlir::ShapedType::kDynamic);
+      return mlir::success();
+    }
+    llvm::APInt extent;
+    mlir::OptionalParseResult parsed = parser.parseOptionalInteger(extent);
+    if (!parsed.has_value())
+      return std::nullopt;
+    if (mlir::failed(*parsed))
+      return mlir::failure();
+    return appendExtent(extent);
+  };
 
-  llvm::APInt extent;
-  if (parser.parseInteger(extent))
-    return mlir::failure();
-  if (mlir::failed(appendExtent(extent)))
-    return mlir::failure();
-
-  if (parser.parseKeyword("x"))
+  mlir::OptionalParseResult first = parseOptionalExtent();
+  if (!first.has_value())
+    return parser.emitError(parser.getCurrentLocation(),
+                            "expected an array extent (an integer or `?`)");
+  if (mlir::failed(*first) || parser.parseKeyword("x"))
     return mlir::failure();
 
   while (true) {
-    llvm::APInt nextExtent;
-    mlir::OptionalParseResult parseNextExtent =
-        parser.parseOptionalInteger(nextExtent);
+    mlir::OptionalParseResult parseNextExtent = parseOptionalExtent();
     if (!parseNextExtent.has_value())
       break;
-    if (mlir::failed(*parseNextExtent) ||
-        mlir::failed(appendExtent(nextExtent)) || parser.parseKeyword("x"))
+    if (mlir::failed(*parseNextExtent) || parser.parseKeyword("x"))
       return mlir::failure();
   }
   return parser.parseType(elementType);
@@ -175,8 +185,13 @@ parseShapeAndElementType(mlir::AsmParser &parser,
 void printShapeAndElementType(mlir::AsmPrinter &printer,
                               llvm::ArrayRef<int64_t> shape,
                               mlir::Type elementType) {
-  for (int64_t extent : shape)
-    printer << extent << " x ";
+  for (int64_t extent : shape) {
+    if (mlir::ShapedType::isDynamic(extent))
+      printer << "?";
+    else
+      printer << extent;
+    printer << " x ";
+  }
   printer.printType(elementType);
 }
 } // namespace
@@ -660,7 +675,44 @@ llvm::SmallVector<mlir::Type> RcBoxType::getHeaderTypes() const {
     auto ptrTy = mlir::LLVM::LLVMPointerType::get(getContext());
     return {ptrTy, ptrTy, ptrTy};
   }
+  // A dynamic-extent array box stores the full strided-memref encoding —
+  // exactly what `memref.extract_strided_metadata` returns, minus the base
+  // pointer: offset, then one size and one stride per dimension, all
+  // index-typed so the width follows the target's data layout.
+  if (auto arrayTy = llvm::dyn_cast<ArrayType>(getEleTy());
+      arrayTy && !arrayTy.hasStaticShape()) {
+    llvm::SmallVector<mlir::Type> header;
+    auto indexTy = mlir::IndexType::get(getContext());
+    header.push_back(mlir::IntegerType::get(getContext(), 32));
+    header.push_back(indexTy); // offset
+    for (size_t i = 0, rank = arrayTy.getRank(); i < 2 * rank; ++i)
+      header.push_back(indexTy); // sizes, then strides
+    return header;
+  }
   return {mlir::IntegerType::get(getContext(), 32)};
+}
+
+bool RcBoxType::hasDynamicArrayPayload() const {
+  auto arrayTy = llvm::dyn_cast<ArrayType>(getEleTy());
+  return arrayTy && !arrayTy.hasStaticShape();
+}
+
+uint64_t
+RcBoxType::getDynamicPayloadOffset(const mlir::DataLayout &dataLayout) const {
+  assert(hasDynamicArrayPayload() &&
+         "payload offset is the strided-header layout's; static boxes use "
+         "deriveLayoutForRcBox");
+  uint64_t offset = 0;
+  uint64_t align = 1;
+  for (mlir::Type header : getHeaderTypes()) {
+    uint64_t memberAlign = dataLayout.getTypeABIAlignment(header);
+    offset = llvm::alignTo(offset, memberAlign);
+    offset += dataLayout.getTypeSize(header);
+    align = std::max(align, memberAlign);
+  }
+  uint64_t elemAlign = dataLayout.getTypeABIAlignment(
+      llvm::cast<ArrayType>(getEleTy()).getElementType());
+  return llvm::alignTo(offset, std::max(align, elemAlign));
 }
 
 bool RecordType::hasFusedHeader() const {
@@ -1363,6 +1415,9 @@ RcBoxType::getTypeSizeInBits(const mlir::DataLayout &dataLayout,
   // overlays the element's leading count slot.
   if (isHeaderFused())
     return dataLayout.getTypeSizeInBits(getElementType());
+  assert(!hasDynamicArrayPayload() &&
+         "a dynamic-array box has no static size; the allocation computes "
+         "header + product(sizes) * elemsize at runtime");
   auto derived = deriveLayoutForRcBox(*this, dataLayout);
   if (!derived)
     llvm_unreachable("RcBoxType must have a fixed size");
@@ -1373,6 +1428,15 @@ uint64_t RcBoxType::getABIAlignment(const mlir::DataLayout &dataLayout,
                                     mlir::DataLayoutEntryListRef params) const {
   if (isHeaderFused())
     return dataLayout.getTypeABIAlignment(getElementType());
+  if (hasDynamicArrayPayload()) {
+    // max over the header members (index-heavy) and the element type; the
+    // shape never affects alignment.
+    uint64_t align = dataLayout.getTypeABIAlignment(
+        llvm::cast<ArrayType>(getEleTy()).getElementType());
+    for (mlir::Type header : getHeaderTypes())
+      align = std::max(align, dataLayout.getTypeABIAlignment(header));
+    return align;
+  }
   auto derived = deriveLayoutForRcBox(*this, dataLayout);
   if (!derived)
     llvm_unreachable("RcBoxType must have a fixed alignment");
@@ -1448,8 +1512,8 @@ ArrayType::verify(llvm::function_ref<::mlir::InFlightDiagnostic()> emitError,
     return mlir::failure();
   }
   for (int64_t extent : shape) {
-    if (extent < 0) {
-      emitError() << "array extents must be non-negative";
+    if (extent < 0 && !mlir::ShapedType::isDynamic(extent)) {
+      emitError() << "array extents must be non-negative or `?`";
       return mlir::failure();
     }
   }
@@ -1491,6 +1555,9 @@ void ArrayType::print(mlir::AsmPrinter &printer) const {
 llvm::TypeSize
 ArrayType::getTypeSizeInBits(const mlir::DataLayout &dataLayout,
                              mlir::DataLayoutEntryListRef params) const {
+  assert(hasStaticShape() &&
+         "a dynamic-extent array has no static size; its box carries the "
+         "strided-header layout instead");
   llvm::TypeSize elementSize = dataLayout.getTypeSize(getElementType());
   uint64_t totalElements = 1;
   for (int64_t extent : getShape())

--- a/lib/Transformation/TokenReuse/TokenReuse.cpp
+++ b/lib/Transformation/TokenReuse/TokenReuse.cpp
@@ -120,8 +120,16 @@ namespace {
 static constexpr int kReallocEnsureCutoff = 2;
 int heuristic(TokenType producedType, mlir::TypedValue<RcType> producerRc,
               TokenAcceptor consumer, EquivalenceAnalysis &equivalence) {
+  TokenType consumerType = consumer.getTokenType();
+  // Ensure/realloc encode the requested size in their result type, so they
+  // cannot preserve a dynamic allocation's SSA byte count. In particular,
+  // equal dynamic token types do not imply equal allocation sizes. Keep the
+  // original allocation until those operations support runtime-sized targets.
+  if (consumerType.isDynamicSize())
+    return -1;
+
   // Under perfect match, we measure the locality score.
-  if (producedType == consumer.getTokenType()) {
+  if (producedType == consumerType) {
     ReussirRcCreateOp create =
         dyn_cast<ReussirRcCreateOp>(consumer.getOperation());
     int localityScore = kReallocEnsureCutoff;
@@ -168,12 +176,11 @@ int heuristic(TokenType producedType, mlir::TypedValue<RcType> producerRc,
     return localityScore;
   }
   // A dynamic token (`token<align, ?>`, an unpinned variant decrement) can be
-  // resized to any acceptor at runtime via realloc — a universal *fallback*
+  // resized to a static acceptor at runtime via realloc — a universal *fallback*
   // donor. It scores below both the ensure tier and the fixed-size same-bin
   // realloc tier, so it is chosen only when no statically-sized donor fits.
   if (producedType.isDynamicSize())
     return 0;
-  TokenType consumerType = consumer.getTokenType();
   size_t oldSize = producedType.getSize();
   size_t newSize = consumerType.getSize();
   size_t oldAlign = producedType.getAlign();

--- a/tests/integration/basic/failure/dynamic_array_regional.mlir
+++ b/tests/integration/basic/failure/dynamic_array_regional.mlir
@@ -1,0 +1,43 @@
+// RUN: %reussir-opt %s --split-input-file --verify-diagnostics
+
+// Regional boxes have state/next/vtable fields instead of the shared
+// strided header. Reject both construction types and borrowed references.
+module {
+  // expected-error @+1 {{dynamic-extent arrays require shared RC capability}}
+  func.func private @flex() -> !reussir.rc<!reussir.array<? x i32> flex>
+}
+
+// -----
+
+module {
+  // expected-error @+1 {{dynamic-extent arrays require shared RC capability}}
+  func.func private @rigid() -> !reussir.rc<!reussir.array<2 x ? x i32> rigid>
+}
+
+// -----
+
+module {
+  // expected-error @+1 {{dynamic-extent arrays do not support regional references}}
+  func.func private @flex_ref(!reussir.ref<!reussir.array<? x i32> flex>)
+}
+
+// -----
+
+module {
+  // expected-error @+1 {{dynamic-extent arrays do not support regional references}}
+  func.func private @rigid_ref(!reussir.ref<!reussir.array<? x i32> rigid>)
+}
+
+// -----
+
+module {
+  // expected-error @+1 {{dynamic-extent arrays do not support regional references}}
+  func.func private @regional_ref(!reussir.ref<!reussir.array<? x i32> regional>)
+}
+
+// -----
+
+module {
+  // expected-error @+1 {{dynamic-extent arrays do not support regional boxes}}
+  func.func private @box(!reussir.rc_box<regional !reussir.array<? x i32>>)
+}

--- a/tests/integration/conversion/dynamic_array_clone_e2e.mlir
+++ b/tests/integration/conversion/dynamic_array_clone_e2e.mlir
@@ -1,0 +1,94 @@
+// RUN: %reussir-opt %s \
+// RUN:   --pass-pipeline='builtin.module(reussir-attach-native-target,func.func(reussir-token-instantiation),reussir-closure-outlining,reussir-lowering-region-patterns,func.func(reussir-inc-dec-cancellation),reussir-rc-decrement-expansion,func.func(reussir-infer-variant-tag),reussir-acquire-drop-expansion,reussir-convert-to-std,func.func(reussir-inc-dec-cancellation),reussir-acquire-drop-expansion{expand-decrement=1 outline-record=1},func.func(reussir-token-reuse),reussir-convert-to-std,func.func(reussir-rc-create-sink),func.func(reussir-rc-create-fusion),reussir-trmc-recursion-analysis,reussir-compile-polymorphic-ffi,canonicalize,cse,control-flow-sink,convert-scf-to-cf,reussir-lowering-basic-ops,convert-to-llvm,reconcile-unrealized-casts,cse,canonicalize)' \
+// RUN:   -o %t.mlir
+// RUN: %reussir-translate --mlir-to-llvmir %t.mlir | %opt -S -O2 -o %t.ll
+// RUN: %llc %t.ll -relocation-model=pic -filetype=obj -o %t.o
+// RUN: %cc %t.o -o %t.exe -L%library_path -lreussir_rt \
+// RUN:   %rpath_flag %extra_sys_libs
+// RUN: %t.exe
+
+// Executable proof of the dynamic-extent clone branch of
+// `array.with_unique_view` (docs/design/dynamic-extent-arrays.md, "Clone
+// compacts"): a shared [0, 1, ..., n-1] is updated through a unique view, so
+// the box is cloned with a runtime-sized token and a runtime-length payload
+// copy. The source must keep its sum (45) and the clone carry the update
+// (145); both boxes are released through their dynamic tokens.
+!dv = !reussir.array<? x i32>
+!rc_dv = !reussir.rc<!dv>
+module {
+  func.func private @iota(%n: index) -> !rc_dv attributes {llvm.linkage = #llvm.linkage<internal>} {
+    %poison = ub.poison : !dv
+    %rc = reussir.rc.create value(%poison : !dv) extents(%n) : !rc_dv
+    %ref = reussir.rc.borrow (%rc : !rc_dv) : !reussir.ref<!dv>
+    %v = reussir.array.view(%ref : !reussir.ref<!dv>) : memref<?xi32, strided<[?], offset: ?>>
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    scf.for %i = %c0 to %n step %c1 {
+      %iv = arith.index_cast %i : index to i32
+      memref.store %iv, %v[%i] : memref<?xi32, strided<[?], offset: ?>>
+    }
+    return %rc : !rc_dv
+  }
+
+  func.func private @sum(%rc: !rc_dv) -> i32 attributes {llvm.linkage = #llvm.linkage<internal>} {
+    %ref = reussir.rc.borrow (%rc : !rc_dv) : !reussir.ref<!dv>
+    %v = reussir.array.view(%ref : !reussir.ref<!dv>) : memref<?xi32, strided<[?], offset: ?>>
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %n = memref.dim %v, %c0 : memref<?xi32, strided<[?], offset: ?>>
+    %c0i = arith.constant 0 : i32
+    %s = scf.for %i = %c0 to %n step %c1 iter_args(%acc = %c0i) -> i32 {
+      %x = memref.load %v[%i] : memref<?xi32, strided<[?], offset: ?>>
+      %a = arith.addi %acc, %x : i32
+      scf.yield %a : i32
+    }
+    return %s : i32
+  }
+
+  func.func private @set0(%rc: !rc_dv, %value: i32) -> !rc_dv attributes {llvm.linkage = #llvm.linkage<internal>} {
+    %updated = reussir.array.with_unique_view (%rc : !rc_dv) -> !rc_dv {
+      ^bb0(%view: memref<?xi32, strided<[?], offset: ?>>):
+        %c0 = arith.constant 0 : index
+        memref.store %value, %view[%c0] : memref<?xi32, strided<[?], offset: ?>>
+        reussir.scf.yield
+    }
+    return %updated : !rc_dv
+  }
+
+  func.func @main() -> i32 {
+    %c10 = arith.constant 10 : index
+    %c100 = arith.constant 100 : i32
+    %c45 = arith.constant 45 : i32
+    %c145 = arith.constant 145 : i32
+
+    %shared = func.call @iota(%c10) : (index) -> !rc_dv
+    reussir.rc.inc (%shared : !rc_dv)
+    %updated = func.call @set0(%shared, %c100) : (!rc_dv, i32) -> !rc_dv
+
+    %original_sum = func.call @sum(%shared) : (!rc_dv) -> i32
+    %original_bad = arith.cmpi ne, %original_sum, %c45 : i32
+    scf.if %original_bad {
+      reussir.panic "shared dynamic array was mutated through the clone"
+    }
+    %updated_sum = func.call @sum(%updated) : (!rc_dv) -> i32
+    %updated_bad = arith.cmpi ne, %updated_sum, %c145 : i32
+    scf.if %updated_bad {
+      reussir.panic "dynamic array clone did not carry the update"
+    }
+    reussir.rc.dec (%shared : !rc_dv)
+    reussir.rc.dec (%updated : !rc_dv)
+
+    // A unique array is updated in place: no clone, same box.
+    %unique = func.call @iota(%c10) : (index) -> !rc_dv
+    %unique_updated = func.call @set0(%unique, %c100) : (!rc_dv, i32) -> !rc_dv
+    %unique_sum = func.call @sum(%unique_updated) : (!rc_dv) -> i32
+    %unique_bad = arith.cmpi ne, %unique_sum, %c145 : i32
+    scf.if %unique_bad {
+      reussir.panic "unique dynamic array update did not persist"
+    }
+    reussir.rc.dec (%unique_updated : !rc_dv)
+
+    %c0 = arith.constant 0 : i32
+    return %c0 : i32
+  }
+}

--- a/tests/integration/conversion/dynamic_array_e2e.mlir
+++ b/tests/integration/conversion/dynamic_array_e2e.mlir
@@ -1,0 +1,51 @@
+// RUN: %reussir-opt %s \
+// RUN:   --pass-pipeline='builtin.module(reussir-attach-native-target,func.func(reussir-token-instantiation),reussir-closure-outlining,reussir-lowering-region-patterns,func.func(reussir-inc-dec-cancellation),reussir-rc-decrement-expansion,func.func(reussir-infer-variant-tag),reussir-acquire-drop-expansion,reussir-convert-to-std,func.func(reussir-inc-dec-cancellation),reussir-acquire-drop-expansion{expand-decrement=1 outline-record=1},func.func(reussir-token-reuse),reussir-convert-to-std,func.func(reussir-rc-create-sink),func.func(reussir-rc-create-fusion),reussir-trmc-recursion-analysis,reussir-compile-polymorphic-ffi,canonicalize,cse,control-flow-sink,convert-scf-to-cf,reussir-lowering-basic-ops,convert-to-llvm,reconcile-unrealized-casts,cse,canonicalize)' \
+// RUN:   -o %t.mlir
+// RUN: %reussir-translate --mlir-to-llvmir %t.mlir | %opt -S -O2 -o %t.ll
+// RUN: %llc %t.ll -relocation-model=pic -filetype=obj -o %t.o
+// RUN: %cc %t.o -o %t.exe -L%library_path -lreussir_rt \
+// RUN:   %rpath_flag %extra_sys_libs
+// RUN: %t.exe
+
+// Executable proof of the dynamic-extent array lifecycle: construct with a
+// runtime extent (token size computed as header + n * elemsize), fill and
+// reduce through the strided view, release through the dynamic token and
+// the unsized free. Asserts sum(0..9) == 45.
+!dv = !reussir.array<? x i32>
+!rc_dv = !reussir.rc<!dv>
+module {
+  // Build [0, 1, ..., n-1], sum it through the strided view, release the box.
+  func.func private @iota_sum(%n: index) -> i32 attributes {llvm.linkage = #llvm.linkage<internal>} {
+    %poison = ub.poison : !dv
+    %rc = reussir.rc.create value(%poison : !dv) extents(%n) : !rc_dv
+    %ref = reussir.rc.borrow (%rc : !rc_dv) : !reussir.ref<!dv>
+    %v = reussir.array.view(%ref : !reussir.ref<!dv>) : memref<?xi32, strided<[?], offset: ?>>
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    scf.for %i = %c0 to %n step %c1 {
+      %iv = arith.index_cast %i : index to i32
+      memref.store %iv, %v[%i] : memref<?xi32, strided<[?], offset: ?>>
+    }
+    %c0i = arith.constant 0 : i32
+    %sum = scf.for %i = %c0 to %n step %c1 iter_args(%acc = %c0i) -> i32 {
+      %x = memref.load %v[%i] : memref<?xi32, strided<[?], offset: ?>>
+      %a = arith.addi %acc, %x : i32
+      scf.yield %a : i32
+    }
+    reussir.rc.dec (%rc : !rc_dv)
+    return %sum : i32
+  }
+
+  func.func @main() -> i32 {
+    %c10 = arith.constant 10 : index
+    %s = func.call @iota_sum(%c10) : (index) -> i32
+    // sum 0..9 = 45
+    %c45 = arith.constant 45 : i32
+    %bad = arith.cmpi ne, %s, %c45 : i32
+    scf.if %bad {
+      reussir.panic "dynamic-extent iota sum mismatch"
+    }
+    %c0 = arith.constant 0 : i32
+    return %c0 : i32
+  }
+}

--- a/tests/integration/conversion/dynamic_array_managed_e2e.mlir
+++ b/tests/integration/conversion/dynamic_array_managed_e2e.mlir
@@ -1,0 +1,111 @@
+// RUN: %reussir-opt %s \
+// RUN:   --pass-pipeline='builtin.module(reussir-attach-native-target,func.func(reussir-token-instantiation),reussir-closure-outlining,reussir-lowering-region-patterns,func.func(reussir-inc-dec-cancellation),reussir-rc-decrement-expansion,func.func(reussir-infer-variant-tag),reussir-acquire-drop-expansion,reussir-convert-to-std,func.func(reussir-inc-dec-cancellation),reussir-acquire-drop-expansion{expand-decrement=1 outline-record=1},func.func(reussir-token-reuse),reussir-convert-to-std,func.func(reussir-rc-create-sink),func.func(reussir-rc-create-fusion),reussir-trmc-recursion-analysis,reussir-compile-polymorphic-ffi,canonicalize,cse,control-flow-sink,convert-scf-to-cf,reussir-lowering-basic-ops,convert-to-llvm,reconcile-unrealized-casts,cse,canonicalize)' \
+// RUN:   -o %t.mlir
+// RUN: %reussir-translate --mlir-to-llvmir %t.mlir | %opt -S -O2 -o %t.ll
+// RUN: %llc %t.ll -relocation-model=pic -filetype=obj -o %t.o
+// RUN: %cc %t.o -o %t.exe -L%library_path -lreussir_rt \
+// RUN:   %rpath_flag %extra_sys_libs
+// RUN: %t.exe
+
+// Executable proof of the ownership traversal over a dynamic-extent array of
+// managed elements: a rank-2 `array<? x 2 x rc<i32>>` whose drop walks a loop
+// nest bounded by `memref.dim` on the leading dim and projects through the
+// dynamic strided layout at every rank. The array is shared and updated
+// through a unique view, so the clone's acquire traversal retains every
+// element once and the two drops release each element exactly twice.
+!e = !reussir.rc<i32>
+!dv = !reussir.array<? x 2 x !e>
+!rc_dv = !reussir.rc<!dv>
+!view = memref<?x2x!e, strided<[?, ?], offset: ?>>
+!row = memref<2x!e, strided<[?], offset: ?>>
+module {
+  // Slot [i][j] holds rc(2i + j).
+  func.func private @make(%n: index) -> !rc_dv attributes {llvm.linkage = #llvm.linkage<internal>} {
+    %poison = ub.poison : !dv
+    %rc = reussir.rc.create value(%poison : !dv) extents(%n) : !rc_dv
+    %ref = reussir.rc.borrow (%rc : !rc_dv) : !reussir.ref<!dv>
+    %v = reussir.array.view(%ref : !reussir.ref<!dv>) : !view
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    scf.for %i = %c0 to %n step %c1 {
+      %row = reussir.array.project(%v : !view) [%i : index] : !row
+      scf.for %j = %c0 to %c2 step %c1 {
+        %slot = reussir.array.project(%row : !row) [%j : index] : !reussir.ref<!e field>
+        %i2 = arith.muli %i, %c2 : index
+        %k = arith.addi %i2, %j : index
+        %kv = arith.index_cast %k : index to i32
+        %elem = reussir.rc.create value(%kv : i32) : !e
+        reussir.ref.store (%slot : !reussir.ref<!e field>) (%elem : !e)
+      }
+    }
+    return %rc : !rc_dv
+  }
+
+  func.func private @sum(%rc: !rc_dv) -> i32 attributes {llvm.linkage = #llvm.linkage<internal>} {
+    %ref = reussir.rc.borrow (%rc : !rc_dv) : !reussir.ref<!dv>
+    %v = reussir.array.view(%ref : !reussir.ref<!dv>) : !view
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %n = memref.dim %v, %c0 : !view
+    %c0i = arith.constant 0 : i32
+    %s = scf.for %i = %c0 to %n step %c1 iter_args(%acc = %c0i) -> i32 {
+      %row = reussir.array.project(%v : !view) [%i : index] : !row
+      %s2 = scf.for %j = %c0 to %c2 step %c1 iter_args(%acc2 = %acc) -> i32 {
+        %slot = reussir.array.project(%row : !row) [%j : index] : !reussir.ref<!e field>
+        %elem = reussir.ref.load (%slot : !reussir.ref<!e field>) : !e
+        %eref = reussir.rc.borrow (%elem : !e) : !reussir.ref<i32>
+        %x = reussir.ref.load (%eref : !reussir.ref<i32>) : i32
+        %a = arith.addi %acc2, %x : i32
+        scf.yield %a : i32
+      }
+      scf.yield %s2 : i32
+    }
+    return %s : i32
+  }
+
+  func.func private @set00(%rc: !rc_dv, %value: !e) -> !rc_dv attributes {llvm.linkage = #llvm.linkage<internal>} {
+    %updated = reussir.array.with_unique_view (%rc : !rc_dv) -> !rc_dv {
+      ^bb0(%view: !view):
+        %c0 = arith.constant 0 : index
+        %row = reussir.array.project(%view : !view) [%c0 : index] : !row
+        %slot = reussir.array.project(%row : !row) [%c0 : index] : !reussir.ref<!e field>
+        // Release the old occupant, then move the new element in.
+        %old = reussir.ref.load (%slot : !reussir.ref<!e field>) : !e
+        reussir.rc.dec (%old : !e)
+        reussir.ref.store (%slot : !reussir.ref<!e field>) (%value : !e)
+        reussir.scf.yield
+    }
+    return %updated : !rc_dv
+  }
+
+  func.func @main() -> i32 {
+    %c5 = arith.constant 5 : index
+    %c100 = arith.constant 100 : i32
+    // sum(0..9) = 45; replacing slot [0][0] (value 0) with 100 gives 145.
+    %c45 = arith.constant 45 : i32
+    %c145 = arith.constant 145 : i32
+
+    %shared = func.call @make(%c5) : (index) -> !rc_dv
+    reussir.rc.inc (%shared : !rc_dv)
+    %hundred = reussir.rc.create value(%c100 : i32) : !e
+    %updated = func.call @set00(%shared, %hundred) : (!rc_dv, !e) -> !rc_dv
+
+    %original_sum = func.call @sum(%shared) : (!rc_dv) -> i32
+    %original_bad = arith.cmpi ne, %original_sum, %c45 : i32
+    scf.if %original_bad {
+      reussir.panic "shared managed dynamic array was mutated through the clone"
+    }
+    %updated_sum = func.call @sum(%updated) : (!rc_dv) -> i32
+    %updated_bad = arith.cmpi ne, %updated_sum, %c145 : i32
+    scf.if %updated_bad {
+      reussir.panic "managed dynamic array clone did not carry the update"
+    }
+    reussir.rc.dec (%shared : !rc_dv)
+    reussir.rc.dec (%updated : !rc_dv)
+
+    %c0 = arith.constant 0 : i32
+    return %c0 : i32
+  }
+}

--- a/tests/integration/conversion/dynamic_array_managed_elements.mlir
+++ b/tests/integration/conversion/dynamic_array_managed_elements.mlir
@@ -1,0 +1,101 @@
+// RUN: %reussir-opt %s --reussir-acquire-drop-expansion | %FileCheck %s --check-prefix=DROP
+// RUN: %reussir-opt %s --reussir-convert-to-std | %FileCheck %s --check-prefix=CLONE
+// RUN: %reussir-opt %s --pass-pipeline='builtin.module(reussir-attach-native-target,convert-scf-to-cf,reussir-lowering-basic-ops,convert-to-llvm,reconcile-unrealized-casts,cse,canonicalize)' | %FileCheck %s --check-prefix=LLVM
+
+// Ownership and cloning of a dynamic-extent array
+// (docs/design/dynamic-extent-arrays.md): the element traversal never
+// unrolls a dynamic shape, takes its loop bounds from `memref.dim` on the
+// view, and projects through the dynamic strided layout at every rank; the
+// `with_unique_view` clone branch sizes its token at runtime, constructs the
+// clone canonical from the source's sizes, and copies the payload flat when
+// the source header is canonical or element-wise otherwise.
+
+!elt = !reussir.rc<i64>
+!dv = !reussir.array<? x 2 x !elt>
+!rc_dv = !reussir.rc<!dv>
+!view = memref<?x2x!elt, strided<[?, ?], offset: ?>>
+!row = memref<2x!elt, strided<[?], offset: ?>>
+
+module {
+  // DROP-LABEL: func.func @drop_dynamic(
+  // DROP: %[[VIEW:.+]] = reussir.array.view(%arg0 : !reussir.ref<!reussir.array<? x 2 x !reussir.rc<i64>>>) : memref<?x2x!reussir.rc<i64>, strided<[?, ?], offset: ?>>
+  // DROP: %[[DIM:.+]] = memref.dim %[[VIEW]], %{{.+}} : memref<?x2x!reussir.rc<i64>, strided<[?, ?], offset: ?>>
+  // DROP: scf.for %[[ROW:.+]] = %{{.+}} to %[[DIM]]
+  // DROP: scf.for %[[COLUMN:.+]] = %{{.+}} to %{{.+}}
+  // DROP: %[[ROW_VIEW:.+]] = reussir.array.project(%[[VIEW]] : memref<?x2x!reussir.rc<i64>, strided<[?, ?], offset: ?>>) [%[[ROW]] : index] : memref<2x!reussir.rc<i64>, strided<[?], offset: ?>>
+  // DROP: reussir.array.project(%[[ROW_VIEW]] : memref<2x!reussir.rc<i64>, strided<[?], offset: ?>>) [%[[COLUMN]] : index] : !reussir.ref<!reussir.rc<i64>>
+  // DROP: reussir.rc.dec
+  // DROP-NOT: reussir.rc.dec
+  // DROP: return
+  func.func @drop_dynamic(%xs: !reussir.ref<!dv>) {
+    reussir.ref.drop (%xs : !reussir.ref<!dv>)
+    return
+  }
+
+  // CLONE-LABEL: func.func @clone_dynamic(
+  // CLONE: } else {
+  // CLONE: %[[SRC:.+]] = reussir.rc.borrow(%arg0 : !reussir.rc<!reussir.array<? x 2 x !reussir.rc<i64>>>)
+  // CLONE: %[[SRC_VIEW:.+]] = reussir.array.view(%[[SRC]] : {{.*}}) : memref<?x2x!reussir.rc<i64>, strided<[?, ?], offset: ?>>
+  // CLONE: %[[BASE:.+]], %[[OFFSET:.+]], %[[SIZES:.+]]:2, %[[STRIDES:.+]]:2 = memref.extract_strided_metadata %[[SRC_VIEW]]
+  // CLONE: %[[C1:.+]] = arith.constant 1 : index
+  // CLONE: %[[STRIDE0:.+]] = arith.muli %[[C1]], %[[SIZES]]#1
+  // CLONE: %[[COUNT:.+]] = arith.muli %[[STRIDE0]], %[[SIZES]]#0
+  // CLONE: %[[C8:.+]] = arith.constant 8 : index
+  // CLONE: %[[BYTES:.+]] = arith.muli %[[COUNT]], %[[C8]]
+  // CLONE: %[[HEADER:.+]] = arith.constant 48 : index
+  // CLONE: %[[BOX_BYTES:.+]] = arith.addi %[[BYTES]], %[[HEADER]]
+  // CLONE: %[[TOKEN:.+]] = reussir.token.alloc(%[[BOX_BYTES]] : index) : <align : 8, size : ?>
+  // CLONE: %[[CLONED:.+]] = reussir.rc.create value(%{{.+}} : !reussir.array<? x 2 x !reussir.rc<i64>>) token(%[[TOKEN]] : !reussir.token<align : 8, size : ?>) extents(%[[SIZES]]#0)
+  // CLONE: %[[DST:.+]] = reussir.rc.borrow(%[[CLONED]]
+  // CLONE: %[[C0:.+]] = arith.constant 0 : index
+  // CLONE: %[[OFF_OK:.+]] = arith.cmpi eq, %[[OFFSET]], %[[C0]]
+  // CLONE: %[[S0_OK:.+]] = arith.cmpi eq, %[[STRIDES]]#0, %[[STRIDE0]]
+  // CLONE: %[[AND0:.+]] = arith.andi %[[OFF_OK]], %[[S0_OK]]
+  // CLONE: %[[S1_OK:.+]] = arith.cmpi eq, %[[STRIDES]]#1, %[[C1]]
+  // CLONE: %[[CANONICAL:.+]] = arith.andi %[[AND0]], %[[S1_OK]]
+  // CLONE: scf.if %[[CANONICAL]] {
+  // CLONE: reussir.ref.memcpy %[[SRC]] to %[[DST]] size(%[[BYTES]] : index)
+  // CLONE: } else {
+  // CLONE: %[[DST_VIEW:.+]] = reussir.array.view(%[[DST]]
+  // CLONE: scf.for %[[I:.+]] = %{{.+}} to %[[SIZES]]#0
+  // CLONE: scf.for %[[J:.+]] = %{{.+}} to %[[SIZES]]#1
+  // CLONE: %[[SRC_ROW:.+]] = reussir.array.project(%[[SRC_VIEW]] : {{.*}}) [%[[I]] : index]
+  // CLONE: %[[SRC_ELT:.+]] = reussir.array.project(%[[SRC_ROW]] : {{.*}}) [%[[J]] : index]
+  // CLONE: %[[DST_ROW:.+]] = reussir.array.project(%[[DST_VIEW]] : {{.*}}) [%[[I]] : index]
+  // CLONE: %[[DST_ELT:.+]] = reussir.array.project(%[[DST_ROW]] : {{.*}}) [%[[J]] : index]
+  // CLONE: reussir.ref.memcpy %[[SRC_ELT]] to %[[DST_ELT]] : <!reussir.rc<i64>> to <!reussir.rc<i64>>
+  // CLONE: }
+  // CLONE: reussir.ref.acquire(%[[DST]]
+  // CLONE: reussir.rc.fetch(%arg0
+  // CLONE: reussir.rc.set(%arg0
+  // CLONE: scf.yield %[[CLONED]]
+  func.func @clone_dynamic(%xs: !rc_dv) -> !rc_dv {
+    %res = reussir.array.with_unique_view (%xs : !rc_dv) -> !rc_dv {
+      ^bb0(%view: !view):
+        reussir.scf.yield
+    }
+    return %res : !rc_dv
+  }
+
+  // A strided projection is descriptor arithmetic: the leading extent for
+  // the bounds assumption is the descriptor's size, the row shift lands in
+  // the live offset field (`offset + i * stride[0]`), the aligned pointer is
+  // untouched, and the trailing size/stride pass through.
+  // The bare-argument descriptor: `%arg1` aligned pointer, `%arg2` offset,
+  // `%arg3`/`%arg4` sizes, `%arg5`/`%arg6` strides, `%arg7` the index.
+  // LLVM-LABEL: llvm.func @project_dynamic(
+  // LLVM: %[[IN_BOUNDS:.+]] = llvm.icmp "ult" %arg7, %arg3
+  // LLVM: llvm.intr.assume %[[IN_BOUNDS]]
+  // LLVM: %[[DELTA:.+]] = llvm.mul %arg7, %arg5
+  // LLVM: %[[SHIFT:.+]] = llvm.add %arg2, %[[DELTA]]
+  // LLVM: llvm.insertvalue %arg1, %{{.+}}[1]
+  // LLVM: llvm.insertvalue %[[SHIFT]], %{{.+}}[2]
+  // LLVM: llvm.insertvalue %arg4, %{{.+}}[3, 0]
+  // LLVM: llvm.insertvalue %arg6, %{{.+}}[4, 0]
+  // LLVM-NOT: llvm.getelementptr
+  // LLVM: llvm.return
+  func.func @project_dynamic(%view: !view, %i: index) -> !row {
+    %row = reussir.array.project(%view : !view) [%i : index] : !row
+    return %row : !row
+  }
+}

--- a/tests/integration/conversion/dynamic_array_token_reuse.mlir
+++ b/tests/integration/conversion/dynamic_array_token_reuse.mlir
@@ -1,0 +1,70 @@
+// RUN: %reussir-opt %s --pass-pipeline='builtin.module(reussir-attach-native-target,func.func(reussir-token-instantiation),reussir-rc-decrement-expansion,reussir-acquire-drop-expansion,reussir-convert-to-std,func.func(reussir-token-reuse))' -o %t.mlir
+// RUN: %FileCheck %s < %t.mlir
+// RUN: %reussir-opt %t.mlir --pass-pipeline='builtin.module(reussir-convert-to-std,convert-scf-to-cf,reussir-lowering-basic-ops,reussir-convert-to-llvm,reconcile-unrealized-casts)' -o %t.llvm.mlir
+// RUN: %reussir-translate --mlir-to-llvmir %t.llvm.mlir -o %t.ll
+
+!array = !reussir.array<? x i32>
+!rc = !reussir.rc<!array>
+!wide = !reussir.rc<!reussir.array<? x i128>>
+
+module {
+  // Equal token types do not imply equal runtime sizes. This used to select
+  // token.ensure, which also lost the required size on its null branch.
+  // CHECK-LABEL: func.func @dynamic_to_dynamic
+  // CHECK: %[[BYTES:.+]] = arith.addi
+  // CHECK: %[[ALLOC:.+]] = reussir.token.alloc(%[[BYTES]] : index)
+  // CHECK: reussir.rc.create
+  // CHECK-SAME: token(%[[ALLOC]]
+  // CHECK-SAME: extents(%arg1)
+  // CHECK: return
+  func.func @dynamic_to_dynamic(%old: !rc, %n: index) -> !rc {
+    reussir.rc.dec (%old : !rc)
+    %poison = ub.poison : !array
+    %new = reussir.rc.create value(%poison : !array) extents(%n) : !rc
+    return %new : !rc
+  }
+
+  // A dynamic donor with a different alignment used to select realloc with
+  // the dynamic size sentinel as the requested byte count.
+  // CHECK-LABEL: func.func @different_alignment
+  // CHECK: %[[BYTES:.+]] = arith.addi
+  // CHECK: %[[ALLOC:.+]] = reussir.token.alloc(%[[BYTES]] : index)
+  // CHECK: reussir.rc.create
+  // CHECK-SAME: token(%[[ALLOC]]
+  // CHECK-SAME: extents(%arg1)
+  // CHECK: return
+  func.func @different_alignment(%old: !wide, %n: index) -> !rc {
+    reussir.rc.dec (%old : !wide)
+    %poison = ub.poison : !array
+    %new = reussir.rc.create value(%poison : !array) extents(%n) : !rc
+    return %new : !rc
+  }
+
+  // Fixed-size donors must not consume a dynamic recipient's allocation.
+  // CHECK-LABEL: func.func @static_to_dynamic
+  // CHECK: %[[BYTES:.+]] = arith.addi
+  // CHECK: %[[ALLOC:.+]] = reussir.token.alloc(%[[BYTES]] : index)
+  // CHECK: reussir.rc.create
+  // CHECK-SAME: token(%[[ALLOC]]
+  // CHECK-SAME: extents(%arg1)
+  // CHECK: return
+  func.func @static_to_dynamic(%old: !reussir.rc<i32>, %n: index) -> !rc {
+    reussir.rc.dec (%old : !reussir.rc<i32>)
+    %poison = ub.poison : !array
+    %new = reussir.rc.create value(%poison : !array) extents(%n) : !rc
+    return %new : !rc
+  }
+
+  // Preserve the supported direction: a dynamic box can still donate to a
+  // statically sized recipient through the unsized realloc ABI.
+  // CHECK-LABEL: func.func @dynamic_to_static
+  // CHECK: %[[REUSED:.+]] = reussir.token.realloc
+  // CHECK: reussir.rc.create
+  // CHECK-SAME: token(%[[REUSED]]
+  // CHECK: return
+  func.func @dynamic_to_static(%old: !rc, %value: i32) -> !reussir.rc<i32> {
+    reussir.rc.dec (%old : !rc)
+    %new = reussir.rc.create value(%value : i32) : !reussir.rc<i32>
+    return %new : !reussir.rc<i32>
+  }
+}

--- a/tests/integration/conversion/dynamic_array_token_reuse_e2e.mlir
+++ b/tests/integration/conversion/dynamic_array_token_reuse_e2e.mlir
@@ -1,0 +1,85 @@
+// RUN: %reussir-opt %s --pass-pipeline='builtin.module(reussir-attach-native-target,func.func(reussir-token-instantiation),reussir-rc-decrement-expansion,reussir-acquire-drop-expansion,reussir-convert-to-std,func.func(reussir-token-reuse),reussir-convert-to-std,canonicalize,cse,convert-scf-to-cf,reussir-lowering-basic-ops,reussir-convert-to-llvm,reconcile-unrealized-casts,canonicalize)' -o %t.mlir
+// RUN: %reussir-translate --mlir-to-llvmir %t.mlir | %opt -S -O2 -o %t.ll
+// RUN: %llc %t.ll -relocation-model=pic -filetype=obj -o %t.o
+// RUN: %cc %t.o -o %t.exe -L%library_path -lreussir_rt %rpath_flag %extra_sys_libs
+// RUN: %t.exe
+
+// Dropping one dynamic box and constructing a larger one must preserve the
+// runtime allocation size on both the unique and shared decrement paths.
+!array = !reussir.array<? x i32>
+!rc = !reussir.rc<!array>
+!view = memref<?xi32, strided<[?], offset: ?>>
+module {
+  func.func private @fill(%xs: !rc) attributes {llvm.linkage = #llvm.linkage<internal>} {
+    %ref = reussir.rc.borrow (%xs : !rc) : !reussir.ref<!array>
+    %view = reussir.array.view(%ref : !reussir.ref<!array>) : !view
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %n = memref.dim %view, %c0 : !view
+    scf.for %i = %c0 to %n step %c1 {
+      %value = arith.index_cast %i : index to i32
+      memref.store %value, %view[%i] : !view
+    }
+    return
+  }
+
+  func.func private @make(%n: index) -> !rc attributes {llvm.linkage = #llvm.linkage<internal>} {
+    %poison = ub.poison : !array
+    %xs = reussir.rc.create value(%poison : !array) extents(%n) : !rc
+    func.call @fill(%xs) : (!rc) -> ()
+    return %xs : !rc
+  }
+
+  func.func private @replace(%old: !rc, %n: index) -> !rc attributes {llvm.linkage = #llvm.linkage<internal>} {
+    reussir.rc.dec (%old : !rc)
+    %poison = ub.poison : !array
+    %xs = reussir.rc.create value(%poison : !array) extents(%n) : !rc
+    func.call @fill(%xs) : (!rc) -> ()
+    return %xs : !rc
+  }
+
+  func.func private @check(%xs: !rc, %expected: i32) attributes {llvm.linkage = #llvm.linkage<internal>} {
+    %ref = reussir.rc.borrow (%xs : !rc) : !reussir.ref<!array>
+    %view = reussir.array.view(%ref : !reussir.ref<!array>) : !view
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c0i = arith.constant 0 : i32
+    %n = memref.dim %view, %c0 : !view
+    %sum = scf.for %i = %c0 to %n step %c1 iter_args(%acc = %c0i) -> i32 {
+      %value = memref.load %view[%i] : !view
+      %next = arith.addi %acc, %value : i32
+      scf.yield %next : i32
+    }
+    %bad = arith.cmpi ne, %sum, %expected : i32
+    scf.if %bad {
+      reussir.panic "dynamic array replacement lost its size or contents"
+    }
+    return
+  }
+
+  func.func @main() -> i32 {
+    %c0 = arith.constant 0 : index
+    %c3 = arith.constant 3 : index
+    %c64 = arith.constant 64 : index
+    %c0i = arith.constant 0 : i32
+    %c3i = arith.constant 3 : i32
+    %c2016 = arith.constant 2016 : i32
+
+    %unique = func.call @make(%c3) : (index) -> !rc
+    %larger = func.call @replace(%unique, %c64) : (!rc, index) -> !rc
+    func.call @check(%larger, %c2016) : (!rc, i32) -> ()
+    reussir.rc.dec (%larger : !rc)
+
+    %shared = func.call @make(%c3) : (index) -> !rc
+    reussir.rc.inc (%shared : !rc)
+    %fresh = func.call @replace(%shared, %c64) : (!rc, index) -> !rc
+    func.call @check(%shared, %c3i) : (!rc, i32) -> ()
+    func.call @check(%fresh, %c2016) : (!rc, i32) -> ()
+    reussir.rc.dec (%shared : !rc)
+
+    %empty = func.call @replace(%fresh, %c0) : (!rc, index) -> !rc
+    func.call @check(%empty, %c0i) : (!rc, i32) -> ()
+    reussir.rc.dec (%empty : !rc)
+    return %c0i : i32
+  }
+}

--- a/tests/integration/conversion/dynamic_array_view.mlir
+++ b/tests/integration/conversion/dynamic_array_view.mlir
@@ -1,0 +1,50 @@
+// RUN: %reussir-opt %s \
+// RUN:   --pass-pipeline='builtin.module(reussir-attach-native-target,func.func(reussir-token-instantiation),control-flow-sink,convert-scf-to-cf,reussir-lowering-basic-ops,convert-to-llvm,reconcile-unrealized-casts,cse,canonicalize)' \
+// RUN:   | %FileCheck %s
+
+// A dynamic-extent array (docs/design/dynamic-extent-arrays.md) boxes as
+// `{ i32 count | index offset | index size[r] | index stride[r] | tail }`;
+// `array.view` is a straight header copy — recover the box from the payload
+// ref by the static header offset, load the descriptor fields, address as
+// `payload + offset + i * stride`.
+
+!dv = !reussir.array<? x i32>
+!rc_dv = !reussir.rc<!dv>
+
+module {
+  // CHECK-LABEL: llvm.func @read
+  // CHECK: %[[PAYLOAD:.+]] = llvm.getelementptr %arg0[0, 4] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i32, i64, i64, i64, array<0 x i32>)>
+  // CHECK: %[[BOX:.+]] = llvm.getelementptr %[[PAYLOAD]][-32] : (!llvm.ptr) -> !llvm.ptr, i8
+  // CHECK: %[[OFFP:.+]] = llvm.getelementptr %[[BOX]][0, 1]
+  // CHECK: %[[OFF:.+]] = llvm.load %[[OFFP]] : !llvm.ptr -> i64
+  // CHECK: %[[STRP:.+]] = llvm.getelementptr %[[BOX]][0, 3]
+  // CHECK: %[[STR:.+]] = llvm.load %[[STRP]] : !llvm.ptr -> i64
+  // CHECK: llvm.getelementptr %{{.+}}[%[[OFF]]]
+  // CHECK: llvm.mul %arg1, %[[STR]]
+  // CHECK: llvm.load %{{.+}} : !llvm.ptr -> i32
+  func.func @read(%a: !rc_dv, %i: index) -> i32 {
+    %ref = reussir.rc.borrow (%a : !rc_dv) : !reussir.ref<!dv>
+    %v = reussir.array.view(%ref : !reussir.ref<!dv>) : memref<?xi32, strided<[?], offset: ?>>
+    %x = memref.load %v[%i] : memref<?xi32, strided<[?], offset: ?>>
+    return %x : i32
+  }
+
+  // Construction: the instantiated token computes `header + n * elemsize`,
+  // allocation takes the generic entry point with the runtime size, and the
+  // header stores are canonical (offset 0, size n, stride 1).
+  // CHECK-LABEL: llvm.func @make
+  // CHECK-DAG: %[[C4:.+]] = llvm.mlir.constant(4 : index) : i64
+  // CHECK-DAG: %[[C32:.+]] = llvm.mlir.constant(32 : index) : i64
+  // CHECK: %[[BYTES0:.+]] = llvm.mul %arg0, %[[C4]]
+  // CHECK: %[[BYTES:.+]] = llvm.add %[[BYTES0]], %[[C32]]
+  // CHECK: %[[TOK:.+]] = llvm.call @__reussir_allocate(%{{.+}}, %[[BYTES]])
+  // CHECK-DAG: llvm.getelementptr %[[TOK]][0, 1]
+  // CHECK-DAG: llvm.getelementptr %[[TOK]][0, 2]
+  // CHECK-DAG: llvm.getelementptr %[[TOK]][0, 3]
+  // CHECK-DAG: llvm.getelementptr %[[TOK]][0, 0]
+  func.func @make(%n: index) -> !rc_dv {
+    %poison = ub.poison : !dv
+    %rc = reussir.rc.create value(%poison : !dv) extents(%n) : !rc_dv
+    return %rc : !rc_dv
+  }
+}

--- a/tests/unittest/cases/array.cpp
+++ b/tests/unittest/cases/array.cpp
@@ -71,6 +71,39 @@ TEST_F(ReussirTest, ViewTypeElementTypeTest) {
   EXPECT_EQ(viewType.getElementType(), i8Type);
 }
 
+TEST_F(ReussirTest, DynamicArraysRequireSharedStorage) {
+  auto i32Type = mlir::IntegerType::get(context.get(), 32);
+  mlir::Type dynamicArray = ArrayType::get(
+      context.get(), {mlir::ShapedType::kDynamic, 2}, i32Type);
+  mlir::Type staticArray = ArrayType::get(context.get(), {4, 2}, i32Type);
+  auto loc = mlir::UnknownLoc::get(context.get());
+  mlir::ScopedDiagnosticHandler handler(context.get(), [](mlir::Diagnostic &) {
+    return mlir::success();
+  });
+
+  // Shared dynamic boxes and their payload references remain valid.
+  EXPECT_TRUE(RcType::getChecked(loc, context.get(), dynamicArray,
+                                 Capability::shared, AtomicKind::normal));
+  EXPECT_TRUE(RcBoxType::getChecked(loc, context.get(), dynamicArray, false));
+  EXPECT_TRUE(RefType::getChecked(loc, context.get(), dynamicArray,
+                                  Capability::unspecified, AtomicKind::normal));
+
+  // Both region-local and frozen references would recover the wrong header.
+  // Static arrays retain their existing capability support.
+  for (Capability capability : {Capability::flex, Capability::rigid}) {
+    EXPECT_FALSE(RcType::getChecked(loc, context.get(), dynamicArray,
+                                    capability, AtomicKind::normal));
+    EXPECT_FALSE(RefType::getChecked(loc, context.get(), dynamicArray,
+                                     capability, AtomicKind::normal));
+    EXPECT_TRUE(RcType::getChecked(loc, context.get(), staticArray,
+                                   capability, AtomicKind::normal));
+    EXPECT_TRUE(RefType::getChecked(loc, context.get(), staticArray,
+                                    capability, AtomicKind::normal));
+  }
+  EXPECT_FALSE(RcBoxType::getChecked(loc, context.get(), dynamicArray, true));
+  EXPECT_TRUE(RcBoxType::getChecked(loc, context.get(), staticArray, true));
+}
+
 TEST_F(ReussirTest, RcTypeIsValidMemRefElementType) {
   auto i64Type = mlir::IntegerType::get(context.get(), 64);
   auto rcType = reussir::RcType::get(context.get(), i64Type);


### PR DESCRIPTION
The dialect half of `docs/design/dynamic-extent-arrays.md`, picking up where #597's frontend left off. Everything is exercised by an **executed** e2e test — construct with a runtime extent, fill and reduce through the strided view, free through the dynamic token.

## What lands

- **Type**: `!reussir.array<? x i32>` parses, prints, and verifies (`?` = `ShapedType::kDynamic`, matching memref); `getTypeSizeInBits` asserts on dynamic shapes instead of multiplying the sentinel.
- **Strided-header box**: `RcBoxType::hasDynamicArrayPayload()` — the box header carries the full strided-memref encoding `{ i32 count | index offset | index size[r] | index stride[r] | payload tail }`, i.e. exactly `memref.extract_strided_metadata` minus the base pointer. Header members are `index`-typed, so 32-bit targets get the layout from the same data-layout machinery (no hand-computed offsets); alignment stays answerable, and the LLVM conversion emits the header struct with a zero-length tail.
- **`array.view`**: types as `memref<?x…, strided<[?,…], offset: ?>>` and lowers to a straight header copy — the box is recovered from the payload ref by the *static* header offset, descriptor fields are loads, both descriptor pointers are the payload ref. Post-canonicalize a load is literally `payload + offset + i·stride`.
- **Allocation**: `token.alloc(%bytes : index) : token<align, ?>` (verifier enforces the size-operand pairing) → generic `__reussir_allocate`; `TokenInstantiation` assembles `header + ∏sizes × elemsize` from `rc.create`'s new `extents(…)` operands.
- **Construction/destruction**: `rc.create … extents(%n)` writes the canonical header (offset 0, merged static/runtime sizes, suffix-product strides — the canonical-on-construction invariant from the design doc) and skips the payload store; `rc.dec`/`rc.reinterpret` produce `token<align, ?>`, freed via `__reussir_dealloc_unsized` — dynamic tokens remain the universal score-0 reuse donors with no `TokenReuse` change.

## Verification

`dynamic_array_view.mlir` FileChecks the descriptor build and the runtime size computation; `dynamic_array_e2e.mlir` compiles through `reussir-translate → opt -O2 → llc → clang`, runs against `libreussir_rt`, and asserts `sum(iota(10)) == 45`. Full lit suite 504/504, `reussir-ut` 32/32.

## Follow-ups (called out in the doc's Status section)

`with_unique_view`'s clone branch for dynamic arrays (runtime-length copy), dynamic `array.project`, the restride op family, `expand-strided-metadata` in the shipping pipeline, and wiring the frontend codegen off its `err(…)` stubs onto these ops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EpQbdaWoHeGduNHRQzSH8V

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/599"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790607575&installation_model_id=426051&pr_number=599&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F599&signature=9de4019257db03fe591701d7883852c72a5c59c8bc85ab03f0aee8d0b6b3f2d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->