### PR TITLE
[ci] pin the nightly macOS release build to Homebrew llvm@22

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -162,7 +162,9 @@ jobs:
       - name: Install Homebrew dependencies
         run: |
           brew update
-          brew install cmake ninja llvm spdlog googletest python@3
+          # llvm@22 (keg-only) pins the toolchain: FindLLVM.cmake requires
+          # LLVM 22.x and the unversioned formula moved on to 23.
+          brew install cmake ninja llvm@22 spdlog googletest python@3
           pip3 install 'lit<24' --break-system-packages
 
       - name: Setup Rust
@@ -173,9 +175,13 @@ jobs:
 
       - name: Setup environment paths
         run: |
-          LLVM_PREFIX=$(brew --prefix llvm)
+          LLVM_PREFIX=$(brew --prefix llvm@22)
           echo "LLVM_PREFIX=${LLVM_PREFIX}" >> $GITHUB_ENV
           echo "${LLVM_PREFIX}/bin" >> $GITHUB_PATH
+          # llvm@22 is keg-only: its lib dir no longer implies the shared
+          # Homebrew lib dir on the linker path, so -lzstd/-lxml2 from
+          # llvm-sys/tblgen-sys stop resolving without this.
+          echo "LIBRARY_PATH=$(brew --prefix)/lib" >> $GITHUB_ENV
           echo "DYLD_LIBRARY_PATH=${LLVM_PREFIX}/lib:$DYLD_LIBRARY_PATH" >> $GITHUB_ENV
           echo "LLVM_SYMBOLIZER_PATH=${LLVM_PREFIX}/bin/llvm-symbolizer" >> $GITHUB_ENV
 
@@ -626,7 +632,7 @@ jobs:
             **Platforms:**
             - Linux x86_64 (built against LLVM 22)
             - Linux aarch64 (built against LLVM 22)
-            - macOS ARM64 (built against Homebrew LLVM)
+            - macOS ARM64 (built against Homebrew LLVM 22)
             - Windows x64 (built against MSVC LLVM via conda-forge)
 
             **Usage:** Extract the archive and add `<prefix>/bin` to `PATH`.
@@ -653,7 +659,7 @@ jobs:
             **Platforms:**
             - Linux x86_64 (built against LLVM 22)
             - Linux aarch64 (built against LLVM 22)
-            - macOS ARM64 (built against Homebrew LLVM)
+            - macOS ARM64 (built against Homebrew LLVM 22)
             - Windows x64 (built against MSVC LLVM via conda-forge)
 
             **Usage:** Extract the archive and add `<prefix>/bin` to `PATH`.


### PR DESCRIPTION
Homebrew's unversioned `llvm` formula moved on to LLVM 23.1.0, which `FindLLVM.cmake` rejects (`Reussir requires LLVM 22.x (found 23.1.0)`), breaking the Nightly Release `build-macos` job at configure time — see run 33258271329.

This ports the exact `llvm@22` pin that already fixed the macOS Full Pipeline in #595:

- install the keg-only `llvm@22` formula instead of unversioned `llvm`
- resolve `LLVM_PREFIX` via `brew --prefix llvm@22`
- put the shared Homebrew lib dir on `LIBRARY_PATH` so `-lzstd`/`-lxml2` from llvm-sys/tblgen-sys keep resolving against the keg-only toolchain
- release-notes body now says "Homebrew LLVM 22" for the macOS artifact

The Nightly Release workflow does not run on pull requests, so the proof comes from the identical, already-green configuration in `mlir-cpp-test-macos.yml`; the nightly run on the merge commit verifies it end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FxBAMmJ3CUQxPFuX73fWh6

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/600"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790626142&installation_model_id=426051&pr_number=600&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F600&signature=1243431f76389c4bbf0632ae18d768e09677b7e3296605dfcd2e088a36725857"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->