### PR TITLE
[rene] replace redb with TurboKV metadata storage

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -23,3 +23,11 @@ CFLAGS = "-DMI_MAX_ALIGN_SIZE=8"
 # per-package build directories.
 [unstable]
 build-dir-new-layout = false
+
+# TurboKV's persisted Bloom filters use gxhash, which requires hardware AES.
+# CMake supplies the same flags for rene because its RUSTFLAGS override these.
+[target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))']
+rustflags = ["-C", "target-feature=+aes,+sse2"]
+
+[target.'cfg(target_arch = "aarch64")']
+rustflags = ["-C", "target-feature=+aes,+neon"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -780,6 +780,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-skiplist"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df29de440c58ca2cc6e587ec3d22347551a32435fbde9d2bff64e78a9ffa151b"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1365,6 +1375,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "gxhash"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ce1bab7aa741d4e7042b2aae415b78741f267a98a7271ea226cd5ba6c43d7d"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1391,6 +1410,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -1999,6 +2020,15 @@ dependencies = [
 
 [[package]]
 name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "lru"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
@@ -2017,6 +2047,15 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "url",
+]
+
+[[package]]
+name = "lz4_flex"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
+dependencies = [
+ "twox-hash",
 ]
 
 [[package]]
@@ -2140,6 +2179,15 @@ name = "memchr"
 version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+
+[[package]]
+name = "memmap2"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memmem"
@@ -2375,6 +2423,16 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -3060,7 +3118,7 @@ dependencies = [
  "hashbrown 0.17.1",
  "itertools 0.14.0",
  "kasuari",
- "lru",
+ "lru 0.18.0",
  "palette",
  "serde",
  "strum",
@@ -3190,15 +3248,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08ad765b21a08b1a8e5cdce052719188a23772bcbefb3c439f0baaf62c56ceac"
 
 [[package]]
-name = "redb"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e925444704b5f17d32bf42f5b6e2df050bceebc3dcd6e71cc73dafe8092e839"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3288,15 +3337,16 @@ dependencies = [
  "palc",
  "ratatui",
  "ratatui-image",
- "redb",
  "sailfish",
  "serde",
  "serde_json",
  "tar",
  "tempfile",
+ "tokio",
  "toml_edit 0.25.12+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
+ "turbokv",
  "zstd",
 ]
 
@@ -3675,6 +3725,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3872,6 +3932,12 @@ name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "snap"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "199905e6153d6405f9728fe44daace35f8f837bbf830bb6e85fbd5828709a886"
 
 [[package]]
 name = "socket2"
@@ -4586,6 +4652,39 @@ checksum = "dd69c5aa8f924c7519d6372789a74eac5b94fb0f8fcf0d4a97eb0bfc3e785f39"
 dependencies = [
  "stable_deref_trait",
 ]
+
+[[package]]
+name = "turbokv"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46cbcdd2035e2c20531bd1f68115f3efecf710d0c6cddf1f22dbd4932da03ce8"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "crc32fast",
+ "crossbeam-skiplist",
+ "gxhash",
+ "libc",
+ "lru 0.12.5",
+ "lz4_flex",
+ "memmap2",
+ "num_cpus",
+ "parking_lot",
+ "serde",
+ "serde_bytes",
+ "snap",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "windows-sys 0.61.2",
+ "zstd",
+]
+
+[[package]]
+name = "twox-hash"
+version = "2.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5283634e518fe9e82c7b20520bb4bc209009fd16c82077c802f8111ecbb0117a"
 
 [[package]]
 name = "typed-arena"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,9 +108,9 @@ mlir-sys = "220"
 # evaluates package manifests (`rene.ncl`) with it.
 nickel-lang = "2.2"
 palc = "0.0.2"
-# `rene`'s build-status store (`reussir-build/rene.redb`); its exclusive file
-# lock doubles as the cross-process build-directory lock.
-redb = "4.1"
+# `rene`'s build-status store (`reussir-build/rene.meta`); its exclusive
+# directory lock doubles as the cross-process build-directory lock.
+turbokv = "0.6"
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["arbitrary_precision"] }
 # tar + zstd bundle the `reussir-rt` source tree into the `rene` binary

--- a/crates/rene/CMakeLists.txt
+++ b/crates/rene/CMakeLists.txt
@@ -18,9 +18,24 @@ else()
     set(RENE_CARGO_PROFILE_DIR "release")
 endif()
 
