### PR TITLE
[ci][nix] migrate the Linux pipelines to the Nix flake

### DIFF
--- a/.github/workflows/miri-reussir-rt.yml
+++ b/.github/workflows/miri-reussir-rt.yml
@@ -23,18 +23,23 @@ jobs:
   miri-test:
     name: Miri Test (reussir-rt)
     runs-on: ubuntu-latest
-    
+
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@master
-      with:
-        toolchain: nightly-2026-03-15
-        components: rust-src, rustfmt, clippy, miri
+    - name: Install Nix
+      uses: DeterminateSystems/nix-installer-action@v22
 
+    - name: Cache cargo
+      uses: Swatinem/rust-cache@v2
+
+    # The flake's pinned toolchain carries the miri component
+    # (rust-toolchain.toml), so this is the same interpreter every
+    # developer gets from `nix develop .#rust`.
     - name: Run Miri tests on reussir-rt
       run: |
-        cd crates/reussir-rt
-        cargo miri test -p reussir-rt
+        nix develop .#rust --command bash -c '
+          cd crates/reussir-rt
+          cargo miri test -p reussir-rt
+        '

--- a/.github/workflows/mlir-cpp-test.yml
+++ b/.github/workflows/mlir-cpp-test.yml
@@ -1,5 +1,10 @@
 name: MLIR Backend MultiArch
 
+# The toolchain comes from the Nix flake: the same pinned LLVM/MLIR 22,
+# clang, lit, wasmer, and Rust toolchain every developer gets from
+# `nix develop`, on both architectures. No apt.llvm.org, no external
+# installers — a formula or repository bump upstream cannot break this
+# pipeline (see the lit 23 and Homebrew LLVM 23 incidents).
 on:
   push:
     branches: [ main ]
@@ -14,7 +19,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        llvm-version: [22]
         os: [ubuntu-24.04, ubuntu-24.04-arm]
 
     runs-on: ${{ matrix.os }}
@@ -29,8 +33,9 @@ jobs:
       # ~15G of scratch, but the runner image already uses ~60G and hosted
       # runner disks vary in size, so smaller runners tip over. Reclaim the
       # large toolchains this C++/Rust/LLVM build never uses (~25G+) — Android
-      # SDK, .NET, Haskell (GHC), and Swift — to restore headroom. Best-effort:
-      # a missing path on any given image is not an error.
+      # SDK, .NET, Haskell (GHC), and Swift — to restore headroom (the Nix
+      # store adds its own several GB on top). Best-effort: a missing path on
+      # any given image is not an error.
       - name: Free up disk space
         run: |
           before=$(df -B1 --output=avail / | tail -1)
@@ -47,97 +52,33 @@ jobs:
       - name: Restore file timestamps
         uses: chetan/git-restore-mtime-action@v2
 
