### PR TITLE
[nix] optional windows-cross dev shell: cargo-xwin + wine + conda MSVC LLVM

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -78,6 +78,46 @@
           '';
         };
 
+        # Rust standard library for the MSVC target, at the same pinned
+        # nightly as rust-toolchain.toml (same channel manifest, same hash).
+        # Kept out of rust-toolchain.toml so rustup users and the default
+        # shell don't download a Windows std they never use; only the
+        # windows-cross shell below pays for it.
+        windowsRustToolchain = fenix.packages.${system}.combine [
+          rustToolchain
+          (fenix.packages.${system}.targets."x86_64-pc-windows-msvc".toolchainOf {
+            channel = "nightly";
+            date = "2026-03-15";
+            sha256 = "sha256-4ot8+Fs79G1hUwlEYI6700QBLKdkLb33yzwOou1o5Yk=";
+          }).rust-std
+        ];
+
+        # Bakes the conda-forge MSVC LLVM/MLIR toolchain the Windows CI uses
+        # (.github/conda/windows-msvc.yml) into a local win-64 prefix, so the
+        # backend crates have the same import libraries and headers to build
+        # against as the GitHub runners. Only the library subset of the CI
+        # env file is fetched: the host-side tools (cmake, ninja, python,
+        # lit) come from nix, and the pip section cannot execute inside a
+        # foreign-platform prefix. Versions must track windows-msvc.yml.
+        bakeMsvcLlvm = pkgs.writeShellScriptBin "reussir-bake-msvc-llvm" ''
+          set -euo pipefail
+          prefix="''${XDG_CACHE_HOME:-$HOME/.cache}/reussir-msvc-conda"
+          if [ -e "$prefix/Library/lib/cmake/mlir/MLIRConfig.cmake" ] && [ "''${1:-}" != "--force" ]; then
+            echo "MSVC LLVM/MLIR already baked at $prefix (use --force to redo)"
+            exit 0
+          fi
+          # --platform win-64 extracts the Windows packages without running
+          # their activation scripts, which is all a cross link needs.
+          ${pkgs.micromamba}/bin/micromamba create --yes \
+            --root-prefix "''${XDG_CACHE_HOME:-$HOME/.cache}/reussir-micromamba" \
+            --prefix "$prefix" \
+            --platform win-64 \
+            --channel conda-forge \
+            'llvmdev=22.1.8' 'llvm-tools=22.1.8' 'mlir=22.1.8' \
+            'compiler-rt=22.1.8' gtest spdlog zlib zstd libxml2
+          echo "Baked MSVC LLVM/MLIR into $prefix/Library"
+        '';
+
         # System header flags for the clang-scan-deps workaround.
         #
         # cmake 3.28+ with C++23 uses clang-scan-deps (the raw binary, not the
@@ -327,6 +367,81 @@ PRESETS_EOF
             echo "    cmake --build build                # compile"
             echo "    cmake --build build --target reussir-vscode-package # build VSIX"
             echo "    ln -sf build/compile_commands.json .   # for clangd"