+# TurboKV's gxhash dependency requires AES instructions. Select features for
+# the Rust target, including when cargo-xwin builds x86_64 on an ARM host.
+if(REUSSIR_CARGO_BUILD_TARGET)
+    set(RENE_ARCH "${REUSSIR_CARGO_BUILD_TARGET}")
+else()
+    set(RENE_ARCH "${CMAKE_SYSTEM_PROCESSOR}")
+endif()
+string(TOLOWER "${RENE_ARCH}" RENE_ARCH)
+set(RENE_RUSTFLAGS "-Awarnings")
+if(RENE_ARCH MATCHES "^(x86_64|amd64|i[3-6]86|x86)(-|$)")
+    string(APPEND RENE_RUSTFLAGS " -Ctarget-feature=+aes,+sse2")
+elseif(RENE_ARCH MATCHES "^(aarch64|arm64)(-|$)")
+    string(APPEND RENE_RUSTFLAGS " -Ctarget-feature=+aes,+neon")
+endif()
+
 set(RENE_CARGO_ENV
     CARGO_TARGET_DIR=${CMAKE_BINARY_DIR}/target
-    RUSTFLAGS=-Awarnings)
+    "RUSTFLAGS=${RENE_RUSTFLAGS}")
 
 set(RENE_BIN rene${CMAKE_EXECUTABLE_SUFFIX})
 

--- a/crates/rene/Cargo.toml
+++ b/crates/rene/Cargo.toml
@@ -32,8 +32,10 @@ palc.workspace = true
 # check over the local path-dependency graph (one available version per
 # package today).
 astral-pubgrub = "0.6"
-# The build-status store; its exclusive file lock is also the build-dir lock.
-redb.workspace = true
+# The build-status store; its exclusive directory lock is also the build-dir lock.
+turbokv.workspace = true
+# TurboKV's I/O and maintenance run on a private runtime in `db`.
+tokio.workspace = true
 serde.workspace = true
 # Re-render the evaluated manifest's JSON export pretty-printed for `build`'s
 # config dump, parse `cargo --message-format=json` output, and encode the

--- a/crates/rene/src/db.rs
+++ b/crates/rene/src/db.rs
@@ -1,14 +1,14 @@
 //! The build directory and its status database.
 //!
-//! `reussir-build/rene.redb` (see [`crate::tables`] for the schema) records
-//! what the build directory already contains. redb holds an exclusive
+//! `reussir-build/rene.meta` (see [`crate::tables`] for the schema) records
+//! what the build directory already contains. TurboKV holds an exclusive
 //! cross-process file lock for as long as the database is open, and that lock
 //! *is* the build-directory lock: `build` opens the database first and keeps
 //! it open for the whole build. Other builds wait for that lock, while
 //! `clean` refuses to delete a directory whose database it cannot open.
 //!
-//! Deleting the database file releases its lock, so `clean` cannot hold the
-//! lock *through* the deletion. Instead it narrows the window: while still
+//! Deleting the database directory removes its lock file, so `clean` cannot
+//! hold the lock *through* deletion. Instead it narrows the window: while still
 //! holding the lock it stamps [`tables::CLEANING_KEY`], then unlocks and
 //! deletes. A `build` that slips in between sees the stamp and refuses the
 //! directory — the same refusal an *interrupted* clean earns, so a
@@ -17,19 +17,29 @@
 //! is the accepted trade-off for not inventing a second locking scheme.
 
 use std::path::{Path, PathBuf};
+use std::sync::Mutex;
 use std::time::Duration;
 
-use redb::{Database, DatabaseError, ReadableDatabase, ReadableTable, TableError};
+use tokio::runtime::Runtime;
+use turbokv::{Db, DbError as TurboError, DbOptions, WriteBatch};
 
 use crate::{deps, tables};
 
-/// The status database's file name inside the build directory.
-pub const DB_FILE: &str = "rene.redb";
+/// The status database's directory name inside the build directory.
+pub const DB_DIR: &str = "rene.meta";
 
 /// An open build directory, holding the status database (and its lock).
 pub struct BuildDir {
     root: PathBuf,
-    db: Database,
+    // Taken by Drop so TurboKV can finish maintenance and release the lock
+    // before the runtime shuts down. Dropping Db alone is not a clean close.
+    db: Option<Db>,
+    // Rene uses compio. Keep TurboKV's Tokio I/O behind this synchronous
+    // adapter; the current-thread runtime runs only during database calls.
+    runtime: Runtime,
+    // Serialize the scan and batch of a replacement if callers share this
+    // handle across threads. A batch alone cannot protect the preceding scan.
+    sources_write: Mutex<()>,
 }
 
 /// Why the build directory could not be opened or cleaned.