-      - name: Setup Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: nightly-2026-03-15
-          components: rust-src, rustfmt, clippy
-          # The WebAssembly suites (tests/integration/rene/wasi_*.rr)
-          # cross-build packages for these targets: the runtime bake, the
-          # polyffi textures, and the launcher link are all rustc
-          # invocations that need the target's standard library. Without one
-          # the matching lit feature (`wasip1`, `wasip1-threads`) stays off
-          # and its suite reports UNSUPPORTED instead of running.
-          target: wasm32-wasip1, wasm32-wasip1-threads
-
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y cmake ninja-build wget libgtest-dev libgmock-dev libspdlog-dev libgmp-dev
-          sudo pip install 'lit<24' --break-system-packages
-
-      # The engine that runs what the WebAssembly suite builds. The official
-      # installer drops the binary in ~/.wasmer/bin; putting that on PATH is
-      # what lets CMake's find_program see it at configure time, which is what
-      # turns the `wasmer` lit feature on.
-      - name: Install wasmer
-        run: |
-          curl https://get.wasmer.io -sSfL | sh
-          echo "$HOME/.wasmer/bin" >> $GITHUB_PATH
-          "$HOME/.wasmer/bin/wasmer" --version
-
-      - name: Install LLVM ${{ matrix.llvm-version }}
-        run: |
-          # Add LLVM apt repository GPG key
-          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
-          
-          # Get Ubuntu codename
-          CODENAME=$(lsb_release -cs)
-          
-          # Add LLVM apt repository with consistent suffix pattern
-          echo "deb http://apt.llvm.org/${CODENAME}/ llvm-toolchain-${CODENAME}-${{ matrix.llvm-version }} main" | sudo tee /etc/apt/sources.list.d/llvm.list
-          
-          # Update apt cache
-          sudo apt-get update
-          
-          # Install LLVM/Clang toolchain. libpolly-*-dev provides the static
-          # Polly archives that llvm-config --link-static references (needed by
-          # mlir-sys / tblgen / llvm-sys); libclang-*-dev provides libclang for
-          # their bindgen step. python3-lldb-* provides lldb's script support,
-          # which the debuginfo lit suite needs to load the Reussir formatters
-          # (tests/integration/debuginfo; gdb comes with the runner image).
-          # libomp-*-dev lets lit's `%cc -fopenmp` probe succeed so the
-          # OpenMP e2e drivers (conversion/*_omp_e2e and the omp sanitizer
-          # tests) actually run instead of reporting UNSUPPORTED.
-          sudo apt-get install -y \
-            clang-${{ matrix.llvm-version }} \
-            lldb-${{ matrix.llvm-version }} \
-            python3-lldb-${{ matrix.llvm-version }} \
-            lld-${{ matrix.llvm-version }} \
-            clangd-${{ matrix.llvm-version }} \
-            libclang-${{ matrix.llvm-version }}-dev \
-            libmlir-${{ matrix.llvm-version }}-dev \
-            mlir-${{ matrix.llvm-version }}-tools \
-            llvm-${{ matrix.llvm-version }}-dev \
-            llvm-${{ matrix.llvm-version }}-tools \
-            libpolly-${{ matrix.llvm-version }}-dev \
-            libomp-${{ matrix.llvm-version }}-dev
-          
-          echo "LD_LIBRARY_PATH=/usr/lib/llvm-${{ matrix.llvm-version }}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
-          echo "LLVM_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer-${{ matrix.llvm-version }}" >> $GITHUB_ENV
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v22
 
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
           variant: sccache
-          key: ${{ matrix.os }}-${{ matrix.llvm-version }}
+          key: ${{ matrix.os }}-nix
+
+      # Materialize the dev shell up front so toolchain substitution has its
+      # own timing and log section. The shellHook writes CMakeUserPresets.json
+      # (the nix-dev preset used below) on every entry.
+      - name: Build dev shell
+        run: nix develop --command true
 
       - name: Configure CMake
         run: |
-          env RUSTC_WRAPPER=sccache \
-          cmake -B build \
-          -G Ninja \
-          -DLLVM_USE_LINKER=lld \
-          -DCMAKE_CXX_COMPILER=clang++-${{ matrix.llvm-version }} \
-          -DCMAKE_C_COMPILER=clang-${{ matrix.llvm-version }} \
-          -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-          -DREUSSIR_ENABLE_PEDANTIC=ON \
-          -DREUSSIR_ENABLE_TESTS=ON \
-          -DREUSSIR_RUNTIME_SANITIZERS="address;leak;memory;thread" \
-          -DCMAKE_C_COMPILER_LAUNCHER=sccache \
-          -DCMAKE_CXX_COMPILER_LAUNCHER=sccache \
-          -DLLVM_DIR=/usr/lib/llvm-${{ matrix.llvm-version }}/lib/cmake/llvm \
-          -DMLIR_DIR=/usr/lib/llvm-${{ matrix.llvm-version }}/lib/cmake/mlir
+          nix develop --command bash -c '
+            env RUSTC_WRAPPER=sccache \
+            cmake --preset nix-dev -B build \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DREUSSIR_ENABLE_PEDANTIC=ON \
+            -DREUSSIR_ENABLE_TESTS=ON \
+            -DREUSSIR_RUNTIME_SANITIZERS="address;leak;memory;thread" \
+            -DCMAKE_C_COMPILER_LAUNCHER=sccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
+          '
 
       - name: Build
         # Also build the sanitized runtime variants here: the `check` target
@@ -145,33 +86,41 @@ jobs:
         # features by whether the libraries exist when it starts — built only
         # later (by check-sanitizer), the whole sanitizer/ suite shows up as
         # UNSUPPORTED in the main integration-test run.
-        run: cmake --build build --parallel --target all reussir-rt-sanitizers
+        run: |
+          nix develop --command bash -c '
+            env RUSTC_WRAPPER=sccache \
+            cmake --build build --parallel --target all reussir-rt-sanitizers
+          '
 
       - name: Run Unit Tests
         run: |
-          cmake --build build --target reussir-ut
-          ctest --test-dir build --output-on-failure
+          nix develop --command bash -c '
+            cmake --build build --target reussir-ut
+            ctest --test-dir build --output-on-failure
+          '
 
       - name: Run Integration Tests
