### PR TITLE
[cmake] re-resolve rustc when the cached path is gone

### DIFF
--- a/crates/reussir-rt/CMakeLists.txt
+++ b/crates/reussir-rt/CMakeLists.txt
@@ -27,6 +27,16 @@ set(REUSSIR_RT_TARGET_DIR "${REUSSIR_RT_TARGET_DIR}" PARENT_SCOPE)
 # dylib's dynamically linked libstd lives at link and load time. Going
 # through PATH respects rustup shims, so rust-toolchain.toml still selects
 # the pinned toolchain.
+#
+# find_program caches never re-validate: after a toolchain bump the nix
+# store path this resolved to can be garbage-collected, and every later
+# reconfigure of the build dir dies on the dead cache entry. Drop a stale
+# entry so the lookup re-runs against the current shell.
+if(REUSSIR_RUSTC_PATH AND NOT EXISTS "${REUSSIR_RUSTC_PATH}")
+    message(STATUS
+        "Cached rustc ${REUSSIR_RUSTC_PATH} no longer exists; re-resolving")
+    unset(REUSSIR_RUSTC_PATH CACHE)
+endif()
 find_program(REUSSIR_RUSTC_PATH rustc REQUIRED)
 execute_process(
     COMMAND ${REUSSIR_RUSTC_PATH} --print target-libdir


### PR DESCRIPTION
Fixes the 100%-reproducible local `ninja check` breakage: `REUSSIR_RUSTC_PATH` is a `find_program` cache entry, and the toolchain bump (miri/wasip1 in `rust-toolchain.toml`) changed the fenix derivation — once the old store path was garbage-collected, every reconfigure of an existing build dir died with *'Failed to run rustc --print target-libdir'*.

The lookup now drops a cache entry whose path no longer exists and re-resolves against the current shell. Verified by poisoning the cache with a nonexistent path and reconfiguring.

**Workaround for already-broken build dirs** (until this lands): `cmake -B build -U REUSSIR_RUSTC_PATH`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FxBAMmJ3CUQxPFuX73fWh6

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/616"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790698775&installation_model_id=426051&pr_number=616&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F616&signature=fc5befe8fc88f3ac28cdee134e87850aa1a652433a6b312197188569e52827d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->