@@ -60,20 +70,30 @@ impl BuildDir {
     pub fn open(root: &Path) -> Result<Self, DbError> {
         std::fs::create_dir_all(root)
             .map_err(|e| DbError::Other(format!("cannot create `{}`: {e}", root.display())))?;
-        let path = root.join(DB_FILE);
-        let db = Database::create(&path).map_err(|e| match e {
-            DatabaseError::DatabaseAlreadyOpen => DbError::InUse(path.clone()),
-            other => DbError::Other(format!("cannot open `{}`: {other}", path.display())),
-        })?;
+        let path = root.join(DB_DIR);
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(other)?;
+        // Acknowledge each batch only after its WAL has been synced,
+        // preserving immediate commit durability for the cleaning marker.
+        let db = runtime
+            .block_on(Db::open_with_options(&path, DbOptions::paranoid()))
+            .map_err(|e| match e {
+                TurboError::DirectoryLocked { .. } => DbError::InUse(path.clone()),
+                other => DbError::Other(format!("cannot open `{}`: {other}", path.display())),
+            })?;
         Ok(BuildDir {
             root: root.to_owned(),
-            db,
+            db: Some(db),
+            runtime,
+            sources_write: Mutex::new(()),
         })
     }
 
     /// Open a build directory once its current build, if any, releases the
-    /// database. Redb exposes a non-blocking cross-process lock, so builds
-    /// turn `DatabaseAlreadyOpen` into an asynchronous wait here rather than
+    /// database. TurboKV exposes a non-blocking cross-process lock, so builds
+    /// turn `DirectoryLocked` into an asynchronous wait here rather than
     /// forcing every caller to arrange its own serialization.
     pub async fn open_wait(root: &Path) -> Result<Self, DbError> {
         let mut waiting = false;
@@ -97,18 +117,11 @@ impl BuildDir {
     /// (`rene inspect --frozen`) does not leave a build directory behind in a
     /// package that was never built.
     pub fn open_existing(root: &Path) -> Result<Option<Self>, DbError> {
-        let path = root.join(DB_FILE);
-        if !path.is_file() {
+        let path = root.join(DB_DIR);
+        if !path.try_exists().map_err(other)? {
             return Ok(None);
         }
-        let db = Database::open(&path).map_err(|e| match e {
-            DatabaseError::DatabaseAlreadyOpen => DbError::InUse(path.clone()),
-            other => DbError::Other(format!("cannot open `{}`: {other}", path.display())),
-        })?;
-        Ok(Some(BuildDir {
-            root: root.to_owned(),
-            db,
-        }))
+        Self::open(root).map(Some)
     }
 
     pub fn root(&self) -> &Path {
@@ -116,16 +129,14 @@ impl BuildDir {
     }
 
     /// Read a status value. `None` both for an absent key and for a fresh
-    /// database whose status table was never written.
+    /// database whose status namespace was never written.
     pub fn status(&self, key: &str) -> Result<Option<String>, DbError> {
-        let txn = self.db.begin_read().map_err(other)?;
-        let table = match txn.open_table(tables::STATUS) {
-            Ok(table) => table,
-            Err(TableError::TableDoesNotExist(_)) => return Ok(None),
-            Err(e) => return Err(other(e)),
-        };
-        let value = table.get(key).map_err(other)?;
-        Ok(value.map(|v| v.value().to_owned()))
+        self.runtime
+            .block_on(self.database().get(format!("{}{key}", tables::STATUS)))
+            .map_err(other)?
+            .map(String::from_utf8)
+            .transpose()
+            .map_err(other)
     }
 
     /// Is the directory's teardown in flight or interrupted? Set by
@@ -135,69 +146,71 @@ impl BuildDir {
         Ok(self.status(tables::CLEANING_KEY)?.is_some())
     }
 
-    /// Write status values in one transaction.
+    /// Write status values in one atomic, durable batch.
     pub fn set_status(&self, entries: &[(&str, &str)]) -> Result<(), DbError> {
-        let txn = self.db.begin_write().map_err(other)?;
-        {
-            let mut table = txn.open_table(tables::STATUS).map_err(other)?;
-            for (key, value) in entries {
-                table.insert(key, value).map_err(other)?;
-            }
+        let mut batch = WriteBatch::new();
+        for (key, value) in entries {
+            batch.put(format!("{}{key}", tables::STATUS), value);
         }
-        txn.commit().map_err(other)
+        self.runtime
+            .block_on(self.database().write_batch(&batch))
+            .map_err(other)
     }
 
-    /// The recorded source graph, in path order (redb iterates its keys, and
-    /// the path is the key). Empty both for a fresh database and for one
-    /// whose sources table was never written.
+    /// The recorded source graph, in path order (TurboKV scans keys in byte
+    /// order, and the path follows a fixed prefix). Empty for a fresh database
+    /// or one whose sources namespace was never written.
     pub fn sources(&self) -> Result<Vec<deps::SourceFile>, DbError> {
-        let txn = self.db.begin_read().map_err(other)?;
-        let table = match txn.open_table(tables::SOURCES) {
-            Ok(table) => table,
-            Err(TableError::TableDoesNotExist(_)) => return Ok(Vec::new()),
-            Err(e) => return Err(other(e)),
-        };
-        let mut files = Vec::new();
-        for row in table.iter().map_err(other)? {
-            let (key, value) = row.map_err(other)?;
-            let (module, mtime_ns, size, hash) = value.value();
-            files.push(deps::SourceFile {
-                path: key.value().to_owned(),
-                record: deps::SourceRecord {
-                    module: deps::split_module(module),
-                    mtime_ns,
-                    size,
-                    hash: *hash,
-                },
-            });
-        }
-        Ok(files)
+        self.runtime
+            .block_on(self.database().scan_prefix(tables::SOURCES))
+            .map_err(other)?
+            .into_iter()
+            .map(|(key, value)| {
+                Ok(deps::SourceFile {
+                    path: String::from_utf8(key[tables::SOURCES.len()..].to_vec())
+                        .map_err(other)?,
+                    record: serde_json::from_slice(&value).map_err(other)?,
+                })
+            })
+            .collect()
     }
 
-    /// Replace the whole source graph. The table is emptied first: a rebuilt
-    /// graph is a new snapshot, and a file that dropped out of it must not
+    /// Replace the whole source graph in one batch of deletes and puts. A
+    /// rebuilt graph is a new snapshot, and a file that dropped out must not
     /// survive as a phantom row that would keep invalidating later builds.
     pub fn replace_sources(&self, files: &[deps::SourceFile]) -> Result<(), DbError> {
-        let txn = self.db.begin_write().map_err(other)?;
+        let _guard = self.sources_write.lock().map_err(other)?;
+        let mut batch = WriteBatch::new();
+        for (key, _) in self
+            .runtime
+            .block_on(self.database().scan_prefix(tables::SOURCES))
+            .map_err(other)?
         {
-            let mut table = txn.open_table(tables::SOURCES).map_err(other)?;
-            table.retain(|_, _| false).map_err(other)?;
-            for file in files {
-                let module = file.record.module.join(deps::MODULE_SEPARATOR);
-                table
-                    .insert(
-                        file.path.as_str(),
-                        (
-                            module.as_str(),
-                            file.record.mtime_ns,
-                            file.record.size,
-                            &file.record.hash,
-                        ),
-                    )
-                    .map_err(other)?;
-            }
+            batch.delete(key);
         }
-        txn.commit().map_err(other)
+        for file in files {
+            batch.put(
+                format!("{}{}", tables::SOURCES, file.path),
+                serde_json::to_vec(&file.record).map_err(other)?,
+            );
+        }
+        self.runtime
+            .block_on(self.database().write_batch(&batch))
+            .map_err(other)
+    }
+
+    fn database(&self) -> &Db {
+        self.db.as_ref().expect("database is open until drop")
+    }
+}
+
+impl Drop for BuildDir {
+    fn drop(&mut self) {
+        if let Some(db) = self.db.take()
+            && let Err(e) = self.runtime.block_on(db.close())
+        {
+            tracing::warn!("cannot close `{}`: {e}", self.root.join(DB_DIR).display());
+        }
     }
 }
 
@@ -221,22 +234,19 @@ pub fn clean(root: &Path) -> Result<CleanOutcome, DbError> {
     if !root.exists() {
         return Ok(CleanOutcome::Missing);
     }
-    let path = root.join(DB_FILE);
+    let path = root.join(DB_DIR);
     if path.exists() {
         // Take the lock (open, never create) and stamp the teardown marker.
         // Failures other than the lock — a corrupt or truncated database —
         // must not wedge `clean`, whose whole job is disposing of such state.
-        match Database::open(&path) {
-            Ok(db) => {
-                let dir = BuildDir {
-                    root: root.to_owned(),
-                    db,
-                };
+        match BuildDir::open_existing(root) {
+            Ok(Some(dir)) => {
                 if let Err(e) = dir.set_status(&[(tables::CLEANING_KEY, "true")]) {
                     tracing::warn!("cannot stamp `{}` as cleaning: {e}", path.display());
                 }
             }
-            Err(DatabaseError::DatabaseAlreadyOpen) => return Err(DbError::InUse(path)),
+            Ok(None) => {}
+            Err(e @ DbError::InUse(_)) => return Err(e),
             Err(e) => tracing::warn!("ignoring unreadable `{}`: {e}", path.display()),
         }
     }
@@ -258,6 +268,87 @@ mod tests {
         assert_eq!(dir.status("a").unwrap().as_deref(), Some("1"));
         assert_eq!(dir.status("b").unwrap().as_deref(), Some("2"));
         assert_eq!(dir.status("nope").unwrap(), None);
+        dir.set_status(&[("a", "updated"), ("empty", "")]).unwrap();
+        drop(dir);
+
+        let dir = BuildDir::open_existing(tmp.path()).unwrap().unwrap();
+        assert_eq!(dir.status("a").unwrap().as_deref(), Some("updated"));
+        assert_eq!(dir.status("b").unwrap().as_deref(), Some("2"));
+        assert_eq!(dir.status("empty").unwrap().as_deref(), Some(""));
+        assert_eq!(dir.status("nope").unwrap(), None);
+    }
+
+    #[test]
+    fn source_replacement_persists_and_preserves_status() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = BuildDir::open(tmp.path()).unwrap();
+        assert!(dir.sources().unwrap().is_empty());
+        let source = deps::SourceFile {
+            path: "status/λ.rr".to_owned(),
+            record: deps::SourceRecord {
+                module: vec!["pkg".to_owned(), "λ".to_owned()],
+                mtime_ns: u64::MAX,
+                size: u64::MAX,
+                hash: [255; 32],
+            },
+        };
+        let removed = deps::SourceFile {
+            path: "sources/old.rr".to_owned(),
+            ..source.clone()
+        };
+        dir.set_status(&[("sources/old.rr", "kept")]).unwrap();
+        dir.replace_sources(&[source.clone(), removed]).unwrap();
+        let updated = deps::SourceFile {
+            record: deps::SourceRecord {
+                module: Vec::new(),
+                hash: [0; 32],
+                ..source.record
+            },
+            ..source
+        };
+        dir.replace_sources(std::slice::from_ref(&updated)).unwrap();
+        drop(dir);
+
+        let dir = BuildDir::open_existing(tmp.path()).unwrap().unwrap();
+        assert_eq!(dir.sources().unwrap(), vec![updated]);
+        assert_eq!(
+            dir.status("sources/old.rr").unwrap().as_deref(),
+            Some("kept")
+        );
+        dir.replace_sources(&[]).unwrap();
+        drop(dir);
+
+        let dir = BuildDir::open_existing(tmp.path()).unwrap().unwrap();
+        assert!(dir.sources().unwrap().is_empty());
+        assert_eq!(
+            dir.status("sources/old.rr").unwrap().as_deref(),
+            Some("kept")
+        );
+    }
+
+    #[test]
+    fn metadata_uses_a_new_directory_and_leaves_the_old_cache_alone() {
+        let tmp = tempfile::tempdir().unwrap();
+        let legacy = tmp.path().join("rene.redb");
+        std::fs::write(&legacy, b"old cache").unwrap();
+        assert!(BuildDir::open_existing(tmp.path()).unwrap().is_none());
+        assert!(!tmp.path().join(DB_DIR).exists());
+
+        let dir = BuildDir::open(tmp.path()).unwrap();
+        assert!(tmp.path().join("rene.meta").is_dir());
+        assert!(dir.sources().unwrap().is_empty());
+        assert_eq!(std::fs::read(legacy).unwrap(), b"old cache");
+    }
+
+    #[test]
+    fn clean_removes_unreadable_metadata() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("build");
+        std::fs::create_dir(&root).unwrap();
+        std::fs::write(root.join(DB_DIR), b"not a database directory").unwrap();
+        assert!(BuildDir::open_existing(&root).is_err());
+        assert_eq!(clean(&root).unwrap(), CleanOutcome::Removed);
+        assert!(!root.exists());
     }
 
     #[test]

--- a/crates/rene/src/deps.rs
+++ b/crates/rene/src/deps.rs
@@ -29,19 +29,6 @@ use crate::tables;
 /// the crate root, and its `mod` declarations discover the rest.
 pub const SRC_DIR: &str = "src";
 
-/// The separator a module path is stored under (its written form, `pkg::math`
-/// — see [`tables::SOURCES`]).
-pub const MODULE_SEPARATOR: &str = "::";
-
-/// Split a stored module path back into its segments. An empty column is an
-/// empty path, not a single empty segment.
-pub fn split_module(module: &str) -> Vec<String> {
-    if module.is_empty() {
-        return Vec::new();
-    }
-    module.split(MODULE_SEPARATOR).map(str::to_owned).collect()
-}
-
 /// What is recorded for one file of the source graph (see
 /// [`tables::SOURCES`]).
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -603,18 +590,6 @@ mod tests {
             file.to_json()["hash"],
             serde_json::json!(blake3::hash(b"contents").to_hex().to_string())
         );
-    }
-
-    /// Module paths round-trip through their stored `pkg::math` form.
-    #[test]
-    fn module_paths_round_trip_through_the_stored_column() {
-        for module in [
-            vec![],
-            vec!["p".to_owned()],
-            vec!["p".to_owned(), "math".to_owned(), "ops".to_owned()],
-        ] {
-            assert_eq!(split_module(&module.join(MODULE_SEPARATOR)), module);
-        }
     }
 
     /// Every row round-trips through the table, and the graph reads back in

--- a/crates/rene/src/lib.rs
+++ b/crates/rene/src/lib.rs
@@ -4,7 +4,7 @@
 //! evaluating to the package description (name, dependencies, …) — and
 //! Reussir sources. Targets may name independent crate-root files, falling
 //! back to `src/lib.rr` when no path is given. Builds run in a build directory
-//! (`reussir-build/` by default) whose status lives in a redb
+//! (`reussir-build/` by default) whose status lives in a TurboKV
 //! database: the baked bundled `reussir-rt` runtime ([`rt`]), the package's
 //! source graph as `rrc --scan-deps` reported it ([`deps`]), and the built
 //! products of the manifest's declared targets ([`compile`]). Dependencies

--- a/crates/rene/src/main.rs
+++ b/crates/rene/src/main.rs
@@ -304,13 +304,13 @@ fn main() -> ExitCode {
 fn init_tracing(verbose: bool, color: bool) {
     use tracing_subscriber::EnvFilter;
     let filter = EnvFilter::try_from_default_env()
-        // pubgrub narrates every solver step at INFO; that is solver
-        // debugging, not build progress, so it stays behind RUST_LOG.
+        // Solver steps and database maintenance are dependency diagnostics;
+        // keep them behind RUST_LOG so normal output shows build progress.
         .unwrap_or_else(|_| {
             EnvFilter::new(if verbose {
-                "debug,pubgrub=warn"
+                "debug,pubgrub=warn,turbokv=warn"
             } else {
-                "info,pubgrub=warn"
+                "info,pubgrub=warn,turbokv=warn"
             })
         });
     let _ = tracing_subscriber::fmt()

--- a/crates/rene/src/tables.rs
+++ b/crates/rene/src/tables.rs
@@ -1,35 +1,26 @@
-//! Table definitions for the build-status database (`reussir-build/rene.redb`).
+//! Key namespaces for the build-status database (`reussir-build/rene.meta`).
 //!
-//! Every table and key the database holds is declared here, so the on-disk
+//! Every namespace and key the database holds is declared here, so the on-disk
 //! schema can be reviewed in one place. Values are JSON strings — the schema
 //! of each value is owned by the module that writes it (referenced per key
 //! below).
 
-use redb::TableDefinition;
-
 /// Build status: string keys (the `*_KEY` constants) to JSON-encoded values.
-pub const STATUS: TableDefinition<&str, &str> = TableDefinition::new("status");
+/// The prefix separates status keys from source paths in TurboKV's keyspace.
+pub const STATUS: &str = "status/";
 
 /// The package's source graph, as last reported by `rrc --scan-deps`: one
 /// row per file, keyed by its path, holding what staleness is judged from.
-/// The value is a redb tuple, which encodes it natively:
-///
-/// ```text
-/// path -> (module, mtime_ns, size, blake3)
-/// ```
-///
-/// `module` is the file's module path in its written form (`pkg::math`);
-/// segments are identifiers, so joining is unambiguous. `blake3` is the raw
-/// 32-byte digest — hex is for [`crate::deps::SourceFile::to_json`] to
-/// render, not for storage to carry.
+/// Keys are this prefix followed by the UTF-8 path; values are JSON-encoded
+/// [`crate::deps::SourceRecord`]s, including module segments and the digest's
+/// 32 bytes. Hex is for [`crate::deps::SourceFile::to_json`] to render.
 ///
 /// The graph is a *set* of files: nothing in rene depends on the order the
 /// scan walked them in (staleness checks every row, and `rrc` rediscovers
 /// the graph itself), so rows simply come back in path order. Written by
 /// [`crate::deps`], always wholesale — the graph is a single snapshot, so a
 /// rebuild replaces every row rather than updating one.
-pub const SOURCES: TableDefinition<&str, (&str, u64, u64, &[u8; 32])> =
-    TableDefinition::new("sources");
+pub const SOURCES: &str = "sources/";
 
 /// Blake3 hex digest of the evaluated manifest the [`SOURCES`] snapshot was
 /// taken under (a bare hex string). A mismatch invalidates the snapshot: a

--- a/tests/integration/rene/source_graph.rr
+++ b/tests/integration/rene/source_graph.rr
@@ -21,6 +21,8 @@
 // the graph: discovery order (the crate root first), module paths, and a
 // Blake3 digest per file.
 // RUN: %rene inspect --manifest-path %t.pkg/rene.ncl | %FileCheck %s --check-prefix=SCAN
+// RUN: test -d %t.pkg/reussir-build/rene.meta
+// RUN: test ! -e %t.pkg/reussir-build/rene.redb
 
 // SCAN:      "files": [
 // SCAN:          "hash": "{{[0-9a-f]+}}"


### PR DESCRIPTION
Replace Rene's redb engine with TurboKV 0.6, storing build metadata in `reussir-build/rene.meta`. Existing `rene.redb` caches are left untouched; metadata is rebuilt in the new store.

Preserve exclusive build-directory locking, atomic durable status/source-graph updates, ordered source reads, and the clean marker. A private Tokio runtime explicitly closes the database before releasing its lock. Routine TurboKV maintenance logs remain behind `RUST_LOG`.

Support both required CPU architectures in Cargo and CMake, including cross-compilation:

- AArch64: `+aes,+neon`.
- x86-64: `+aes,+sse2`.

These flags reflect TurboKV's hardware AES requirement. CMake selects them from the Rust target when cross-compiling, rather than from the host CPU.

Validation:

- AArch64: 50 Rene unit tests and 27 CLI tests passed; one existing slow test ignored.
- x86-64 Linux: cross-built Rene and all test executables with `cargo test --no-run --locked --release -p rene --target x86_64-unknown-linux-gnu`, using Zig for C compilation/linking. The x86-64 tests were compiled, not executed on this AArch64 host.
- All 32 C++ unit tests passed.
- Four focused lit tests passed: `rene/build`, `rene/deps`, `rene/new`, and `rene/source_graph`. The Nix test environment required its zlib directory in `LD_LIBRARY_PATH`.
- Checked CMake feature selection for native AArch64/x86-64 and both cross-build directions; formatting and diff checks passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reussir-lang/codesmith/reussir/pr/623"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791172020&installation_model_id=426051&pr_number=623&repository=reussir-lang%2Freussir&return_to=https%3A%2F%2Fgithub.com%2Freussir-lang%2Freussir%2Fpull%2F623&signature=4e456e0f48058acb362bd2a0d3c28a2461dd5a94b2c651e66d40086c2b144032"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->