### PR TITLE
[ci] migrate the macOS pipeline to the Nix flake

### DIFF
--- a/.github/workflows/mlir-cpp-test-macos.yml
+++ b/.github/workflows/mlir-cpp-test-macos.yml
@@ -1,5 +1,11 @@
-name: macOS Full Pipeline (Homebrew)
+name: macOS Full Pipeline (Nix)
 
+# The toolchain comes from the Nix flake, same as the Linux pipelines:
+# pinned LLVM/MLIR 22, clang, lit, wasmer, and the fenix Rust toolchain
+# (whose rust-toolchain.toml supplies the wasm stds the WebAssembly
+# suites cross-build against). No Homebrew — an unversioned formula bump
+# cannot break this pipeline again (see the llvm@22 incident), and the
+# whole aarch64-darwin closure is served by cache.nixos.org.
 on:
   push:
     branches: [ main ]
@@ -11,12 +17,8 @@ permissions:
 
 jobs:
   build:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [macos-15]  # ARM64 macOS runner
+    runs-on: macos-15
 
-    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -26,70 +28,54 @@ jobs:
       - name: Restore file timestamps
         uses: chetan/git-restore-mtime-action@v2
 
-      - name: Install Homebrew dependencies
-        run: |
-          brew update
-          # wasmer runs the WebAssembly suites' modules
-          # (tests/integration/rene/wasi_*.rr); CMake finds it on PATH at
-          # configure time, which is what turns the `wasmer` lit feature on.
-          # llvm@22 (keg-only) pins the toolchain: FindLLVM.cmake requires
-          # LLVM 22.x and the unversioned formula moved on to 23.
-          brew install cmake ninja llvm@22 spdlog googletest python@3 wasmer
-          pip3 install 'lit<24' --break-system-packages
-
-      - name: Setup Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: nightly-2026-03-15
-          components: rust-src, rustfmt, clippy
-          # Cross-building those same suites: the runtime bake, the polyffi
-          # textures and the launcher link are rustc invocations that need
-          # the target's standard library. Missing one, the matching lit
-          # feature stays off and its suite reports UNSUPPORTED.
-          target: wasm32-wasip1, wasm32-wasip1-threads
-
-      - name: Setup environment paths
-        run: |
-          LLVM_PREFIX=$(brew --prefix llvm@22)
-          echo "LLVM_PREFIX=${LLVM_PREFIX}" >> $GITHUB_ENV
-          echo "${LLVM_PREFIX}/bin" >> $GITHUB_PATH
-          # llvm@22 is keg-only: its lib dir no longer implies the shared
-          # Homebrew lib dir on the linker path, so -lzstd/-lxml2 from
-          # llvm-sys/tblgen-sys stop resolving without this.
-          echo "LIBRARY_PATH=$(brew --prefix)/lib" >> $GITHUB_ENV
-          echo "DYLD_LIBRARY_PATH=${LLVM_PREFIX}/lib:$DYLD_LIBRARY_PATH" >> $GITHUB_ENV
-          echo "LLVM_SYMBOLIZER_PATH=${LLVM_PREFIX}/bin/llvm-symbolizer" >> $GITHUB_ENV
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v22
 
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
           variant: sccache
-          key: ${{ matrix.os }}-llvm
+          key: macos-15-nix
+
+      # Materialize the dev shell up front so toolchain substitution has its
+      # own timing and log section. The shellHook writes CMakeUserPresets.json
+      # (the nix-dev preset used below) on every entry.
+      - name: Build dev shell
+        run: nix develop --command true
 
       - name: Configure CMake
         run: |
-          env RUSTC_WRAPPER=sccache \
-          cmake -B build \
-          -G Ninja \
-          -DCMAKE_CXX_COMPILER="${LLVM_PREFIX}/bin/clang++" \
-          -DCMAKE_C_COMPILER="${LLVM_PREFIX}/bin/clang" \
-          -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-          -DREUSSIR_ENABLE_PEDANTIC=ON \
-          -DREUSSIR_ENABLE_TESTS=ON \
-          -DCMAKE_C_COMPILER_LAUNCHER=sccache \
-          -DCMAKE_CXX_COMPILER_LAUNCHER=sccache \
-          -DLLVM_DIR="${LLVM_PREFIX}/lib/cmake/llvm" \
-          -DMLIR_DIR="${LLVM_PREFIX}/lib/cmake/mlir"
+          nix develop --command bash -c '
+            env RUSTC_WRAPPER=sccache \
+            cmake --preset nix-dev -B build \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DREUSSIR_ENABLE_PEDANTIC=ON \
+            -DREUSSIR_ENABLE_TESTS=ON \
+            -DCMAKE_C_COMPILER_LAUNCHER=sccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
+          '
 
       - name: Build
-        run: cmake --build build --parallel
+        run: |
+          nix develop --command bash -c '
+            env RUSTC_WRAPPER=sccache \
+            cmake --build build --parallel
+          '
 
       - name: Run Unit Tests
         run: |
-          cmake --build build --target reussir-ut
-          ctest --test-dir build --output-on-failure
+          nix develop --command bash -c '
+            cmake --build build --target reussir-ut
+            ctest --test-dir build --output-on-failure
+          '
 
       - name: Run Integration Tests
+        # The nix toolchain links dylibs by absolute store install names, so
+        # unlike the old Homebrew setup no LLVM path is needed here; the
+        # build tree's own lib dir stays exported as insurance for tests
+        # that load Reussir dylibs without an rpath entry.
         run: |
-          export DYLD_LIBRARY_PATH="${GITHUB_WORKSPACE}/build/lib:${LLVM_PREFIX}/lib:$DYLD_LIBRARY_PATH"
-          cmake --build build --target check
+          nix develop --command bash -c '
+            export DYLD_LIBRARY_PATH="$PWD/build/lib${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}"
+            cmake --build build --target check
+          '


### PR DESCRIPTION
Stacked on #606 (which stacks on #605).

Completes the CI-on-nix story: the macOS Full Pipeline now runs from `nix develop` with the flake's pinned LLVM/MLIR 22, clang, lit, wasmer, and Rust toolchain instead of Homebrew formulas. The `llvm@22` keg-only pin (and its `LIBRARY_PATH` workaround) this replaces existed precisely because an unversioned formula bump broke the pipeline — that class of failure is gone.

**De-risked from Linux before pushing** (no macOS hardware here):
- `devShells.aarch64-darwin.default` **evaluates cleanly** (`nix eval .#devShells.aarch64-darwin.default.drvPath`)
- the heavy closure is **verified present on cache.nixos.org** for aarch64-darwin — mlir 22.1.8, llvm-lib 22.1.8, clang-wrapper 22.1.8, wasmer 7.2.0, gdb 17.1 all return narinfo 200 — so nothing compiles from source on the runner
- wasm stds now come from `rust-toolchain.toml` (added in #604) rather than a setup-rust target list
- sccache: same host-PATH-append behavior as verified for Linux

The old `DYLD_LIBRARY_PATH` LLVM export is gone (nix dylibs carry absolute store install names); the build tree's own `lib/` stays exported in the check step as insurance.

The real end-to-end proof is this PR's own macOS run once the stack retargets to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FxBAMmJ3CUQxPFuX73fWh6

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/607"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790632316&installation_model_id=426051&pr_number=607&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F607&signature=1c31ba6e29f187a02f89628c6f695a5010c6bf3772cf36341809e0c213617ca2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->