### PR TITLE
[tests] retire the cross-wine gates — the wine toolchain is required

### DIFF
--- a/tests/integration/codegen/executable.rr
+++ b/tests/integration/codegen/executable.rr
@@ -1,7 +1,3 @@
-// The link stage has the host rustc drive the linker, which Wine cannot
-// await (no waitable handle for unix children); see
-// tests/integration/rene/lit.local.cfg.
-// UNSUPPORTED: cross-wine
 // `rrc --emit executable`: the driver finishes the stage chain with a link
 // step — the program's objects, the embedded Rust launcher
 // (crates/reussir-rt/launcher/main.rs, so the program starts under the full

--- a/tests/integration/conversion/nested_polyffi.mlir
+++ b/tests/integration/conversion/nested_polyffi.mlir
@@ -1,8 +1,4 @@
 // UNSUPPORTED: darwin
-// cross-wine: the polyffi pass writes its generated Rust module into the
-// Wine-side temp directory and spawns the host rustc, which cannot see it
-// across the unix/windows filesystem boundary.
-// UNSUPPORTED: cross-wine
 // RUN: %reussir-opt --reussir-compile-polymorphic-ffi=optimized %s \
 // RUN:   -reussir-lowering-basic-ops --convert-to-llvm \
 // RUN:   --reconcile-unrealized-casts | %reussir-translate --reussir-to-llvmir \

--- a/tests/integration/frontend/extern_link.rr
+++ b/tests/integration/frontend/extern_link.rr
@@ -1,6 +1,3 @@
-// polyffi spawns the host rustc, which Wine cannot await (no waitable
-// handle for unix children); see tests/integration/rene/lit.local.cfg.
-// UNSUPPORTED: cross-wine
 // The full cross-package build: the dependency compiles once into a
 // staticlib + interface, the consumer instantiates its generics locally
 // (`weak_odr`, so any other unit's identical instance collapses with it)

--- a/tests/integration/frontend/ffi_btree_set_record_e2e.rr
+++ b/tests/integration/frontend/ffi_btree_set_record_e2e.rr
@@ -1,6 +1,3 @@
-// polyffi spawns the host rustc, which Wine cannot await (no waitable
-// handle for unix children); see tests/integration/rene/lit.local.cfg.
-// UNSUPPORTED: cross-wine
 // UNSUPPORTED: darwin
 // A Rust BTreeSet orders compiler-owned Reussir records through the Ord
 // bridge. Keeping `old` live while deriving `new` shares the runtime set;

--- a/tests/integration/frontend/ffi_cmp_bridge_capabilities_e2e.rr
+++ b/tests/integration/frontend/ffi_cmp_bridge_capabilities_e2e.rr
@@ -1,6 +1,3 @@
-// polyffi spawns the host rustc, which Wine cannot await (no waitable
-// handle for unix children); see tests/integration/rene/lit.local.cfg.
-// UNSUPPORTED: cross-wine
 // UNSUPPORTED: darwin
 // Exact comparison capabilities on compiler-owned shared values crossing
 // PolyFFI. Each probe takes the element before its bounded Vec: rendering the

--- a/tests/integration/frontend/ffi_cmp_bridge_fn_bound_e2e.rr
+++ b/tests/integration/frontend/ffi_cmp_bridge_fn_bound_e2e.rr
@@ -1,6 +1,3 @@
-// polyffi spawns the host rustc, which Wine cannot await (no waitable
-// handle for unix children); see tests/integration/rene/lit.local.cfg.
-// UNSUPPORTED: cross-wine
 // UNSUPPORTED: darwin
 // An `#[ffi(import)]` signature can be the only source of a comparison
 // requirement: no bounded container appears here, yet the Rust bodies compare

--- a/tests/integration/frontend/ffi_debug.rr
+++ b/tests/integration/frontend/ffi_debug.rr
@@ -1,6 +1,3 @@
-// polyffi spawns the host rustc, which Wine cannot await (no waitable
-// handle for unix children); see tests/integration/rene/lit.local.cfg.
-// UNSUPPORTED: cross-wine
 // UNSUPPORTED: darwin
 // Debug info over opaque FFI records: an `ffi_object` payload answers
 // layout queries with its visible header (the `u32` refcount the FFI

