### PR TITLE
[nix] gdb is Linux-only in the dev shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -262,7 +262,6 @@
             # zlib / libxml2 are LLVM link-time deps on some targets
             pkgs.zlib
             pkgs.libxml2
-            pkgs.gdb
 
             # The engine the WebAssembly lit suites run their modules on
             # (tests/integration/rene/wasi_*.rr). Those suites also want the
@@ -272,6 +271,13 @@
             # to the fenix toolchain above. Missing either piece, a suite
             # reports UNSUPPORTED rather than failing.
             pkgs.wasmer
+          ]
+          # Linux only: gdb cannot properly debug arm64 Mach-O binaries, and
+          # shipping it on darwin flips the lit `gdb` feature on — which made
+          # tests/integration/debuginfo/gdb_print.rr run (and fail) on macOS
+          # where it had always been UNSUPPORTED. lldb covers darwin.
+          ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
+            pkgs.gdb
           ];
 
           # libomp: the OpenMP e2e lit tests probe `clang -fopenmp` and are


### PR DESCRIPTION
Second and final macOS-nix debut fix. With #610 the macOS build now compiles fully; the run on `e58404c` failed exactly one lit test — `tests/integration/debuginfo/gdb_print.rr`.

**Cause:** the flake ships `pkgs.gdb` unconditionally, and nixpkgs has a working gdb 17.1 *package* for aarch64-darwin — so on macOS the lit `gdb` feature turned on for the first time ever (Homebrew arm64 runners never had gdb; the suite was always UNSUPPORTED there). gdb can't properly debug arm64 Mach-O binaries, so the test fails.

**Fix:** `pkgs.gdb` moves behind `lib.optionals stdenv.isLinux`, restoring the exact prior macOS behavior (suite UNSUPPORTED, lldb covers darwin) while Linux keeps full gdb coverage — verified on the Linux shell, and the aarch64-darwin shell still evaluates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FxBAMmJ3CUQxPFuX73fWh6

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/612"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790657233&installation_model_id=426051&pr_number=612&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F612&signature=194413b1db3de5aa3e7a88215c9c51f7ebb27f2df53536ba80e235f0cd20fd63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->