### PR TITLE
[ci][release] verify Linux artifacts outside the nix shell

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -113,22 +113,30 @@ jobs:
             nix run --inputs-from . nixpkgs#patchelf -- \
               --set-interpreter "$INTERP" --remove-rpath "${PREFIX}"/bin/*
 
-            # Verify: system-resolved dynamic deps only, and each binary
-            # starts from a bare environment against the stock runner
-            # glibc — exactly what end-user machines provide.
-            for bin in rrc rene rrepl reussir-lsp; do
-              echo "--- ldd ${bin}"
-              ldd "${PREFIX}/bin/${bin}"
-              if ldd "${PREFIX}/bin/${bin}" | grep -Ei "libLLVM|libMLIR|/nix/store|not found"; then
-                echo "::error::${bin} has unexpected dynamic dependencies"
-                exit 1
-              fi
-              env -i PATH=/usr/bin:/bin "${PREFIX}/bin/${bin}" --help > /dev/null
-            done
-
-            XZ_OPT=-6 tar -cJf "${PREFIX}.tar.xz" "${PREFIX}"
-            echo "ARCHIVE_NAME=${PREFIX}.tar.xz" >> "$GITHUB_ENV"
+            echo "REUSSIR_PREFIX=${PREFIX}" >> "$GITHUB_ENV"
           '
+
+      # Deliberately OUTSIDE nix develop: the dev shell exports
+      # LD_LIBRARY_PATH full of store paths, which makes ldd resolve every
+      # library to /nix/store and trips the gate below even on correctly
+      # patched binaries. The stock runner environment is exactly what
+      # end-user machines provide.
+      - name: Verify and archive
+        run: |
+          set -euo pipefail
+          PREFIX="${REUSSIR_PREFIX}"
+          for bin in rrc rene rrepl reussir-lsp; do
+            echo "--- ldd ${bin}"
+            ldd "${PREFIX}/bin/${bin}"
+            if ldd "${PREFIX}/bin/${bin}" | grep -Ei "libLLVM|libMLIR|/nix/store|not found"; then
+              echo "::error::${bin} has unexpected dynamic dependencies"
+              exit 1
+            fi
+            env -i PATH=/usr/bin:/bin "${PREFIX}/bin/${bin}" --help > /dev/null
+          done
+
+          XZ_OPT=-6 tar -cJf "${PREFIX}.tar.xz" "${PREFIX}"
+          echo "ARCHIVE_NAME=${PREFIX}.tar.xz" >> "$GITHUB_ENV"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Fixes the `build-linux` Package failures in the first all-nix Nightly Release run (both arches): the ldd no-store-refs gate ran **inside** `nix develop`, whose shellHook exports an `LD_LIBRARY_PATH` full of store paths — so `ldd` resolved every library to `/nix/store` even though the binaries were correctly patchelf'd (the failing log shows the standard `/lib64` interpreter alongside store-resolved libs, i.e. the patch worked and the check environment was wrong).

The Package step now ends after patchelf; a new **Verify and archive** step runs in the stock runner environment — which is exactly what end-user machines provide, i.e. what the gate is meant to prove. macOS needs no equivalent change: `otool -L` reads static load commands, unaffected by environment.

Companion to #610 (macOS scan-deps fix, already in the merge queue); the `build-windows` cross job passed its first CI run untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FxBAMmJ3CUQxPFuX73fWh6

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/611"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790656564&installation_model_id=426051&pr_number=611&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F611&signature=ce82a16bb6c6fce130beccccbf23dbf9cb8536c1dfc807c82383f1440ce88dba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->