--- a/tests/integration/frontend/ffi_flags.rr
+++ b/tests/integration/frontend/ffi_flags.rr
@@ -1,6 +1,3 @@
-// polyffi spawns the host rustc, which Wine cannot await (no waitable
-// handle for unix children); see tests/integration/rene/lit.local.cfg.
-// UNSUPPORTED: cross-wine
 // UNSUPPORTED: darwin
 // The explicit polyffi toolchain flags: `--polyffi-rust-path` and
 // `--polyffi-libdir` pin the rustc executable and the package directories the

--- a/tests/integration/frontend/ffi_member_drop.rr
+++ b/tests/integration/frontend/ffi_member_drop.rr
@@ -1,6 +1,3 @@
-// polyffi spawns the host rustc, which Wine cannot await (no waitable
-// handle for unix children); see tests/integration/rene/lit.local.cfg.
-// UNSUPPORTED: cross-wine
 // UNSUPPORTED: darwin
 // Regression test: an FFI object stored inside a record/variant member,
 // released through the transitive drop glue. The acquire/drop expansion

--- a/tests/integration/frontend/ffi_string_e2e.rr
+++ b/tests/integration/frontend/ffi_string_e2e.rr
@@ -1,6 +1,3 @@
-// polyffi spawns the host rustc, which Wine cannot await (no waitable
-// handle for unix children); see tests/integration/rene/lit.local.cfg.
-// UNSUPPORTED: cross-wine
 // UNSUPPORTED: darwin
 // End-to-end polymorphic FFI over the runtime's copy-on-write string:
 // build a Rust `String` from Reussir one `char` at a time, measure it on

--- a/tests/integration/frontend/ffi_vec.rr
+++ b/tests/integration/frontend/ffi_vec.rr
@@ -1,6 +1,3 @@
-// polyffi spawns the host rustc, which Wine cannot await (no waitable
-// handle for unix children); see tests/integration/rene/lit.local.cfg.
-// UNSUPPORTED: cross-wine
 // UNSUPPORTED: darwin
 // The polymorphic-FFI frontend surface (docs/design/polymorphic-ffi.md):
 // an opaque `#[ffi]` record lowers to an rc'd `ffi_object`, every

--- a/tests/integration/frontend/ffi_vec_e2e.rr
+++ b/tests/integration/frontend/ffi_vec_e2e.rr
@@ -1,6 +1,3 @@
-// polyffi spawns the host rustc, which Wine cannot await (no waitable
-// handle for unix children); see tests/integration/rene/lit.local.cfg.
-// UNSUPPORTED: cross-wine
 // UNSUPPORTED: darwin
 // End-to-end polymorphic FFI: build a Rust `Vec<f64>` from Reussir, sum it
 // on the Rust side (consuming and dropping the vector there), and export

--- a/tests/integration/frontend/ffi_vec_record_e2e.rr
+++ b/tests/integration/frontend/ffi_vec_record_e2e.rr
@@ -1,6 +1,3 @@
-// polyffi spawns the host rustc, which Wine cannot await (no waitable
-// handle for unix children); see tests/integration/rene/lit.local.cfg.
-// UNSUPPORTED: cross-wine
 // UNSUPPORTED: darwin
 // End-to-end clone/drop across the FFI in both directions: a Rust
 // `Vec<List>` holds Reussir enum boxes through the generated

--- a/tests/integration/frontend/instrument_nonlinear_ffi.rr
+++ b/tests/integration/frontend/instrument_nonlinear_ffi.rr
@@ -1,6 +1,3 @@
-// polyffi spawns the host rustc, which Wine cannot await (no waitable
-// handle for unix children); see tests/integration/rene/lit.local.cfg.
-// UNSUPPORTED: cross-wine
 // UNSUPPORTED: darwin
 // `--instrument-nonlinear-ffi` guards every FFI-import call that consumes an
 // rc'd ffi/array value with a reference-count check reporting to