+            echo ""
+          '';
+        };
+        # ---------------------------------------------------------------------------
+        # Windows cross shell (optional): `nix develop .#windows-cross`.
+        #
+        # Cross-builds the LLVM-free Rust crates (the workspace default
+        # members) for x86_64-pc-windows-msvc with cargo-xwin and runs their
+        # test binaries under Wine:
+        #
+        #   cargo xwin build --target x86_64-pc-windows-msvc
+        #   cargo xwin test  --target x86_64-pc-windows-msvc
+        #
+        # cargo-xwin downloads the MSVC CRT and Windows SDK once (into
+        # ~/.cache/cargo-xwin) via the xwin tool; entering this shell
+        # accepts the Microsoft license for those downloads
+        # (XWIN_ACCEPT_LICENSE below). The MLIR-linking crates are out of
+        # scope here — they would additionally need the conda-forge MSVC
+        # LLVM/MLIR toolchain the Windows CI uses.
+        # ---------------------------------------------------------------------------
+        devShells.windows-cross = pkgs.mkShell {
+          name = "reussir-windows-cross";
+
+          packages = [
+            windowsRustToolchain
+            pkgs.cargo-xwin
+
+            # lld-link links the MSVC-target binaries; llvm-lib/llvm-rc back
+            # the cc crate's archiver/resource steps. clang-unwrapped supplies
+            # clang-cl for the C sources the tree-sitter grammar crates build —
+            # deliberately unwrapped: the nix cc wrapper would inject host
+            # (glibc) include and link paths into a Windows cross compile.
+            llvmPkgs.lld
+            llvmPkgs.llvm
+            llvmPkgs.clang-unwrapped
+
+            # 64-bit-only Wine is enough: the msvc target produces x64
+            # binaries, and the wow64 build runs them without multilib.
+            pkgs.wineWow64Packages.minimal
+
+            # One-shot fetch of the conda-forge MSVC LLVM/MLIR toolchain
+            # (same versions as the Windows CI) for backend-crate linking.
+            bakeMsvcLlvm
+          ];
+
+          # The user of this shell accepts the Microsoft Software License for
+          # the MSVC CRT/SDK components xwin fetches.
+          XWIN_ACCEPT_LICENSE = "1";
+
+          # `cargo xwin test` (and `cargo run --target …`) execute the
+          # produced .exe files through this runner.
+          CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_RUNNER = "wine";
+
+          shellHook = ''
+            # Keep the Wine prefix project-local so first-run initialization
+            # never touches ~/.wine.
+            export WINEPREFIX="''${XDG_CACHE_HOME:-$HOME/.cache}/reussir-wineprefix"
+            # Wine is chatty on stderr (fixme:...) — silence it so cargo test
+            # output stays readable.
+            export WINEDEBUG="-all"
+
+            # MSVC LLVM/MLIR (conda-forge, as in the Windows CI): advertise
+            # the baked prefix when present so backend-crate cross builds can
+            # point their *_PREFIX discovery at it.
+            msvc_llvm="''${XDG_CACHE_HOME:-$HOME/.cache}/reussir-msvc-conda/Library"
+            if [ -e "$msvc_llvm/lib/cmake/mlir/MLIRConfig.cmake" ]; then
+              export REUSSIR_MSVC_LLVM_PREFIX="$msvc_llvm"
+            fi
+
+            echo ""
+            echo "  Reussir Windows cross shell — cargo-xwin + Wine"
+            echo ""
+            echo "    cargo xwin build --target x86_64-pc-windows-msvc   # default members"
+            echo "    cargo xwin test  --target x86_64-pc-windows-msvc  # tests run under wine"
+            echo "    reussir-bake-msvc-llvm   # fetch the conda-forge MSVC LLVM/MLIR (once)"
             echo ""
           '';
         };


### PR DESCRIPTION
Adds an **optional** `nix develop .#windows-cross` shell that cross-builds and tests the LLVM-free Rust crates (the workspace default members) for `x86_64-pc-windows-msvc` locally:

```
cargo xwin build --target x86_64-pc-windows-msvc   # default members
cargo xwin test  --target x86_64-pc-windows-msvc   # test .exe files run under wine
reussir-bake-msvc-llvm                             # one-shot conda-forge MSVC LLVM/MLIR fetch
```

**What's in the shell**
- the pinned `nightly-2026-03-15` toolchain plus the `x86_64-pc-windows-msvc` rust-std, combined via fenix from the same channel manifest as `rust-toolchain.toml` — kept out of the toml so rustup users and the default shell don't download a Windows std they never use
- `cargo-xwin` 0.23 (fetches the MSVC CRT + Windows SDK once into `~/.cache/cargo-xwin`; the Microsoft license is accepted via `XWIN_ACCEPT_LICENSE` in the shell), with `lld-link`, `llvm-lib`/`llvm-rc`, and a deliberately **unwrapped** `clang-cl` (the nix cc wrapper would inject host glibc paths into the cross compile) for the C sources the tree-sitter grammar and zstd crates build
- 64-bit-only wine (wow64, no multilib) wired up as `CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_RUNNER`, with a project-local `WINEPREFIX`
- `reussir-bake-msvc-llvm`: micromamba `--platform win-64` fetch of the **library subset** of `.github/conda/windows-msvc.yml` (`llvmdev`/`llvm-tools`/`mlir`/`compiler-rt` 22.1.8, gtest, spdlog, zlib, zstd, libxml2) — the same conda-forge MSVC LLVM the Windows CI builds against — exported as `REUSSIR_MSVC_LLVM_PREFIX` for future backend-crate cross builds. Host-side tools (cmake/ninja/python/lit) stay nix-provided, and the yml's pip section can't execute in a foreign-platform prefix, so those aren't baked.

**Verified locally**
- `cargo xwin build` — all default members compile (61s warm shell)
- `cargo xwin test` — **650 tests pass under wine**: rene 57, reussir-core 465, reussir-lsp 12, reussir-rt 39, reussir-syntax 60, reussir-vscode-wasm 7, trait-dsl 10 (host proc-macro)
- baked `llvm-config.exe` and `mlir-tblgen.exe` run under wine and report 22.1.8

**Out of scope**: the MLIR-linking backend crates — they additionally need the CMake-built C++ side cross-compiled with clang-cl against the baked prefix; the conda bake and `REUSSIR_MSVC_LLVM_PREFIX` are the groundwork for that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FxBAMmJ3CUQxPFuX73fWh6

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/601"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790627045&installation_model_id=426051&pr_number=601&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F601&signature=b5a5e8be5fa535ebd3eb9cfdeefc7135abb88a944407630bcbad2b46341fc634"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->