-        run: cmake --build build --target check
+        run: nix develop --command cmake --build build --target check
 
       - name: Run Sanitizer Integration Tests
-        run: cmake --build build --target check-sanitizer
+        run: nix develop --command cmake --build build --target check-sanitizer
 
       - name: Build and Test pure-Rust frontend tools
         # Pure-Rust frontend crates: the parser/CST tests and the
         # elaboration/monomorphization/ownership tests. Cheap (sub-second
         # test run) but previously never executed in CI.
         run: |
-          cmake --build build --target reussir-syntax-test
-          cmake --build build --target reussir-core-test
-          cmake --build build --target reussir-lsp-test
+          nix develop --command bash -c '
+            cmake --build build --target reussir-syntax-test
+            cmake --build build --target reussir-core-test
+            cmake --build build --target reussir-lsp-test
+          '
 
       - name: Build and Test reussir-backend
-        run: cmake --build build --target reussir-backend-test
+        run: nix develop --command cmake --build build --target reussir-backend-test
 
       - name: Build and Test reussir-codegen
-        run: cmake --build build --target reussir-codegen-test
+        run: nix develop --command cmake --build build --target reussir-codegen-test
 
       - name: Build and Test rrc
-        run: cmake --build build --target rrc-test
+        run: nix develop --command cmake --build build --target rrc-test

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -13,6 +13,11 @@ permissions:
   contents: write
 
 jobs:
+  # Deliberately NOT built from the Nix flake (unlike the test pipelines):
+  # binaries linked inside a nix shell carry a /nix/store ELF interpreter
+  # and glibc, which would break the release artifacts' "runs from a bare
+  # environment" guarantee. The apt toolchain below links against the
+  # runner's stock glibc, which is what end-user machines have.
   build-linux:
     strategy:
       fail-fast: false

--- a/.github/workflows/rene-test.yml
+++ b/.github/workflows/rene-test.yml
@@ -27,20 +27,61 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
 
+# rene is a plain Rust crate (no LLVM/MLIR build), so testing it on every
+# platform users run it on is cheap. The Linux legs run from the Nix flake's
+# lean Rust shell (the same pinned toolchain as `nix develop .#rust`); macOS
+# and Windows provision the toolchain with rustup. On Windows the
+# fake-toolchain CLI tests sit out (#[cfg(unix)] shell scripts), but the
+# crate must build and its unit and locking tests hold there — and the real
+# Windows e2e (rene/build.rr, driving the bake and the rrc links with the
+# pinned MSVC linker) runs under the MSVC full pipeline, not here.
 jobs:
+  test-linux:
+    name: Test (rene)
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, ubuntu-24.04-arm]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v22
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      # See the sailfish template-lock rationale on the portable job below.
+      - name: Clear stale sailfish template locks
+        run: find target -path '*sailfish-compiler*/out/templates/*.lock' -delete 2>/dev/null || true
+
+      - name: Warm the sailfish template cache
+        run: nix develop .#rust --command cargo clippy -p rene --lib
+
+      - name: Clippy
+        run: nix develop .#rust --command cargo clippy -p rene --all-targets -- -D warnings
+
+      # The fast suite: manifest loading, build-dir locking, the clean
+      # protocol, and the bake driven through fake cargo/rustc scripts.
+      - name: Run tests
+        run: nix develop .#rust --command cargo test -p rene
+
+      # The real thing, ignored by default because it is slow and
+      # network-dependent: unpack the bundled runtime and bake reussir-rt
+      # with the host toolchain (crates.io + the pinned mlir-sync git rev).
+      - name: Run host-toolchain bake test
+        run: nix develop .#rust --command cargo test -p rene --test cli -- --ignored
+
   test:
     name: Test (rene)
     strategy:
       fail-fast: false
       matrix:
-        # rene is a plain Rust crate (no LLVM/MLIR build), so testing it on
-        # every platform users run it on is cheap. On Windows the
-        # fake-toolchain CLI tests sit out (#[cfg(unix)] shell scripts), but
-        # the crate must build and its unit and locking tests hold there —
-        # and the real Windows e2e (rene/build.rr, driving the bake and the
-        # rrc links with the pinned MSVC linker) runs under the MSVC full
-        # pipeline, not here.
-        os: [ubuntu-24.04, ubuntu-24.04-arm, macos-15, windows-2025]
+        os: [macos-15, windows-2025]
 
     runs-on: ${{ matrix.os }}
 