--- a/tests/integration/frontend/instrument_nonlinear_ffi_e2e.rr
+++ b/tests/integration/frontend/instrument_nonlinear_ffi_e2e.rr
@@ -1,6 +1,3 @@
-// polyffi spawns the host rustc, which Wine cannot await (no waitable
-// handle for unix children); see tests/integration/rene/lit.local.cfg.
-// UNSUPPORTED: cross-wine
 // UNSUPPORTED: darwin
 // End-to-end `--instrument-nonlinear-ffi`: `v` is consumed by the first
 // `total` while still shared with the second (Perceus retains it before the

--- a/tests/integration/frontend/main_attribute.rr
+++ b/tests/integration/frontend/main_attribute.rr
@@ -1,6 +1,3 @@
-// polyffi spawns the host rustc, which Wine cannot await (no waitable
-// handle for unix children); see tests/integration/rene/lit.local.cfg.
-// UNSUPPORTED: cross-wine
 // `#[main]` names the program's entry point. It is exported under the fixed
 // symbol `__reussir_main`, through the same trampoline path an explicit
 // `extern "C" trampoline` takes.

--- a/tests/integration/frontend/str_ffi_e2e.rr
+++ b/tests/integration/frontend/str_ffi_e2e.rr
@@ -1,6 +1,3 @@
-// polyffi spawns the host rustc, which Wine cannot await (no waitable
-// handle for unix children); see tests/integration/rene/lit.local.cfg.
-// UNSUPPORTED: cross-wine
 // A `str` crosses the polymorphic FFI boundary as the runtime's
 // `#[repr(C)] Str<'static>` — bit-identical to the lowered `{ptr, len}`
 // pair — in both directions: as a parameter into a Rust body, and back out

--- a/tests/integration/frontend/trait_pipeline.rr
+++ b/tests/integration/frontend/trait_pipeline.rr
@@ -1,6 +1,3 @@
-// polyffi spawns the host rustc, which Wine cannot await (no waitable
-// handle for unix children); see tests/integration/rene/lit.local.cfg.
-// UNSUPPORTED: cross-wine
 // A self-contained trait program through the whole resumable pipeline: the
 // HIR dump carries the trait items and `TraitCall`s, re-prints losslessly,
 // reaches the same MIR whether monomorphized directly or resumed from the

--- a/tests/integration/lit.cfg.py
+++ b/tests/integration/lit.cfg.py
@@ -30,41 +30,42 @@ config.test_exec_root = os.path.join(config.test_output_root, 'test')
 # Windows-target tools driven from a linux host (the xwin cross build, run
 # through Wine/binfmt): a feature for the few tests that straddle the
 # unix/windows process boundary in ways Wine cannot bridge.
-# REUSSIR_CROSS_WINE_UNGATE=1 suppresses the gate for experiments with a
-# windows-native rustc under Wine; REUSSIR_RUSTC_OVERRIDE and
-# REUSSIR_LIBRARY_PATH_OVERRIDE redirect %rustc_path / %library_path (and
-# REUSSIR_RUSTC) without reconfiguring.
+# REUSSIR_RUSTC_OVERRIDE and REUSSIR_LIBRARY_PATH_OVERRIDE redirect
+# %rustc_path / %library_path (and REUSSIR_RUSTC) without reconfiguring.
 # The TARGET platform: a cross run produces and executes windows binaries
 # even though the host is unix; platform-keyed features and substitutions
 # key on this, not on sys.platform.
 _target_is_windows = (sys.platform == 'win32'
                       or config.reussir_rrc_path.endswith('.exe'))
 if config.reussir_rrc_path.endswith('.exe') and sys.platform != 'win32':
-    # Genuine Wine-environment limitations (console emulation quirks etc.)
-    # stay gated even when everything below is available.
+    # Genuine Wine-environment limitations (console emulation quirks, JIT
+    # section layout) stay gated even with the full toolchain available.
     config.available_features.add('wine-quirks')
