### PR TITLE
[cmake] give clang-scan-deps the spdlog/fmt include dirs under nix

### DIFF
--- a/lib/Bridge/CMakeLists.txt
+++ b/lib/Bridge/CMakeLists.txt
@@ -61,3 +61,23 @@ target_sources(MLIRReussirBridge
 if(REUSSIR_HAS_TPDE)
   target_compile_definitions(MLIRReussirBridge PRIVATE REUSSIR_HAS_TPDE)
 endif()
+
+# Nix scan-deps workaround, spdlog/fmt edition (see the NIX_STORE branch in
+# the top-level CMakeLists): on darwin, spdlog's and fmt's interface include
+# dirs coincide with the nix cc wrapper's implicit dirs, so CMake elides
+# their -I flags — the wrapped compiler still finds the headers through its
+# environment, but clang-scan-deps (the raw binary) does not and the module
+# scan fails with "spdlog/spdlog.h file not found". Raw compile options are
+# never elided. Kept out of the top level because find_package(spdlog) there
+# would leak SPDLOG_FMT_EXTERNAL into tpde's vendored spdlog subproject.
+if(DEFINED ENV{NIX_STORE})
+  get_target_property(REUSSIR_SPDLOG_INCS spdlog::spdlog INTERFACE_INCLUDE_DIRECTORIES)
+  set(REUSSIR_SCANDEP_INCS ${REUSSIR_SPDLOG_INCS})
+  if(TARGET fmt::fmt)
+    get_target_property(REUSSIR_FMT_INCS fmt::fmt INTERFACE_INCLUDE_DIRECTORIES)
+    list(APPEND REUSSIR_SCANDEP_INCS ${REUSSIR_FMT_INCS})
+  endif()
+  foreach(inc IN LISTS REUSSIR_SCANDEP_INCS)
+    target_compile_options(MLIRReussirBridge PRIVATE "-I${inc}")
+  endforeach()
+endif()


### PR DESCRIPTION
Fixes the first-run failure of **macOS Full Pipeline (Nix)** on `b3090f4` (run 33290262546): module scanning in `lib/Bridge` died with `'spdlog/spdlog.h' file not found`.

**Cause:** on darwin, spdlog's and fmt's interface include dirs coincide with the nix cc wrapper's implicit include dirs, so CMake elides their `-I` flags — the wrapped compiler finds the headers via its environment, but `clang-scan-deps` is a raw binary and doesn't. Same class as the existing top-level `NIX_STORE` workaround for MLIR/LLVM/GTest.

**Fix:** inject them as raw `target_compile_options` on `MLIRReussirBridge` (raw options are never elided), scoped to `lib/Bridge` — a top-level `find_package(spdlog)` leaks `SPDLOG_FMT_EXTERNAL` into tpde's vendored spdlog and breaks configure (verified while iterating).

Verified on Linux: configure clean, the Bridge modules target rebuilds from scratch. The macOS proof is this landing's own CI run.

Everything else in the landed stack debuted green: Windows Cross (xwin+wine) ✅, VS Code Extension ✅, CodeQL ✅; MLIR MultiArch and Nightly Release were still running at last check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FxBAMmJ3CUQxPFuX73fWh6

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/610"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790656041&installation_model_id=426051&pr_number=610&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F610&signature=c6a80cdab9489f0d34b0441e88d826200a70cec0c5c88d315d965621b12bfef4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->