@@ -86,13 +127,8 @@ jobs:
       - name: Clippy
         run: cargo clippy -p rene --all-targets -- -D warnings
 
-      # The fast suite: manifest loading, build-dir locking, the clean
-      # protocol, and the bake driven through fake cargo/rustc scripts.
       - name: Run tests
         run: cargo test -p rene
 
-      # The real thing, ignored by default because it is slow and
-      # network-dependent: unpack the bundled runtime and bake reussir-rt
-      # with the host toolchain (crates.io + the pinned mlir-sync git rev).
       - name: Run host-toolchain bake test
         run: cargo test -p rene --test cli -- --ignored

--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -1,5 +1,11 @@
 name: VS Code Extension
 
+# Runs from the Nix flake's vscode shell: the pinned Rust toolchain (with
+# the wasm32-unknown-unknown std from rust-toolchain.toml), Node 24, and
+# the wasm-bindgen CLI at the flake's version — the same lockstep pin the
+# dev shell documents, so the CLI can never drift from the Cargo.toml
+# wasm-bindgen pin the way an independently-installed binary could.
+# scripts/build-wasm.mjs still verifies the match and fails fast.
 on:
   push:
     branches: [ main ]
@@ -17,55 +23,39 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: nightly-2026-03-15
-          components: rust-src, rustfmt, clippy
-          target: wasm32-unknown-unknown
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v22
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 24
-          cache: npm
-          cache-dependency-path: editors/vscode/package-lock.json
-
-      # Must equal the workspace's exact wasm-bindgen pin (Cargo.toml);
-      # scripts/build-wasm.mjs verifies the match and fails the build fast.
-      - name: Install wasm-bindgen CLI
-        uses: taiki-e/install-action@v2
-        with:
-          tool: wasm-bindgen@0.2.121
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
 
       - name: Install extension dependencies
-        working-directory: editors/vscode
-        run: npm ci
+        run: nix develop .#vscode --command bash -c 'cd editors/vscode && npm ci'
 
       - name: Test Rust client codec
-        run: cargo test --locked --package reussir-vscode-wasm
+        run: nix develop .#vscode --command cargo test --locked --package reussir-vscode-wasm
 
       - name: Lint Rust client codec
-        run: cargo clippy --locked --package reussir-vscode-wasm --all-targets -- -D warnings
+        run: nix develop .#vscode --command cargo clippy --locked --package reussir-vscode-wasm --all-targets -- -D warnings
 
       - name: Build native language server
-        run: cargo build --locked --package reussir-lsp
+        run: nix develop .#vscode --command cargo build --locked --package reussir-lsp
 
       - name: Build extension and run protocol smoke test
-        working-directory: editors/vscode
         run: |
-          npm run build
-          npm run test:protocol
+          nix develop .#vscode --command bash -c '
+            cd editors/vscode
+            npm run build
+            npm run test:protocol
+          '
 
       - name: Package VSIX
-        working-directory: editors/vscode
         env:
           REUSSIR_VSIX_OUT: ${{ github.workspace }}/reussir-vscode.vsix
-        run: npm run package:vsix
+        run: nix develop .#vscode --command bash -c 'cd editors/vscode && npm run package:vsix'
 
       - name: Inspect VSIX contents
-        working-directory: editors/vscode
-        run: npx --no-install vsce ls --no-dependencies
+        run: nix develop .#vscode --command bash -c 'cd editors/vscode && npx --no-install vsce ls --no-dependencies'
 
       - name: Upload VSIX
         uses: actions/upload-artifact@v4

--- a/flake.nix
+++ b/flake.nix
@@ -445,6 +445,33 @@ PRESETS_EOF
             echo ""
           '';
         };
+
+        # ---------------------------------------------------------------------------
+        # Lean CI shells. The pure-Rust pipelines don't need the LLVM/MLIR
+        # closure the default shell drags in, and CI startup time is dominated
+        # by store downloads — so give them exactly what they use.
+        # ---------------------------------------------------------------------------
+
+        # rene tests and the reussir-rt Miri pipeline: the pinned toolchain
+        # (rust-toolchain.toml supplies miri and the wasm stds) plus the
+        # stdenv cc that build scripts and test links need.
+        devShells.rust = pkgs.mkShell {
+          name = "reussir-rust";
+          packages = [ rustToolchain ];
+        };
+
+        # VS Code extension pipeline: the wasm codec build, the TypeScript
+        # bundling, and the VSIX packaging. wasm-bindgen-cli from nixpkgs is
+        # the same version-lockstep pin the default shell documents;
+        # scripts/build-wasm.mjs still verifies it against Cargo.lock.
+        devShells.vscode = pkgs.mkShell {
+          name = "reussir-vscode";
+          packages = [
+            rustToolchain
+            pkgs.nodejs_24
+            pkgs.wasm-bindgen-cli
+          ];
+        };
       }
     );
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -3,5 +3,10 @@ channel = "nightly-2026-03-15"
 # rust-src feeds the sanitized runtime variants: the memory/thread builds
 # compile std themselves (-Zbuild-std, see crates/reussir-rt/CMakeLists.txt).
 # Declaring it here provisions it through rustup and the Nix flake alike.