-    # With the windows-native Rust toolchain baked
-    # (reussir-bake-msvc-rustc; the windows-cross shell exports
-    # REUSSIR_MSVC_RUSTC) and the runtime tree built by wine-cargo
-    # (target-rt-wine — proc macros as windows DLLs), the polyffi/rene/link
-    # suites run under Wine and the cross-wine gate lifts itself. Missing
-    # either piece, those suites stay gated.
+    # The windows-native Rust toolchain (reussir-bake-msvc-rustc; the
+    # windows-cross shell exports REUSSIR_MSVC_RUSTC) and the runtime tree
+    # built by wine-cargo (target-rt-wine — proc macros as windows DLLs)
+    # are REQUIRED for cross lit runs: without them the polyffi suites
+    # cannot compile and rene would wait forever on an unspawnable unix
+    # cargo. Fail fast with instructions instead of degrading.
     _wine_rustc = os.environ.get('REUSSIR_MSVC_RUSTC', '')
     _wine_deps = os.path.join(
         os.path.dirname(os.path.dirname(config.test_output_root)),
         'target-rt-wine', 'release', 'deps')
     _wine_ready = bool(_wine_rustc) and os.path.exists(_wine_rustc) \
         and os.path.isdir(_wine_deps)
-    if _wine_ready:
-        config.environment['REUSSIR_RUSTC'] = _wine_rustc
-        config.environment['REUSSIR_RUSTC_DEPS'] = _wine_deps
-        config.library_path = _wine_deps
-        _prev_winepath = os.environ.get('WINEPATH', '')
-        os.environ['WINEPATH'] = (
-            (_prev_winepath + ';' if _prev_winepath else '')
-            + 'z:' + _wine_deps.replace('/', '\\'))
-    elif not os.environ.get('REUSSIR_CROSS_WINE_UNGATE'):
-        config.available_features.add('cross-wine')
+    if not _wine_ready:
+        lit_config.fatal(
+            'cross lit runs need the windows-native Rust toolchain: run '
+            'reussir-bake-msvc-rustc, then build the Wine runtime tree '
+            '(see the windows-cross shell banner for the cargo.exe '
+            'command).')
+    config.environment['REUSSIR_RUSTC'] = _wine_rustc
+    config.environment['REUSSIR_RUSTC_DEPS'] = _wine_deps
+    config.library_path = _wine_deps
+    _prev_winepath = os.environ.get('WINEPATH', '')
+    os.environ['WINEPATH'] = (
+        (_prev_winepath + ';' if _prev_winepath else '')
+        + 'z:' + _wine_deps.replace('/', '\\'))
 else:
     _wine_ready = False
 if os.environ.get('REUSSIR_RUSTC_OVERRIDE'):

--- a/tests/integration/rene/lit.local.cfg
+++ b/tests/integration/rene/lit.local.cfg
@@ -1,5 +1,0 @@
-# rene shells out to the host cargo/rustc for the runtime bake. Under the
-# Windows cross run (PE rene.exe through Wine) that unix subprocess cannot
-# be awaited — Wine returns no waitable handle — so the whole suite wedges.
-if 'cross-wine' in config.available_features:
-    config.unsupported = True

--- a/tests/integration/std/lit.local.cfg
+++ b/tests/integration/std/lit.local.cfg
@@ -1,4 +1,0 @@
-# Driven through rene (see rene/lit.local.cfg): unsupported under the
-# Windows cross run for the same unwaitable-unix-subprocess reason.
-if 'cross-wine' in config.available_features:
-    config.unsupported = True


### PR DESCRIPTION
Per review (*'ffi is working now with rustc.exe but the patch still contains unsupported flags'*): the conditional `cross-wine` feature, its 18 per-file annotations, and the rene/std directory gates are gone (−64 lines). In their place, cross lit runs **fail fast at config load** with bake instructions when the windows toolchain or wine runtime tree is missing — degrading to skips only hid a broken setup (and rene would hang on an unspawnable unix cargo).

`wine-quirks` remains the only wine-specific gate: the console-color assertion (`rene/build_color.rr`) and the JIT repl suite (COFF loader section-layout flakiness), both genuine Wine limitations.

Verified on a bare workstation shell: **464 passed / 73 unsupported / 0 failed, exit 0** — the delta from the previous 489 is exactly the since-gated repl suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FxBAMmJ3CUQxPFuX73fWh6

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/615"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790695724&installation_model_id=426051&pr_number=615&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F615&signature=931e7814e28ed4547f20b8fedd95159203ed6a78cb9214378b56d557308ef221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->