-components = ["rust-src"]
-targets = ["wasm32-unknown-unknown", "wasm32-wasip1-threads"]
+# miri backs the reussir-rt Miri CI pipeline, which runs from the flake
+# toolchain.
+components = ["rust-src", "miri"]
+# Both wasip1 flavors: the WebAssembly lit suites cross-build packages for
+# each, and a missing std turns the matching suite UNSUPPORTED instead of
+# running it.
+targets = ["wasm32-unknown-unknown", "wasm32-wasip1", "wasm32-wasip1-threads"]


### PR DESCRIPTION
Stacked on #601. The Linux test pipelines now run from `nix develop`, so CI uses exactly the toolchain every developer gets locally — pinned LLVM/MLIR 22, clang, lit, wasmer, and the fenix Rust toolchain — on both x86_64 and aarch64. No apt.llvm.org, no external installers: an upstream formula or repo bump can no longer break these pipelines the way the lit 23 and Homebrew LLVM 23 releases did.

**Per workflow**
- **mlir-cpp-test**: `DeterminateSystems/nix-installer-action` + `nix develop` steps using the shellHook-written `nix-dev` preset; the `llvm-version` matrix dimension is gone (the flake pins 22). **sccache is unchanged** — `nix develop` appends the host PATH (verified empirically), so the ccache-action binary and its GitHub-cache save/restore keep working, and the nix compilers' fixed store paths give it *stabler* keys than apt's silently-updated packages. The cache key namespace changed to `<os>-nix`, so first run per arch is cold.
- **rene-test**: Linux legs run from a new lean `devShells.rust` (no LLVM/MLIR closure to download); macOS/Windows legs keep rustup, unchanged.
- **miri-reussir-rt**: runs from `devShells.rust`; miri now comes from `rust-toolchain.toml`.
- **vscode-extension**: runs from a new `devShells.vscode` (Rust + Node 24 + wasm-bindgen-cli), making the CLI↔crate version lockstep structural instead of a manually-synced `taiki-e/install-action` pin.
- **rust-toolchain.toml**: adds `miri` and the `wasm32-wasip1` target (Linux CI provisioned it via rustup before; without it that lit suite silently reports UNSUPPORTED under the flake).
- **nightly-release build-linux deliberately stays on apt**: nix-linked binaries carry a `/nix/store` ELF interpreter, which would break the release artifacts' bare-environment guarantee (comment added in the workflow).

**Verified locally in the actual flake shells**
- full C++ pipeline: `cmake --preset nix-dev` configure with `REUSSIR_RUNTIME_SANITIZERS="address;leak;memory;thread"`, 312-target build + sanitized runtimes, 32/32 unit tests
- lit integration suite: **535/536 pass**, the one UNSUPPORTED being `codegen/dynlib_windows.rr` (Windows-only by design) — sanitizer, wasm, and debuginfo suites all ran
- rene: `clippy -D warnings` clean + tests green in `devShells.rust`
- miri: 39 tests green from the flake toolchain
- `devShells.vscode`: node v24.16.0, wasm-bindgen 0.2.121 (the lockstep pin)
- host-PATH sccache resolves inside `nix develop`
- actionlint clean on all four workflows

**Caveats**
- Nix store substitution replaces the apt install time; no store caching action yet — cache.nixos.org is fast, and `nix-community/cache-nix-action` can be added later if it becomes the bottleneck.
- `Swatinem/rust-cache` in the lean jobs keys off the runner's preinstalled rustc (it runs outside the shell) — occasional cold cargo cache at worst, never a correctness issue.
- The migrated workflows only trigger on PRs targeting `main`, so CI proves them out once this retargets to main after #601 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FxBAMmJ3CUQxPFuX73fWh6

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/602"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790631713&installation_model_id=426051&pr_number=602&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F602&signature=ce51a47e323a6e8f6dcc2b2bb15fb8168c44929094a46c796b42aa19e4d09200"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->